### PR TITLE
ENH Add kappa_alpha_deg property to AdHocDiffractometer (#3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,8 @@ The default coordinate system follows You (1999):
 | `YHAT` (+y) | longitudinal (along beam, toward equipment) |
 | `ZHAT` (+z) | lateral (to our left facing the equipment) |
 
-The Busing & Levy (1967) convention (used in `fourc_v`, `fourc_h`,
-`kappa4c`, `kappa4c_h`) has x=lateral, y=longitudinal, z=vertical.
+The Busing & Levy (1967) convention (used in `fourcv`, `fourch`,
+`kappa4cv`, `kappa4ch`) has x=lateral, y=longitudinal, z=vertical.
 
 Basis dicts (`_BASIS_YOU`, `_BASIS_BL`) in `factories.py` encode these.
 
@@ -207,12 +207,12 @@ in `list_geometries()`.  Naming convention:
 
 | Suffix | Meaning |
 |---|---|
-| `_v` | vertical detector axis (laboratory, horizontal scattering plane) |
-| `_h` | lateral detector axis (synchrotron, vertical scattering plane) |
+| `v` | vertical detector axis (laboratory, horizontal scattering plane) |
+| `h` | lateral detector axis (synchrotron, vertical scattering plane) |
 | no suffix | detector convention unambiguous (psic, sixc) or compound (zaxis, s2d2) |
 
-Current factories: `psic`, `fourc_v`, `fourc_h`, `sixc`, `kappa4c`,
-`kappa4c_h`, `kappa6c`, `zaxis`, `s2d2`, `fivec`.
+Current factories: `psic`, `fourcv`, `fourch`, `sixc`, `kappa4cv`,
+`kappa4ch`, `kappa6c`, `zaxis`, `s2d2`, `fivec`.
 
 Walko (2016) designation system is noted in docstrings (S3D1, S4D2, etc.).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,11 +72,11 @@ wave number, and named laboratory lines are out of scope here — see #21.
 
 ### 1.3 Kappa alpha queryable on the geometry instance ([#3](https://github.com/prjemian/ad_hoc_diffractometer/issues/3))
 
-- [ ] Store `kappa_alpha_deg` as an attribute on the `AdHocDiffractometer`
+- [x] Store `kappa_alpha_deg` as an attribute on the `AdHocDiffractometer`
       instance returned by kappa factory functions (kappa4c, kappa4c_h,
       kappa6c); currently baked only into the axis vector
-- [ ] Add a `kappa_alpha` property or metadata dict to the instance
-- [ ] Tests verifying the value is correct and matches the axis vector
+- [x] Add a `kappa_alpha_deg` property on the instance; `None` for non-kappa geometries
+- [x] Tests verifying the value is correct and matches the axis vector
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ as they are completed.
 - [x] `AdHocDiffractometer` class: stacking order, basis validation,
       sample/detector rotation matrices, summary
 - [x] `@register_geometry` decorator and `list_geometries()` registry
-- [x] Geometry factories: psic, fourc_v, fourc_h, sixc, kappa4c, kappa4c_h,
+- [x] Geometry factories: psic, fourcv, fourch, sixc, kappa4cv, kappa4ch,
       kappa6c, zaxis, s2d2, fivec
 - [x] `Lattice` class: 7 crystal systems, lazy B matrix, reciprocal vectors,
       Cartesian lattice vectors, display precision
@@ -73,7 +73,7 @@ wave number, and named laboratory lines are out of scope here — see #21.
 ### 1.3 Kappa alpha queryable on the geometry instance ([#3](https://github.com/prjemian/ad_hoc_diffractometer/issues/3))
 
 - [x] Store `kappa_alpha_deg` as an attribute on the `AdHocDiffractometer`
-      instance returned by kappa factory functions (kappa4c, kappa4c_h,
+      instance returned by kappa factory functions (kappa4cv, kappa4ch,
       kappa6c); currently baked only into the axis vector
 - [x] Add a `kappa_alpha_deg` property on the instance; `None` for non-kappa geometries
 - [x] Tests verifying the value is correct and matches the axis vector

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -14,11 +14,11 @@ from .display import get_precision
 from .display import set_precision
 from .factories import KAPPA_ALPHA_DEFAULT
 from .factories import fivec
-from .factories import fourc_h
-from .factories import fourc_v
+from .factories import fourch
+from .factories import fourcv
 from .factories import get_geometry
-from .factories import kappa4c
-from .factories import kappa4c_h
+from .factories import kappa4ch
+from .factories import kappa4cv
 from .factories import kappa6c
 from .factories import list_geometries
 from .factories import make_geometry
@@ -61,11 +61,11 @@ __all__ = [
     "make_geometry",
     "KAPPA_ALPHA_DEFAULT",
     "psic",
-    "fourc_v",
-    "fourc_h",
+    "fourcv",
+    "fourch",
     "sixc",
-    "kappa4c",
-    "kappa4c_h",
+    "kappa4cv",
+    "kappa4ch",
     "kappa6c",
     "zaxis",
     "s2d2",

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -445,6 +445,7 @@ def kappa4c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
             f"Four-circle kappa diffractometer, vertical detector (laboratory). "
             f"Kappa alpha = {alpha_deg} deg."
         ),
+        kappa_alpha_deg=alpha_deg,
     )
 
 
@@ -493,6 +494,7 @@ def kappa4c_h(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
             f"Four-circle kappa diffractometer, lateral detector (synchrotron). "
             f"Kappa alpha = {alpha_deg} deg."
         ),
+        kappa_alpha_deg=alpha_deg,
     )
 
 
@@ -548,6 +550,7 @@ def kappa6c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
             f"(lateral detector, synchrotron). "
             f"Kappa alpha = {alpha_deg} deg."
         ),
+        kappa_alpha_deg=alpha_deg,
     )
 
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -6,13 +6,13 @@ _GEOMETRY_REGISTRY under its function name.  Use list_geometries() to
 retrieve all registered factories as a {name: callable} dict.
 
 Naming convention:
-    Eulerian geometries:     fourc_v, fourc_h, sixc, psic
-    Kappa geometries:        kappa4c, kappa4c_h, kappa6c
+    Eulerian geometries:     fourcv, fourch, sixc, psic
+    Kappa geometries:        kappa4cv, kappa4ch, kappa6c
     Inclined geometries:     zaxis, s2d2, fivec
 
-Detector axis suffix convention (_v / _h):
-    _v  ->  vertical detector axis   (laboratory / horizontal scattering plane)
-    _h  ->  lateral   detector axis  (synchrotron / vertical scattering plane)
+Detector axis suffix convention (v / h):
+    v  ->  vertical detector axis   (laboratory / horizontal scattering plane)
+    h  ->  lateral   detector axis  (synchrotron / vertical scattering plane)
 
     Walko (2016): "at synchrotron sources the scattering plane is usually
     vertical, to take advantage of the (typically) s-polarization of the
@@ -21,23 +21,23 @@ Detector axis suffix convention (_v / _h):
     Where no suffix is given, the geometry has no single-axis 2theta detector
     (inclined geometries) or the detector convention is unambiguous (psic, sixc).
 
-    fourc_v (vertical detector) is the default/laboratory convention.
-    kappa4c (vertical detector) is the default/laboratory convention.
+    fourcv (vertical detector) is the default/laboratory convention.
+    kappa4cv (vertical detector) is the default/laboratory convention.
 
 Kappa angle (alpha) convention (Walko 2016; Enraf-Nonius; ITC Vol. C Sec. 2.2.6):
     The kappa axis lies in the vertical-lateral plane, tilted alpha degrees
     from the vertical axis toward the lateral axis.  Typical value: 50 deg.
 
 Walko (2016) designations:
-    S3D1      fourc_v, fourc_h, kappa4c, kappa4c_h
+    S3D1      fourcv, fourch, kappa4cv, kappa4ch
     S4D2      psic, kappa6c
     (S3D2)1   sixc   (sample and detector share base stage)
-    (S3D1)1   fivec  (fourc_v mounted on vertical base)
+    (S3D1)1   fivec  (fourcv mounted on vertical base)
     (S1D2)1   zaxis  (sample and detector share alpha base stage)
     S2D2      s2d2   (fully decoupled sample/detector pairs)
 
 References (chronological):
-    W.R. Busing & H.A. Levy, Acta Cryst. 22, 457-464 (1967)               fourc_v / fourc_h
+    W.R. Busing & H.A. Levy, Acta Cryst. 22, 457-464 (1967)               fourcv / fourch
     J.M. Bloch, J. Appl. Cryst. 18, 33-36 (1985)                          zaxis
     E. Vlieg et al., J. Appl. Cryst. 20, 330-337 (1987)                   fivec
     M. Lohmeier & E. Vlieg, J. Appl. Cryst. 26, 706-716 (1993)            sixc
@@ -94,14 +94,14 @@ def list_geometries() -> dict[str, type]:
     Returns
     -------
     dict
-        Keys are factory function names (e.g. 'psic', 'fourc_v', 'kappa4c').
+        Keys are factory function names (e.g. 'psic', 'fourcv', 'kappa4cv').
         Values are the callable factory functions.
 
     Examples
     --------
     >>> from ad_hoc_diffractometer import list_geometries
     >>> list_geometries()
-    {'psic': <function psic ...>, 'fourc_v': <function fourc_v ...>, ...}
+    {'psic': <function psic ...>, 'fourcv': <function fourcv ...>, ...}
     >>> list_geometries()['psic']()   # instantiate by name
     AdHocDiffractometer(name='psic', ...)
     """
@@ -120,7 +120,7 @@ def get_geometry(name: str):
     ----------
     name : str
         Name of the geometry, as registered by @register_geometry
-        (e.g. 'psic', 'fourc_v', 'kappa4c').
+        (e.g. 'psic', 'fourcv', 'kappa4cv').
 
     Returns
     -------
@@ -139,8 +139,8 @@ def get_geometry(name: str):
     >>> factory = get_geometry("psic")
     >>> factory()
     AdHocDiffractometer(name='psic', ...)
-    >>> get_geometry("kappa4c")(alpha_deg=50)
-    AdHocDiffractometer(name='kappa4c', ...)
+    >>> get_geometry("kappa4cv")(alpha_deg=50)
+    AdHocDiffractometer(name='kappa4cv', ...)
     """
     if name not in _GEOMETRY_REGISTRY:
         available = sorted(_GEOMETRY_REGISTRY.keys())
@@ -162,7 +162,7 @@ def make_geometry(name: str, **kwargs) -> AdHocDiffractometer:
     Parameters
     ----------
     name : str
-        Name of the geometry (e.g. 'psic', 'fourc_v', 'kappa4c').
+        Name of the geometry (e.g. 'psic', 'fourcv', 'kappa4cv').
     **kwargs
         Keyword arguments forwarded to the factory function.  Most factories
         take no arguments; kappa factories accept alpha_deg.
@@ -182,8 +182,8 @@ def make_geometry(name: str, **kwargs) -> AdHocDiffractometer:
     >>> from ad_hoc_diffractometer import make_geometry
     >>> make_geometry("psic")
     AdHocDiffractometer(name='psic', ...)
-    >>> make_geometry("kappa4c", alpha_deg=50)
-    AdHocDiffractometer(name='kappa4c', ...)
+    >>> make_geometry("kappa4cv", alpha_deg=50)
+    AdHocDiffractometer(name='kappa4cv', ...)
     >>> make_geometry("kappa6c", alpha_deg=55)
     AdHocDiffractometer(name='kappa6c', ...)
     """
@@ -261,7 +261,7 @@ def psic() -> AdHocDiffractometer:
 
 
 @register_geometry
-def fourc_v() -> AdHocDiffractometer:
+def fourcv() -> AdHocDiffractometer:
     """
     Busing & Levy (1967) four-circle Eulerian diffractometer, vertical detector.
 
@@ -297,7 +297,7 @@ def fourc_v() -> AdHocDiffractometer:
         Stage("two_theta", -_ZHAT_BL, parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
-        name="fourc_v",
+        name="fourcv",
         stages=stages,
         basis=_BASIS_BL,
         description=(
@@ -308,7 +308,7 @@ def fourc_v() -> AdHocDiffractometer:
 
 
 @register_geometry
-def fourc_h() -> AdHocDiffractometer:
+def fourch() -> AdHocDiffractometer:
     """
     Busing & Levy (1967) four-circle Eulerian diffractometer, lateral detector.
 
@@ -341,7 +341,7 @@ def fourc_h() -> AdHocDiffractometer:
         Stage("two_theta", -_XHAT_BL, parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
-        name="fourc_h",
+        name="fourch",
         stages=stages,
         basis=_BASIS_BL,
         description=(
@@ -401,13 +401,13 @@ KAPPA_ALPHA_DEFAULT = 50.0
 
 
 @register_geometry
-def kappa4c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
+def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
     Four-circle kappa diffractometer, vertical detector (laboratory default).
 
     Walko (2016) designation: S3D1.
 
-    The chi circle of a standard Eulerian fourc_v is replaced by a kappa arm.
+    The chi circle of a standard Eulerian fourcv is replaced by a kappa arm.
     The kappa axis lies in the vertical-lateral plane, tilted alpha degrees
     from the vertical toward the lateral axis.
 
@@ -438,7 +438,7 @@ def kappa4c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
         Stage("two_theta", -_ZHAT_BL, parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
-        name="kappa4c",
+        name="kappa4cv",
         stages=stages,
         basis=_BASIS_BL,
         description=(
@@ -450,13 +450,13 @@ def kappa4c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
 
 
 @register_geometry
-def kappa4c_h(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
+def kappa4ch(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
     Four-circle kappa diffractometer, lateral detector (synchrotron).
 
     Walko (2016) designation: S3D1.
 
-    Identical to kappa4c() but the two_theta (detector) axis is lateral,
+    Identical to kappa4cv() but the two_theta (detector) axis is lateral,
     corresponding to the synchrotron configuration with a vertical
     scattering plane.
 
@@ -487,7 +487,7 @@ def kappa4c_h(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
         Stage("two_theta", -_XHAT_BL, parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
-        name="kappa4c_h",
+        name="kappa4ch",
         stages=stages,
         basis=_BASIS_BL,
         description=(
@@ -505,7 +505,7 @@ def kappa6c(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
 
     Walko (2016) designation: S4D2.
 
-    Extends the kappa4c geometry with two additional axes (mu, nu) in
+    Extends the kappa4cv geometry with two additional axes (mu, nu) in
     the style of the psic geometry (You 1999), giving full orientation freedom.
     This is the synchrotron configuration with a lateral detector.
 
@@ -652,12 +652,12 @@ def s2d2() -> AdHocDiffractometer:
 @register_geometry
 def fivec() -> AdHocDiffractometer:
     """
-    Five-circle diffractometer (fourc_v mounted on a vertical base).
+    Five-circle diffractometer (fourcv mounted on a vertical base).
 
     Walko (2016) designation: (S3D1)1.
     Basis: xHat=vertical, yHat=longitudinal, zHat=lateral.
 
-    A standard Eulerian four-circle (fourc_v) is mounted on a fifth vertical
+    A standard Eulerian four-circle (fourcv) is mounted on a fifth vertical
     rotation stage (mu) as a base.  The sample and detector motions are coupled
     through mu.  This provides an additional degree of freedom for accessing
     wider regions of reciprocal space, particularly at synchrotron sources.
@@ -690,7 +690,7 @@ def fivec() -> AdHocDiffractometer:
         stages=stages,
         basis=_BASIS_YOU,
         description=(
-            "Five-circle diffractometer: fourc_v on vertical mu base "
+            "Five-circle diffractometer: fourcv on vertical mu base "
             "(Vlieg et al. 1987; Walko 2016 (S3D1)1). "
             "Sample and detector coupled through mu."
         ),

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -50,8 +50,8 @@ class AdHocDiffractometer:
         unit cell edge lengths.  Default is None (unset).  Must be > 0
         if provided.
     kappa_alpha_deg : float or None, optional
-        Kappa tilt angle in degrees for kappa geometries (kappa4c,
-        kappa4c_h, kappa6c).  None for non-kappa geometries.  Set by
+        Kappa tilt angle in degrees for kappa geometries (kappa4cv,
+        kappa4ch, kappa6c).  None for non-kappa geometries.  Set by
         the kappa factory functions; not intended to be changed after
         construction.
 
@@ -229,7 +229,7 @@ class AdHocDiffractometer:
 
         This is the angle between the kappa rotation axis and the vertical
         axis (toward the lateral axis).  Typical value: 50 deg.
-        Set by kappa factory functions (kappa4c, kappa4c_h, kappa6c).
+        Set by kappa factory functions (kappa4cv, kappa4ch, kappa6c).
         """
         return self._kappa_alpha_deg
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -49,6 +49,11 @@ class AdHocDiffractometer:
         X-ray or neutron wavelength in Å.  Must match the units used for
         unit cell edge lengths.  Default is None (unset).  Must be > 0
         if provided.
+    kappa_alpha_deg : float or None, optional
+        Kappa tilt angle in degrees for kappa geometries (kappa4c,
+        kappa4c_h, kappa6c).  None for non-kappa geometries.  Set by
+        the kappa factory functions; not intended to be changed after
+        construction.
 
     Attributes
     ----------
@@ -58,6 +63,8 @@ class AdHocDiffractometer:
         Stages with role='detector', in stacking order (floor first).
     wavelength : float or None
         Wavelength in Å, or None if not set.
+    kappa_alpha_deg : float or None
+        Kappa tilt angle in degrees, or None for non-kappa geometries.
     """
 
     DEFAULT_BASIS = {
@@ -73,11 +80,13 @@ class AdHocDiffractometer:
         basis: dict | None = None,
         description: str = "",
         wavelength: float | None = None,
+        kappa_alpha_deg: float | None = None,
     ):
         self.name = name
         self.description = description
         self.basis = basis if basis is not None else dict(self.DEFAULT_BASIS)
         self.wavelength = wavelength  # validated via property setter
+        self.kappa_alpha_deg = kappa_alpha_deg
 
         # Validate basis vectors
         self._check_basis()
@@ -208,6 +217,27 @@ class AdHocDiffractometer:
             if value <= 0:
                 raise ValueError(f"wavelength must be > 0 Å; got {value}.")
         self._wavelength = value
+
+    # ------------------------------------------------------------------
+    # Kappa alpha
+    # ------------------------------------------------------------------
+
+    @property
+    def kappa_alpha_deg(self) -> float | None:
+        """
+        Kappa tilt angle in degrees, or None for non-kappa geometries.
+
+        This is the angle between the kappa rotation axis and the vertical
+        axis (toward the lateral axis).  Typical value: 50 deg.
+        Set by kappa factory functions (kappa4c, kappa4c_h, kappa6c).
+        """
+        return self._kappa_alpha_deg
+
+    @kappa_alpha_deg.setter
+    def kappa_alpha_deg(self, value: float | None) -> None:
+        if value is not None:
+            value = float(value)
+        self._kappa_alpha_deg = value
 
     # ------------------------------------------------------------------
     # Public interface

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -5,8 +5,8 @@ Covers:
   - list_geometries()
   - get_geometry()
   - make_geometry()
-  - All geometry factory functions: psic, fourc_v, fourc_h, sixc,
-    kappa4c, kappa4c_h, kappa6c, zaxis, s2d2, fivec
+  - All geometry factory functions: psic, fourcv, fourch, sixc,
+    kappa4cv, kappa4ch, kappa6c, zaxis, s2d2, fivec
 """
 
 import re
@@ -20,11 +20,11 @@ from ad_hoc_diffractometer import YHAT
 from ad_hoc_diffractometer import ZHAT
 from ad_hoc_diffractometer import AdHocDiffractometer
 from ad_hoc_diffractometer import fivec
-from ad_hoc_diffractometer import fourc_h
-from ad_hoc_diffractometer import fourc_v
+from ad_hoc_diffractometer import fourch
+from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import get_geometry
-from ad_hoc_diffractometer import kappa4c
-from ad_hoc_diffractometer import kappa4c_h
+from ad_hoc_diffractometer import kappa4ch
+from ad_hoc_diffractometer import kappa4cv
 from ad_hoc_diffractometer import kappa6c
 from ad_hoc_diffractometer import list_geometries
 from ad_hoc_diffractometer import make_geometry
@@ -42,11 +42,11 @@ def test_list_geometries_returns_all_factories():
     geoms = list_geometries()
     expected = {
         "psic",
-        "fourc_v",
-        "fourc_h",
+        "fourcv",
+        "fourch",
         "sixc",
-        "kappa4c",
-        "kappa4c_h",
+        "kappa4cv",
+        "kappa4ch",
         "kappa6c",
         "zaxis",
         "s2d2",
@@ -83,11 +83,11 @@ def test_list_geometries_returns_copy():
     "name, context",
     [
         pytest.param("psic", does_not_raise(), id="get-psic"),
-        pytest.param("fourc_v", does_not_raise(), id="get-fourc_v"),
-        pytest.param("fourc_h", does_not_raise(), id="get-fourc_h"),
+        pytest.param("fourcv", does_not_raise(), id="get-fourcv"),
+        pytest.param("fourch", does_not_raise(), id="get-fourch"),
         pytest.param("sixc", does_not_raise(), id="get-sixc"),
-        pytest.param("kappa4c", does_not_raise(), id="get-kappa4c"),
-        pytest.param("kappa4c_h", does_not_raise(), id="get-kappa4c_h"),
+        pytest.param("kappa4cv", does_not_raise(), id="get-kappa4cv"),
+        pytest.param("kappa4ch", does_not_raise(), id="get-kappa4ch"),
         pytest.param("kappa6c", does_not_raise(), id="get-kappa6c"),
         pytest.param("zaxis", does_not_raise(), id="get-zaxis"),
         pytest.param("s2d2", does_not_raise(), id="get-s2d2"),
@@ -126,13 +126,15 @@ def test_get_geometry_error_lists_available():
     "name, kwargs, context",
     [
         pytest.param("psic", {}, does_not_raise(), id="make-psic-no-kwargs"),
-        pytest.param("fourc_v", {}, does_not_raise(), id="make-fourc_v-no-kwargs"),
-        pytest.param("kappa4c", {}, does_not_raise(), id="make-kappa4c-default-alpha"),
+        pytest.param("fourcv", {}, does_not_raise(), id="make-fourcv-no-kwargs"),
         pytest.param(
-            "kappa4c",
+            "kappa4cv", {}, does_not_raise(), id="make-kappa4cv-default-alpha"
+        ),
+        pytest.param(
+            "kappa4cv",
             {"alpha_deg": 50.0},
             does_not_raise(),
-            id="make-kappa4c-explicit-alpha-50",
+            id="make-kappa4cv-explicit-alpha-50",
         ),
         pytest.param(
             "kappa6c",
@@ -166,7 +168,7 @@ def test_make_geometry_returns_correct_instance():
 
 def test_make_geometry_kappa_alpha_forwarded():
     """Keyword args must be forwarded to the factory (kappa alpha test)."""
-    g = make_geometry("kappa4c", alpha_deg=45.0)
+    g = make_geometry("kappa4cv", alpha_deg=45.0)
     expected = np.cos(np.deg2rad(45)) * np.array([0, 0, 1]) + np.sin(
         np.deg2rad(45)
     ) * np.array([1, 0, 0])
@@ -190,20 +192,20 @@ def test_make_geometry_kappa_alpha_forwarded():
             id="psic-stage-lists",
         ),
         pytest.param(
-            fourc_v,
-            "fourc_v",
+            fourcv,
+            "fourcv",
             ["omega", "chi", "phi"],
             ["two_theta"],
             does_not_raise(),
-            id="fourc_v-stage-lists",
+            id="fourcv-stage-lists",
         ),
         pytest.param(
-            fourc_h,
-            "fourc_h",
+            fourch,
+            "fourch",
             ["omega", "chi", "phi"],
             ["two_theta"],
             does_not_raise(),
-            id="fourc_h-stage-lists",
+            id="fourch-stage-lists",
         ),
         pytest.param(
             sixc,
@@ -214,20 +216,20 @@ def test_make_geometry_kappa_alpha_forwarded():
             id="sixc-stage-lists",
         ),
         pytest.param(
-            kappa4c,
-            "kappa4c",
+            kappa4cv,
+            "kappa4cv",
             ["komega", "kappa", "kphi"],
             ["two_theta"],
             does_not_raise(),
-            id="kappa4c-stage-lists",
+            id="kappa4cv-stage-lists",
         ),
         pytest.param(
-            kappa4c_h,
-            "kappa4c_h",
+            kappa4ch,
+            "kappa4ch",
             ["komega", "kappa", "kphi"],
             ["two_theta"],
             does_not_raise(),
-            id="kappa4c_h-stage-lists",
+            id="kappa4ch-stage-lists",
         ),
         pytest.param(
             kappa6c,
@@ -288,28 +290,28 @@ def test_geometry_factories(
         pytest.param(psic, "chi", "eta", does_not_raise(), id="psic-chi-on-eta"),
         pytest.param(psic, "phi", "chi", does_not_raise(), id="psic-phi-on-chi"),
         pytest.param(psic, "delta", "nu", does_not_raise(), id="psic-delta-on-nu"),
-        # fourc_v
+        # fourcv
         pytest.param(
-            fourc_v, "omega", None, does_not_raise(), id="fourc_v-omega-on-floor"
+            fourcv, "omega", None, does_not_raise(), id="fourcv-omega-on-floor"
         ),
         pytest.param(
-            fourc_v,
+            fourcv,
             "two_theta",
             None,
             does_not_raise(),
-            id="fourc_v-two_theta-decoupled",
+            id="fourcv-two_theta-decoupled",
         ),
         pytest.param(
-            fourc_v, "chi", "omega", does_not_raise(), id="fourc_v-chi-on-omega"
+            fourcv, "chi", "omega", does_not_raise(), id="fourcv-chi-on-omega"
         ),
-        pytest.param(fourc_v, "phi", "chi", does_not_raise(), id="fourc_v-phi-on-chi"),
-        # fourc_h
+        pytest.param(fourcv, "phi", "chi", does_not_raise(), id="fourcv-phi-on-chi"),
+        # fourch
         pytest.param(
-            fourc_h,
+            fourch,
             "two_theta",
             None,
             does_not_raise(),
-            id="fourc_h-two_theta-decoupled",
+            id="fourch-two_theta-decoupled",
         ),
         # sixc
         pytest.param(sixc, "alpha", None, does_not_raise(), id="sixc-alpha-on-floor"),
@@ -322,22 +324,22 @@ def test_geometry_factories(
         pytest.param(
             sixc, "gamma", "delta", does_not_raise(), id="sixc-gamma-on-delta"
         ),
-        # kappa4c
+        # kappa4cv
         pytest.param(
-            kappa4c, "komega", None, does_not_raise(), id="kappa4c-komega-on-floor"
+            kappa4cv, "komega", None, does_not_raise(), id="kappa4cv-komega-on-floor"
         ),
         pytest.param(
-            kappa4c,
+            kappa4cv,
             "two_theta",
             None,
             does_not_raise(),
-            id="kappa4c-two_theta-decoupled",
+            id="kappa4cv-two_theta-decoupled",
         ),
         pytest.param(
-            kappa4c, "kappa", "komega", does_not_raise(), id="kappa4c-kappa-on-komega"
+            kappa4cv, "kappa", "komega", does_not_raise(), id="kappa4cv-kappa-on-komega"
         ),
         pytest.param(
-            kappa4c, "kphi", "kappa", does_not_raise(), id="kappa4c-kphi-on-kappa"
+            kappa4cv, "kphi", "kappa", does_not_raise(), id="kappa4cv-kphi-on-kappa"
         ),
         # kappa6c
         pytest.param(kappa6c, "mu", None, does_not_raise(), id="kappa6c-mu-on-floor"),
@@ -412,12 +414,12 @@ def test_geometry_parent_chain(factory, stage_name, expected_parent, context):
             psic, "delta", -ZHAT, does_not_raise(), id="psic-delta-lateral-left-handed"
         ),
         pytest.param(
-            kappa4c,
+            kappa4cv,
             "kappa",
             np.cos(np.deg2rad(50)) * np.array([0, 0, 1])
             + np.sin(np.deg2rad(50)) * np.array([1, 0, 0]),
             does_not_raise(),
-            id="kappa4c-kappa-axis-tilted",
+            id="kappa4cv-kappa-axis-tilted",
         ),
     ],
 )
@@ -435,11 +437,11 @@ def test_geometry_axes(factory, stage_name, expected_axis, context):
 @pytest.mark.parametrize(
     "factory, alpha_deg, context",
     [
-        pytest.param(kappa4c, 50.0, does_not_raise(), id="kappa4c-default-alpha"),
-        pytest.param(kappa4c_h, 50.0, does_not_raise(), id="kappa4c_h-default-alpha"),
+        pytest.param(kappa4cv, 50.0, does_not_raise(), id="kappa4cv-default-alpha"),
+        pytest.param(kappa4ch, 50.0, does_not_raise(), id="kappa4ch-default-alpha"),
         pytest.param(kappa6c, 50.0, does_not_raise(), id="kappa6c-default-alpha"),
-        pytest.param(kappa4c, 45.0, does_not_raise(), id="kappa4c-custom-alpha-45"),
-        pytest.param(kappa4c_h, 35.0, does_not_raise(), id="kappa4c_h-custom-alpha-35"),
+        pytest.param(kappa4cv, 45.0, does_not_raise(), id="kappa4cv-custom-alpha-45"),
+        pytest.param(kappa4ch, 35.0, does_not_raise(), id="kappa4ch-custom-alpha-35"),
         pytest.param(kappa6c, 55.0, does_not_raise(), id="kappa6c-custom-alpha-55"),
     ],
 )
@@ -453,8 +455,8 @@ def test_kappa_alpha_deg_stored(factory, alpha_deg, context):
 @pytest.mark.parametrize(
     "factory, alpha_deg, context",
     [
-        pytest.param(kappa4c, 50.0, does_not_raise(), id="kappa4c-axis-matches-50"),
-        pytest.param(kappa4c, 45.0, does_not_raise(), id="kappa4c-axis-matches-45"),
+        pytest.param(kappa4cv, 50.0, does_not_raise(), id="kappa4cv-axis-matches-50"),
+        pytest.param(kappa4cv, 45.0, does_not_raise(), id="kappa4cv-axis-matches-45"),
         pytest.param(kappa6c, 55.0, does_not_raise(), id="kappa6c-axis-matches-55"),
     ],
 )
@@ -467,6 +469,8 @@ def test_kappa_alpha_deg_matches_axis_vector(factory, alpha_deg, context):
     with context:
         g = factory(alpha_deg=alpha_deg)
         kax = g.stage("kappa").axis
-        basis = _BASIS_YOU if factory is kappa6c else _BASIS_BL
+        basis = (
+            _BASIS_YOU if factory is kappa6c else _BASIS_BL
+        )  # kappa4cv/kappa4ch use BL
         expected_axis = kappa_axis(g.kappa_alpha_deg, basis=basis)
         np.testing.assert_allclose(kax, expected_axis, atol=1e-12)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -425,3 +425,48 @@ def test_geometry_axes(factory, stage_name, expected_axis, context):
     with context:
         g = factory()
         np.testing.assert_allclose(g.stage(stage_name).axis, expected_axis, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# kappa_alpha_deg on kappa factory instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, alpha_deg, context",
+    [
+        pytest.param(kappa4c, 50.0, does_not_raise(), id="kappa4c-default-alpha"),
+        pytest.param(kappa4c_h, 50.0, does_not_raise(), id="kappa4c_h-default-alpha"),
+        pytest.param(kappa6c, 50.0, does_not_raise(), id="kappa6c-default-alpha"),
+        pytest.param(kappa4c, 45.0, does_not_raise(), id="kappa4c-custom-alpha-45"),
+        pytest.param(kappa4c_h, 35.0, does_not_raise(), id="kappa4c_h-custom-alpha-35"),
+        pytest.param(kappa6c, 55.0, does_not_raise(), id="kappa6c-custom-alpha-55"),
+    ],
+)
+def test_kappa_alpha_deg_stored(factory, alpha_deg, context):
+    """kappa_alpha_deg on the instance matches the alpha_deg passed to the factory."""
+    with context:
+        g = factory(alpha_deg=alpha_deg)
+        assert g.kappa_alpha_deg == pytest.approx(alpha_deg)
+
+
+@pytest.mark.parametrize(
+    "factory, alpha_deg, context",
+    [
+        pytest.param(kappa4c, 50.0, does_not_raise(), id="kappa4c-axis-matches-50"),
+        pytest.param(kappa4c, 45.0, does_not_raise(), id="kappa4c-axis-matches-45"),
+        pytest.param(kappa6c, 55.0, does_not_raise(), id="kappa6c-axis-matches-55"),
+    ],
+)
+def test_kappa_alpha_deg_matches_axis_vector(factory, alpha_deg, context):
+    """kappa_alpha_deg is consistent with the kappa stage axis vector."""
+    from ad_hoc_diffractometer import kappa_axis
+    from ad_hoc_diffractometer.factories import _BASIS_BL
+    from ad_hoc_diffractometer.factories import _BASIS_YOU
+
+    with context:
+        g = factory(alpha_deg=alpha_deg)
+        kax = g.stage("kappa").axis
+        basis = _BASIS_YOU if factory is kappa6c else _BASIS_BL
+        expected_axis = kappa_axis(g.kappa_alpha_deg, basis=basis)
+        np.testing.assert_allclose(kax, expected_axis, atol=1e-12)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -498,3 +498,38 @@ def test_wavelength_in_summary(psic_geom, capsys):
     psic_geom.summary()
     out = capsys.readouterr().out
     assert "1.540600 Å" in out
+
+
+# ---------------------------------------------------------------------------
+# kappa_alpha_deg attribute
+# ---------------------------------------------------------------------------
+
+
+def test_kappa_alpha_deg_default_is_none(psic_geom):
+    """Non-kappa geometries have kappa_alpha_deg = None."""
+    assert psic_geom.kappa_alpha_deg is None
+
+
+def test_kappa_alpha_deg_settable():
+    """kappa_alpha_deg can be set on a bare AdHocDiffractometer."""
+    from ad_hoc_diffractometer import XHAT
+    from ad_hoc_diffractometer import Stage
+
+    stages = [Stage("a", XHAT, role="sample")]
+    g = AdHocDiffractometer("test", stages, kappa_alpha_deg=50.0)
+    assert g.kappa_alpha_deg == pytest.approx(50.0)
+
+
+def test_kappa_alpha_deg_none_for_non_kappa():
+    """All non-kappa factories return None for kappa_alpha_deg."""
+    from ad_hoc_diffractometer import fivec
+    from ad_hoc_diffractometer import fourc_h
+    from ad_hoc_diffractometer import fourc_v
+    from ad_hoc_diffractometer import psic
+    from ad_hoc_diffractometer import s2d2
+    from ad_hoc_diffractometer import sixc
+    from ad_hoc_diffractometer import zaxis
+
+    for factory in (psic, fourc_v, fourc_h, sixc, zaxis, s2d2, fivec):
+        g = factory()
+        assert g.kappa_alpha_deg is None, f"{factory.__name__} should have None"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -523,13 +523,13 @@ def test_kappa_alpha_deg_settable():
 def test_kappa_alpha_deg_none_for_non_kappa():
     """All non-kappa factories return None for kappa_alpha_deg."""
     from ad_hoc_diffractometer import fivec
-    from ad_hoc_diffractometer import fourc_h
-    from ad_hoc_diffractometer import fourc_v
+    from ad_hoc_diffractometer import fourch
+    from ad_hoc_diffractometer import fourcv
     from ad_hoc_diffractometer import psic
     from ad_hoc_diffractometer import s2d2
     from ad_hoc_diffractometer import sixc
     from ad_hoc_diffractometer import zaxis
 
-    for factory in (psic, fourc_v, fourc_h, sixc, zaxis, s2d2, fivec):
+    for factory in (psic, fourcv, fourch, sixc, zaxis, s2d2, fivec):
         g = factory()
         assert g.kappa_alpha_deg is None, f"{factory.__name__} should have None"


### PR DESCRIPTION
- closes #3

Exposes the kappa tilt angle as a queryable `kappa_alpha_deg` property on `AdHocDiffractometer`, and renames four factory functions to remove underscores from the v/h detector suffix.

## Changes

### kappa_alpha_deg property (#3)
- `kappa_alpha_deg: float | None` property on `AdHocDiffractometer`; `None` for non-kappa geometries
- `kappa4cv`, `kappa4ch`, `kappa6c` factory functions pass `alpha_deg` to the constructor
- 12 new tests: `None` for all non-kappa factories, correct value at default (50°) and custom alpha, axis-vector consistency via `kappa_axis()` reconstruction

### Factory renames (no underscore in v/h suffix)
- `fourc_v`  → `fourcv`
- `fourc_h`  → `fourch`
- `kappa4c`  → `kappa4cv`  (vertical detector is the default/laboratory convention)
- `kappa4c_h` → `kappa4ch`

All imports, `__all__`, tests, docstrings, `AGENTS.md`, and `docs/roadmap.md` updated. 334 tests passing.

Contributed by: OpenCode (argo/claudesonnet46)