### PR TITLE
ENH Add wavelength attribute to AdHocDiffractometer (#1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,11 +40,11 @@ as they are completed.
 Units are fixed as Å to match unit cell edge lengths.  Energy conversions,
 wave number, and named laboratory lines are out of scope here — see #21.
 
-- [ ] Add `wavelength: float | None` attribute to `AdHocDiffractometer`; default `None`
-- [ ] Validate on assignment: if not `None`, must be `> 0`; raise `ValueError` otherwise
-- [ ] `summary()` reports `λ = {value} Å` when set, `λ not set` when `None`
-- [ ] Display value via `display.fmt()`
-- [ ] Tests: default is `None`, valid assignment, invalid (≤ 0), display in `summary()`
+- [x] Add `wavelength: float | None` attribute to `AdHocDiffractometer`; default `None`
+- [x] Validate on assignment: if not `None`, must be `> 0`; raise `ValueError` otherwise
+- [x] `summary()` reports `λ = {value} Å` when set, `λ not set` when `None`
+- [x] Display value via `display.fmt()`
+- [x] Tests: default is `None`, valid assignment, invalid (≤ 0), display in `summary()`
 
 ### 1.2 Motor limits per stage ([#2](https://github.com/prjemian/ad_hoc_diffractometer/issues/2))
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -45,6 +45,10 @@ class AdHocDiffractometer:
             {'vertical': XHAT, 'longitudinal': YHAT, 'lateral': ZHAT}
     description : str, optional
         Free-text description of the geometry.
+    wavelength : float or None, optional
+        X-ray or neutron wavelength in Å.  Must match the units used for
+        unit cell edge lengths.  Default is None (unset).  Must be > 0
+        if provided.
 
     Attributes
     ----------
@@ -52,6 +56,8 @@ class AdHocDiffractometer:
         Stages with role='sample', in stacking order (floor first).
     detector_stages : list of Stage
         Stages with role='detector', in stacking order (floor first).
+    wavelength : float or None
+        Wavelength in Å, or None if not set.
     """
 
     DEFAULT_BASIS = {
@@ -66,10 +72,12 @@ class AdHocDiffractometer:
         stages: list[Stage],
         basis: dict | None = None,
         description: str = "",
+        wavelength: float | None = None,
     ):
         self.name = name
         self.description = description
         self.basis = basis if basis is not None else dict(self.DEFAULT_BASIS)
+        self.wavelength = wavelength  # validated via property setter
 
         # Validate basis vectors
         self._check_basis()
@@ -185,6 +193,23 @@ class AdHocDiffractometer:
         return ordered
 
     # ------------------------------------------------------------------
+    # Wavelength
+    # ------------------------------------------------------------------
+
+    @property
+    def wavelength(self) -> float | None:
+        """Wavelength in Å, or None if not set."""
+        return self._wavelength
+
+    @wavelength.setter
+    def wavelength(self, value: float | None) -> None:
+        if value is not None:
+            value = float(value)
+            if value <= 0:
+                raise ValueError(f"wavelength must be > 0 Å; got {value}.")
+        self._wavelength = value
+
+    # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
 
@@ -261,10 +286,17 @@ class AdHocDiffractometer:
     def summary(self) -> None:
         """Print a human-readable summary of the geometry."""
         from .axes import axis_label
+        from .display import fmt
+
+        if self._wavelength is not None:
+            wl_str = f"{fmt(self._wavelength)} Å"
+        else:
+            wl_str = "not set"
 
         lines = [
             f"AdHocDiffractometer: {self.name}",
             f"  {self.description}",
+            f"  λ = {wl_str}",
             "",
             "  Basis vectors:",
         ]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -421,3 +421,80 @@ def test_check_limits_unknown_stage_raises(psic_geom):
 def test_check_limits_empty_call(psic_geom):
     """Calling check_limits with no arguments must not raise."""
     psic_geom.check_limits()
+
+
+# ---------------------------------------------------------------------------
+# wavelength attribute
+# ---------------------------------------------------------------------------
+
+
+def test_wavelength_default_is_none(psic_geom):
+    """Default wavelength is None (unset)."""
+    assert psic_geom.wavelength is None
+
+
+@pytest.mark.parametrize(
+    "value, context",
+    [
+        pytest.param(1.5406, does_not_raise(), id="cu-kalpha"),
+        pytest.param(0.7107, does_not_raise(), id="mo-kalpha"),
+        pytest.param(0.001, does_not_raise(), id="very-short"),
+        pytest.param(100.0, does_not_raise(), id="very-long"),
+        pytest.param(None, does_not_raise(), id="unset-none"),
+        pytest.param(
+            0.0,
+            pytest.raises(ValueError, match=re.escape("must be > 0")),
+            id="invalid-zero",
+        ),
+        pytest.param(
+            -1.0,
+            pytest.raises(ValueError, match=re.escape("must be > 0")),
+            id="invalid-negative",
+        ),
+    ],
+)
+def test_wavelength_assignment(value, context, psic_geom):
+    with context:
+        psic_geom.wavelength = value
+        assert psic_geom.wavelength == value
+
+
+def test_wavelength_constructor():
+    """wavelength can be supplied at construction time."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    # default
+    assert g.wavelength is None
+    # via setter after construction
+    g.wavelength = 1.5406
+    assert g.wavelength == pytest.approx(1.5406)
+
+
+def test_wavelength_invalid_at_construction():
+    """Supplying an invalid wavelength at construction raises ValueError."""
+    from ad_hoc_diffractometer import XHAT
+    from ad_hoc_diffractometer import Stage
+
+    stages = [Stage("a", XHAT, role="sample")]
+    with pytest.raises(ValueError, match=re.escape("must be > 0")):
+        AdHocDiffractometer("test", stages, wavelength=-1.0)
+
+
+def test_wavelength_reset_to_none(psic_geom):
+    """Wavelength can be cleared back to None after being set."""
+    psic_geom.wavelength = 1.5406
+    psic_geom.wavelength = None
+    assert psic_geom.wavelength is None
+
+
+def test_wavelength_in_summary(psic_geom, capsys):
+    """summary() reports wavelength when set and 'not set' when None."""
+    psic_geom.summary()
+    out = capsys.readouterr().out
+    assert "not set" in out
+
+    psic_geom.wavelength = 1.5406
+    psic_geom.summary()
+    out = capsys.readouterr().out
+    assert "1.540600 Å" in out


### PR DESCRIPTION
- closes #1

Adds a `wavelength` attribute directly to `AdHocDiffractometer`. Units are fixed as Å to match unit cell edge lengths. Energy conversions, wave number, and named laboratory lines are deferred to #21.

## Changes

- `wavelength: float | None` attribute on `AdHocDiffractometer`; default `None` (unset — avoids silently producing wrong d-spacing calculations)
- Validated via property setter: raises `ValueError` if value ≤ 0
- `summary()` reports `λ = {value} Å` when set, `λ not set` when `None`, using `display.fmt()` for consistent precision
- 12 new parametrized tests covering default, valid assignment, invalid values (zero, negative), constructor use, reset to `None`, and `summary()` output

Contributed by: OpenCode (argo/claudesonnet46)