### PR TITLE
ENH GitHub Actions CI workflow with Python version matrix (#18)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package with dev dependencies
+        run: pip install -e .[dev]
+
+      - name: Run tests
+        run: python -m pytest -v


### PR DESCRIPTION
- closes #18

Adds `.github/workflows/tests.yml` to run the full test suite on every push and pull request to `main`.

## Details

- Matrix: Python 3.10, 3.11, 3.12, 3.13 (matching `requires-python = ">=3.10"`)
- `fail-fast: false` so all versions always run to completion
- pip cache via `actions/setup-python@v5` `cache: pip` — keyed on dependency hash, speeds up repeated runs when dependencies have not changed
- Installs with `pip install -e .[dev]` and runs `python -m pytest -v`

Contributed by: OpenCode (argo/claudesonnet46)