### PR TITLE
ENH Orienting reflections data structure (#7)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,13 +107,42 @@ be implemented first.
       (eqs. 29-31) for UB without known lattice parameters
 - [ ] Depends on 2.1
 
-### 2.3 Orienting reflections ([#7](https://github.com/prjemian/ad_hoc_diffractometer/issues/7))
+### 2.3 Orienting reflections data structure ([#7](https://github.com/prjemian/ad_hoc_diffractometer/issues/7))
 
-- [ ] Data structure to store primary and secondary orienting reflections:
-      hkl (Miller indices), motor angles at which the reflection was found,
-      wavelength used
-- [ ] Match the SPEC #G1 format (see spec_G_lines.md)
-- [ ] Tests verifying round-trip: reflection → U → predicted angles
+- [x] `Reflection` dataclass: `name`, `hkl`, `angles` (keyed by stage name),
+      `wavelength`, `geometry_name`; normalisation, validation, `__eq__`
+- [x] `ReflectionList` class: ordered dict of named reflections with
+      dict-like interface (`__getitem__`, `__delitem__`, `__contains__`,
+      `__len__`, `__iter__`), `add()`, `remove()`, `clear()`
+- [x] `ReflectionList.setor1()` / `setor2()`: designate primary/secondary
+      orienting reflections; moving a reflection between slots clears the old
+- [x] `ReflectionList.orienting_reflections` property: `[]`, `[or1]`, or
+      `[or1, or2]`
+- [x] Angle keys validated against the geometry's stage names at `add()` time
+- [x] `AdHocDiffractometer.reflections` holds the `ReflectionList`
+- [x] `AdHocDiffractometer.add_reflection()` convenience wrapper (inherits
+      geometry wavelength)
+
+### 2.4 SPEC #G1 format and reflection round-trip tests ([#25](https://github.com/prjemian/ad_hoc_diffractometer/issues/25))
+
+- [ ] Parse and emit the SPEC #G1 line format (hkl + motor angles + wavelength)
+- [ ] Tests: store a reflection → compute U → back-calculate angles, verify match
+- [ ] Verify compatibility with alignment data in
+      `references/2020-12-13-fourcc-alignment-7-id-c/`
+- [ ] Depends on: #7 (2.3), #5 (2.1 U matrix), #6 (2.2 UB matrix), #26 (2.5)
+
+### 2.5 Sample dict on AdHocDiffractometer ([#26](https://github.com/prjemian/ad_hoc_diffractometer/issues/26))
+
+- [ ] New `Sample` class (`sample.py`): `name`, `lattice` (Lattice), `reflections`
+      (ReflectionList), `U` (3×3 or None), `UB` (3×3 or None)
+- [ ] Default sample: `"test"`, cubic lattice a=1 Å, empty reflections, U/UB=None
+- [ ] `AdHocDiffractometer.samples` — ordered dict, initialised with `"test"`
+- [ ] `AdHocDiffractometer.sample` — property for the active sample (get/set by
+      name or object)
+- [ ] `AdHocDiffractometer.add_reflection()` delegates to the active sample's
+      `ReflectionList`
+- [ ] U and UB matrices live on `Sample`, not on the geometry
+- [ ] Depends on: #7 (2.3); required by: #5 (2.1), #6 (2.2), #25 (2.4)
 
 ---
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -32,6 +32,8 @@ from .lattice import Lattice
 from .lattice import b_matrix
 from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
+from .reflection import Reflection
+from .reflection import ReflectionList
 from .rotation import rotation_matrix
 from .stage import Stage
 
@@ -55,6 +57,8 @@ __all__ = [
     "Stage",
     # geometry
     "AdHocDiffractometer",
+    "Reflection",
+    "ReflectionList",
     # factories
     "list_geometries",
     "get_geometry",

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -10,6 +10,8 @@ import numpy as np
 from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
+from .reflection import Reflection
+from .reflection import ReflectionList
 from .stage import Stage
 
 
@@ -110,6 +112,12 @@ class AdHocDiffractometer:
         # Build ordered lists per role
         self.sample_stages = self._ordered_stages("sample")
         self.detector_stages = self._ordered_stages("detector")
+
+        # Ordered collection of named orienting reflections with or1/or2 management
+        self.reflections: ReflectionList = ReflectionList(
+            geometry_name=self.name,
+            valid_stages=set(self._stages),
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -283,6 +291,42 @@ class AdHocDiffractometer:
                 "The following stages have angles outside their limits:\n"
                 + "\n".join(violations)
             )
+
+    # ------------------------------------------------------------------
+    # Reflections — convenience wrapper around self.reflections
+    # ------------------------------------------------------------------
+
+    def add_reflection(
+        self,
+        name: str,
+        hkl: tuple[float, float, float],
+        angles: dict[str, float],
+        wavelength: float | None = None,
+    ) -> Reflection:
+        """
+        Add a named orienting reflection recorded on this geometry.
+
+        Delegates to ``self.reflections.add()``.  If ``wavelength`` is
+        None the geometry's current wavelength is inherited.
+
+        Parameters
+        ----------
+        name : str
+            Unique label (e.g. ``"r1"``, ``"Si_111"``).
+        hkl : tuple of float
+            Miller indices (h, k, l).
+        angles : dict[str, float]
+            Motor angles in degrees keyed by stage name.  Keys must be
+            stage names of this geometry.
+        wavelength : float or None
+            Wavelength in Å.  If None, inherits ``self.wavelength``.
+
+        Returns
+        -------
+        Reflection
+        """
+        wl = wavelength if wavelength is not None else self._wavelength
+        return self.reflections.add(name=name, hkl=hkl, angles=angles, wavelength=wl)
 
     def sample_rotation_matrix(self) -> np.ndarray:
         """

--- a/src/ad_hoc_diffractometer/reflection.py
+++ b/src/ad_hoc_diffractometer/reflection.py
@@ -1,0 +1,302 @@
+"""
+reflection.py — Reflection and ReflectionList for orienting reflections.
+
+A Reflection stores the Miller indices (hkl), the diffractometer motor
+angles at which the reflection was observed, the wavelength used, and
+the name of the geometry on which it was recorded.
+
+A ReflectionList owns an ordered dict of named Reflection objects and
+manages the primary (or1) and secondary (or2) orienting designations.
+It is held as ``AdHocDiffractometer.reflections``.
+
+Typical usage::
+
+    g = psic()
+    rl = g.reflections                          # ReflectionList
+    r1 = rl.add("r1", hkl=(1, 0, 0),
+                 angles={"mu": 0, "eta": 20, ...},
+                 valid_stages=set(g._stages))
+    r2 = rl.add("r2", hkl=(0, 1, 0), ...)
+    rl.setor1("r1")
+    rl.setor2("r2")
+    rl.orienting_reflections   # -> [r1, r2]
+    rl["r1"]                   # -> r1
+    del rl["r1"]
+    rl.clear()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class Reflection:
+    """
+    One observed reflection used for diffractometer orientation.
+
+    Parameters
+    ----------
+    name : str
+        User-supplied label (e.g. ``"r1"``, ``"Si_111"``).  Set by
+        ``ReflectionList.add()``.
+    hkl : tuple of float
+        Miller indices (h, k, l).  Need not be integers.
+    angles : dict[str, float]
+        Motor angles (degrees) keyed by stage name.  Keys are specific
+        to the geometry named in ``geometry_name`` and are validated by
+        ``ReflectionList.add()`` before the reflection is stored.
+    wavelength : float or None
+        Wavelength in Å.  If None the geometry's wavelength is assumed.
+    geometry_name : str or None
+        Name of the geometry on which this reflection was recorded.
+        Angle keys are only meaningful for that geometry.
+
+    Notes
+    -----
+    Reflections are geometry-specific: angle keys from a ``psic`` geometry
+    cannot be applied to ``kappa6c`` because the stage names differ.
+    ``ReflectionList.add()`` validates keys and records ``geometry_name``
+    so cross-geometry misuse can be detected.
+    """
+
+    name: str
+    hkl: tuple[float, float, float]
+    angles: dict[str, float]
+    wavelength: float | None = field(default=None)
+    geometry_name: str | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        h, k, l = self.hkl  # noqa: E741
+        self.hkl = (float(h), float(k), float(l))
+        self.angles = {n: float(v) for n, v in self.angles.items()}
+        if self.wavelength is not None:
+            self.wavelength = float(self.wavelength)
+            if self.wavelength <= 0:
+                raise ValueError(
+                    f"Reflection wavelength must be > 0 Å; got {self.wavelength}."
+                )
+
+    def __eq__(self, other: object) -> bool:
+        """
+        True if all fields match.
+
+        Two reflections from different geometries are never equal even if
+        hkl and angle values coincide, because the angle keys carry
+        different physical meanings.
+        """
+        if not isinstance(other, Reflection):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.hkl == other.hkl
+            and self.angles == other.angles
+            and self.wavelength == other.wavelength
+            and self.geometry_name == other.geometry_name
+        )
+
+    def __repr__(self) -> str:
+        wl = f"{self.wavelength} Å" if self.wavelength is not None else "not set"
+        return (
+            f"Reflection(name={self.name!r}, hkl={self.hkl}, "
+            f"angles={self.angles}, wavelength={wl}, "
+            f"geometry_name={self.geometry_name!r})"
+        )
+
+
+class ReflectionList:
+    """
+    Ordered, named collection of Reflection objects with or1/or2 management.
+
+    Held as ``AdHocDiffractometer.reflections``.  All mutation methods
+    validate that angle keys belong to the owning geometry.
+
+    Parameters
+    ----------
+    geometry_name : str
+        Name of the owning ``AdHocDiffractometer``.  Stored on every
+        reflection added through this list.
+    valid_stages : set of str
+        Stage names of the owning geometry.  Used to validate angle keys.
+
+    Attributes
+    ----------
+    geometry_name : str
+    valid_stages : set of str
+
+    Examples
+    --------
+    >>> rl = ReflectionList(geometry_name="psic",
+    ...                     valid_stages={"mu", "eta", "chi", "phi",
+    ...                                   "nu", "delta"})
+    >>> r = rl.add("r1", hkl=(1, 0, 0), angles={"mu": 0, "eta": 20})
+    >>> rl.setor1("r1")
+    >>> rl.orienting_reflections
+    [Reflection(name='r1', ...)]
+    """
+
+    def __init__(self, geometry_name: str, valid_stages: set[str]) -> None:
+        self.geometry_name = geometry_name
+        self.valid_stages = set(valid_stages)
+        self._data: dict[str, Reflection] = {}
+        self._or1_name: str | None = None
+        self._or2_name: str | None = None
+
+    # ------------------------------------------------------------------
+    # Dict-like interface
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, name: str) -> Reflection:
+        return self._data[name]
+
+    def __delitem__(self, name: str) -> None:
+        del self._data[name]
+        if self._or1_name == name:
+            self._or1_name = None
+        if self._or2_name == name:
+            self._or2_name = None
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __repr__(self) -> str:
+        return (
+            f"ReflectionList(geometry_name={self.geometry_name!r}, "
+            f"reflections={list(self._data)})"
+        )
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        name: str,
+        hkl: tuple[float, float, float],
+        angles: dict[str, float],
+        wavelength: float | None = None,
+    ) -> Reflection:
+        """
+        Add a named reflection, validate angle keys, and return it.
+
+        Parameters
+        ----------
+        name : str
+            Unique label.
+        hkl : tuple of float
+            Miller indices.
+        angles : dict[str, float]
+            Motor angles; keys must be stage names of this geometry.
+        wavelength : float or None
+            Wavelength in Å; stored as-is (caller supplies the geometry's
+            current wavelength if desired).
+
+        Raises
+        ------
+        ValueError
+            If ``name`` already exists or any angle key is not a valid stage.
+        """
+        if name in self._data:
+            raise ValueError(
+                f"A reflection named {name!r} already exists. Remove it first."
+            )
+        unknown = set(angles) - self.valid_stages
+        if unknown:
+            raise ValueError(
+                f"Angle key(s) {sorted(unknown)} are not stage names in "
+                f"geometry {self.geometry_name!r}. "
+                f"Valid stages: {sorted(self.valid_stages)}."
+            )
+        r = Reflection(
+            name=name,
+            hkl=hkl,
+            angles=dict(angles),
+            wavelength=wavelength,
+            geometry_name=self.geometry_name,
+        )
+        self._data[name] = r
+        return r
+
+    def remove(self, name: str) -> None:
+        """
+        Remove the named reflection and clear any or1/or2 designation it held.
+
+        Raises
+        ------
+        KeyError
+            If no reflection with that name exists.
+        """
+        del self[name]
+
+    def clear(self) -> None:
+        """Remove all reflections and clear or1/or2 designations."""
+        self._data.clear()
+        self._or1_name = None
+        self._or2_name = None
+
+    # ------------------------------------------------------------------
+    # or1 / or2 management
+    # ------------------------------------------------------------------
+
+    def _resolve(self, reflection: str | Reflection) -> str:
+        """Return the name of a reflection given a name or object."""
+        name = reflection.name if isinstance(reflection, Reflection) else reflection
+        if name not in self._data:
+            raise KeyError(f"No reflection named {name!r}. Add it first.")
+        return name
+
+    def setor1(self, reflection: str | Reflection) -> None:
+        """
+        Designate a reflection as primary (or1).
+
+        If it was previously the secondary (or2), that designation is cleared.
+        The previous or1 remains in the list without any designation.
+        """
+        name = self._resolve(reflection)
+        if name == self._or2_name:
+            self._or2_name = None
+        self._or1_name = name
+
+    def setor2(self, reflection: str | Reflection) -> None:
+        """
+        Designate a reflection as secondary (or2).
+
+        If it was previously the primary (or1), that designation is cleared.
+        The previous or2 remains in the list without any designation.
+        """
+        name = self._resolve(reflection)
+        if name == self._or1_name:
+            self._or1_name = None
+        self._or2_name = name
+
+    @property
+    def orienting_reflections(self) -> list[Reflection]:
+        """
+        Ordered list of designated orienting reflections.
+
+        Returns ``[]``, ``[or1]``, or ``[or1, or2]``.  A secondary
+        without a primary is returned as a single-element list containing
+        the secondary.
+        """
+        result: list[Reflection] = []
+        if self._or1_name is not None:
+            result.append(self._data[self._or1_name])
+        if self._or2_name is not None:
+            result.append(self._data[self._or2_name])
+        return result

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,466 @@
+"""
+Unit tests for ad_hoc_diffractometer.reflection.
+
+Covers:
+  - Reflection dataclass: construction, normalisation, validation, __eq__, __repr__
+  - ReflectionList: add, remove, clear, dict-like interface,
+    setor1/setor2, orienting_reflections, cross-geometry safety
+  - AdHocDiffractometer.add_reflection() convenience wrapper
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ad_hoc_diffractometer import Reflection
+from ad_hoc_diffractometer import ReflectionList
+from ad_hoc_diffractometer import kappa6c
+from ad_hoc_diffractometer import psic
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PSIC_STAGES = {"mu", "eta", "chi", "phi", "nu", "delta"}
+_PSIC_ANGLES = {
+    "mu": 0.0,
+    "eta": 20.0,
+    "chi": 90.0,
+    "phi": 0.0,
+    "nu": 0.0,
+    "delta": 40.0,
+}
+
+
+@pytest.fixture
+def rl():
+    """Fresh ReflectionList for psic geometry."""
+    return ReflectionList(geometry_name="psic", valid_stages=_PSIC_STAGES)
+
+
+# ---------------------------------------------------------------------------
+# Reflection dataclass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hkl, angles, wavelength, context",
+    [
+        pytest.param(
+            (1, 0, 0),
+            {"mu": 0.0},
+            1.5406,
+            does_not_raise(),
+            id="valid-integer-hkl",
+        ),
+        pytest.param(
+            (0.5, 0.0, 0.0),
+            {"mu": 0.0},
+            1.5406,
+            does_not_raise(),
+            id="valid-fractional-hkl",
+        ),
+        pytest.param(
+            (1, 0, 0),
+            {"mu": 0.0},
+            None,
+            does_not_raise(),
+            id="valid-wavelength-none",
+        ),
+        pytest.param(
+            (1, 0, 0),
+            {"mu": 0.0},
+            0.0,
+            pytest.raises(ValueError, match=re.escape("must be > 0")),
+            id="invalid-wavelength-zero",
+        ),
+        pytest.param(
+            (1, 0, 0),
+            {"mu": 0.0},
+            -1.5,
+            pytest.raises(ValueError, match=re.escape("must be > 0")),
+            id="invalid-wavelength-negative",
+        ),
+    ],
+)
+def test_reflection_construction(hkl, angles, wavelength, context):
+    with context:
+        r = Reflection(name="r1", hkl=hkl, angles=angles, wavelength=wavelength)
+        assert r.hkl == tuple(float(v) for v in hkl)
+        assert all(isinstance(v, float) for v in r.angles.values())
+
+
+def test_reflection_name_stored():
+    r = Reflection(name="Si_111", hkl=(1, 1, 1), angles={})
+    assert r.name == "Si_111"
+
+
+def test_reflection_hkl_normalised_to_float():
+    r = Reflection(name="r1", hkl=(1, 2, 3), angles={})
+    assert r.hkl == (1.0, 2.0, 3.0)
+
+
+def test_reflection_geometry_name_stored():
+    r = Reflection(name="r1", hkl=(1, 0, 0), angles={}, geometry_name="psic")
+    assert r.geometry_name == "psic"
+
+
+def test_reflection_geometry_name_default_none():
+    r = Reflection(name="r1", hkl=(1, 0, 0), angles={})
+    assert r.geometry_name is None
+
+
+def test_reflection_repr_contains_name_and_geometry():
+    r = Reflection(name="Si_111", hkl=(1, 1, 1), angles={}, geometry_name="psic")
+    assert "Si_111" in repr(r)
+    assert "psic" in repr(r)
+
+
+# ---------------------------------------------------------------------------
+# Reflection.__eq__
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_eq_identical():
+    r1 = Reflection(
+        name="r1",
+        hkl=(1, 0, 0),
+        angles={"mu": 0.0},
+        wavelength=1.5406,
+        geometry_name="psic",
+    )
+    r2 = Reflection(
+        name="r1",
+        hkl=(1, 0, 0),
+        angles={"mu": 0.0},
+        wavelength=1.5406,
+        geometry_name="psic",
+    )
+    assert r1 == r2
+
+
+def test_reflection_eq_different_name():
+    r1 = Reflection(name="r1", hkl=(1, 0, 0), angles={}, geometry_name="psic")
+    r2 = Reflection(name="r2", hkl=(1, 0, 0), angles={}, geometry_name="psic")
+    assert r1 != r2
+
+
+def test_reflection_eq_different_hkl():
+    r1 = Reflection(name="r1", hkl=(1, 0, 0), angles={}, geometry_name="psic")
+    r2 = Reflection(name="r1", hkl=(0, 1, 0), angles={}, geometry_name="psic")
+    assert r1 != r2
+
+
+def test_reflection_eq_different_angles():
+    r1 = Reflection(name="r1", hkl=(1, 0, 0), angles={"mu": 0.0}, geometry_name="psic")
+    r2 = Reflection(name="r1", hkl=(1, 0, 0), angles={"mu": 5.0}, geometry_name="psic")
+    assert r1 != r2
+
+
+def test_reflection_eq_different_wavelength():
+    r1 = Reflection(
+        name="r1", hkl=(1, 0, 0), angles={}, wavelength=1.5406, geometry_name="psic"
+    )
+    r2 = Reflection(
+        name="r1", hkl=(1, 0, 0), angles={}, wavelength=0.7107, geometry_name="psic"
+    )
+    assert r1 != r2
+
+
+def test_reflection_eq_different_geometry_name():
+    r1 = Reflection(name="r1", hkl=(1, 0, 0), angles={}, geometry_name="psic")
+    r2 = Reflection(name="r1", hkl=(1, 0, 0), angles={}, geometry_name="kappa6c")
+    assert r1 != r2
+
+
+def test_reflection_eq_not_implemented_for_non_reflection():
+    r = Reflection(name="r1", hkl=(1, 0, 0), angles={})
+    assert r.__eq__("not a reflection") is NotImplemented
+    assert r != "not a reflection"
+
+
+# ---------------------------------------------------------------------------
+# ReflectionList construction
+# ---------------------------------------------------------------------------
+
+
+def test_reflection_list_empty_by_default(rl):
+    assert len(rl) == 0
+    assert list(rl) == []
+
+
+def test_reflection_list_geometry_name(rl):
+    assert rl.geometry_name == "psic"
+
+
+def test_reflection_list_valid_stages(rl):
+    assert rl.valid_stages == _PSIC_STAGES
+
+
+def test_reflection_list_repr(rl):
+    assert "psic" in repr(rl)
+
+
+# ---------------------------------------------------------------------------
+# ReflectionList.add()
+# ---------------------------------------------------------------------------
+
+
+def test_add_returns_reflection(rl):
+    r = rl.add("r1", hkl=(1, 0, 0), angles={"mu": 0.0})
+    assert isinstance(r, Reflection)
+    assert r.name == "r1"
+    assert r.hkl == (1.0, 0.0, 0.0)
+    assert r.geometry_name == "psic"
+
+
+def test_add_wavelength_stored(rl):
+    r = rl.add("r1", hkl=(1, 0, 0), angles={}, wavelength=1.5406)
+    assert r.wavelength == pytest.approx(1.5406)
+
+
+def test_add_duplicate_name_raises(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    with pytest.raises(ValueError, match=re.escape("already exists")):
+        rl.add("r1", hkl=(0, 1, 0), angles={})
+
+
+def test_add_unknown_angle_key_raises(rl):
+    with pytest.raises(ValueError, match=re.escape("not stage names")):
+        rl.add("r1", hkl=(1, 0, 0), angles={"bogus": 0.0})
+
+
+def test_add_subset_of_stages_allowed(rl):
+    r = rl.add("r1", hkl=(1, 0, 0), angles={"mu": 0.0, "eta": 20.0})
+    assert set(r.angles) == {"mu", "eta"}
+
+
+# ---------------------------------------------------------------------------
+# ReflectionList dict-like interface
+# ---------------------------------------------------------------------------
+
+
+def test_getitem(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    assert rl["r1"].name == "r1"
+
+
+def test_getitem_missing_raises(rl):
+    with pytest.raises(KeyError):
+        _ = rl["missing"]
+
+
+def test_contains(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    assert "r1" in rl
+    assert "missing" not in rl
+
+
+def test_len(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    assert len(rl) == 2
+
+
+def test_iter_ordering(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.add("r3", hkl=(0, 0, 1), angles={})
+    assert list(rl) == ["r1", "r2", "r3"]
+
+
+def test_delitem_clears_or_designation(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.setor1("r1")
+    del rl["r1"]
+    assert "r1" not in rl
+    assert rl.orienting_reflections == []
+
+
+# ---------------------------------------------------------------------------
+# ReflectionList.remove() and .clear()
+# ---------------------------------------------------------------------------
+
+
+def test_remove(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.remove("r1")
+    assert "r1" not in rl
+
+
+def test_remove_missing_raises(rl):
+    with pytest.raises(KeyError):
+        rl.remove("missing")
+
+
+def test_remove_then_readd(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.remove("r1")
+    rl.add("r1", hkl=(0, 1, 0), angles={})
+    assert rl["r1"].hkl == (0.0, 1.0, 0.0)
+
+
+def test_clear(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.setor1("r1")
+    rl.setor2("r2")
+    rl.clear()
+    assert len(rl) == 0
+    assert rl.orienting_reflections == []
+
+
+# ---------------------------------------------------------------------------
+# setor1 / setor2 / orienting_reflections
+# ---------------------------------------------------------------------------
+
+
+def test_orienting_reflections_empty_by_default(rl):
+    assert rl.orienting_reflections == []
+
+
+def test_setor1_by_name(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.setor1("r1")
+    ors = rl.orienting_reflections
+    assert len(ors) == 1
+    assert ors[0].name == "r1"
+
+
+def test_setor1_by_object(rl):
+    r = rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.setor1(r)
+    assert rl.orienting_reflections[0].name == "r1"
+
+
+def test_setor2_by_name(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.setor1("r1")
+    rl.setor2("r2")
+    ors = rl.orienting_reflections
+    assert len(ors) == 2
+    assert ors[0].name == "r1"
+    assert ors[1].name == "r2"
+
+
+def test_setor2_by_object(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    r2 = rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.setor1("r1")
+    rl.setor2(r2)
+    assert rl.orienting_reflections[1].name == "r2"
+
+
+def test_only_or1_set(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.setor1("r1")
+    assert len(rl.orienting_reflections) == 1
+
+
+def test_setor1_replaces_previous(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.setor1("r1")
+    rl.setor1("r2")
+    ors = rl.orienting_reflections
+    assert len(ors) == 1
+    assert ors[0].name == "r2"
+    assert "r1" in rl
+
+
+def test_setor2_replaces_previous(rl):
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.add("r3", hkl=(0, 0, 1), angles={})
+    rl.setor1("r1")
+    rl.setor2("r2")
+    rl.setor2("r3")
+    ors = rl.orienting_reflections
+    assert len(ors) == 2
+    assert ors[1].name == "r3"
+    assert "r2" in rl
+
+
+def test_setor2_was_or1_clears_or1(rl):
+    """Moving a reflection from or1 to or2 clears the primary slot."""
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.setor1("r1")
+    rl.setor2("r1")  # r1 moves to or2; or1 becomes None
+    ors = rl.orienting_reflections
+    assert len(ors) == 1
+    assert ors[0].name == "r1"
+
+
+def test_setor1_was_or2_clears_or2(rl):
+    """Moving a reflection from or2 to or1 clears the secondary slot."""
+    rl.add("r1", hkl=(1, 0, 0), angles={})
+    rl.add("r2", hkl=(0, 1, 0), angles={})
+    rl.setor1("r1")
+    rl.setor2("r2")
+    rl.setor1("r2")  # r2 moves from or2 to or1
+    ors = rl.orienting_reflections
+    assert len(ors) == 1
+    assert ors[0].name == "r2"
+
+
+def test_setor1_unknown_raises(rl):
+    with pytest.raises(KeyError):
+        rl.setor1("missing")
+
+
+def test_setor2_unknown_raises(rl):
+    with pytest.raises(KeyError):
+        rl.setor2("missing")
+
+
+# ---------------------------------------------------------------------------
+# Cross-geometry safety
+# ---------------------------------------------------------------------------
+
+
+def test_cross_geometry_angle_keys_rejected():
+    """psic stage names are not valid in kappa6c."""
+    g = kappa6c()
+    with pytest.raises(ValueError, match=re.escape("not stage names")):
+        g.reflections.add(
+            "r1", hkl=(1, 0, 0), angles={"eta": 20.0, "chi": 90.0, "phi": 0.0}
+        )
+
+
+def test_cross_geometry_geometry_name_differs():
+    g1 = psic()
+    g2 = kappa6c()
+    r = g1.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert r.geometry_name == "psic"
+    assert r.geometry_name != g2.name
+
+
+# ---------------------------------------------------------------------------
+# AdHocDiffractometer.add_reflection() convenience wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_add_reflection_inherits_wavelength(psic_geom):
+    psic_geom.wavelength = 1.5406
+    r = psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert r.wavelength == pytest.approx(1.5406)
+
+
+def test_add_reflection_explicit_wavelength_overrides(psic_geom):
+    psic_geom.wavelength = 1.5406
+    r = psic_geom.add_reflection(
+        "r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES, wavelength=0.7107
+    )
+    assert r.wavelength == pytest.approx(0.7107)
+
+
+def test_add_reflection_stored_in_reflections(psic_geom):
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert "r1" in psic_geom.reflections
+
+
+def test_add_reflection_geometry_name_set(psic_geom):
+    r = psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert r.geometry_name == "psic"


### PR DESCRIPTION
- closes #7

Adds `Reflection`, `ReflectionList`, and reflection management to `AdHocDiffractometer`.

## Changes

- **`reflection.py`** — `Reflection` dataclass (`name`, `hkl`, `angles`, `wavelength`, `geometry_name`; normalisation, validation, `__eq__`, `__repr__`) and `ReflectionList` class (ordered dict, `add/remove/clear`, dict-like interface, `setor1/setor2`, `orienting_reflections` property)
- **`geometry.py`** — `AdHocDiffractometer.reflections` holds a `ReflectionList`; `add_reflection()` convenience wrapper inherits geometry wavelength; all other reflection logic delegated to `ReflectionList`
- **`__init__.py`** — export `Reflection` and `ReflectionList`
- **`tests/test_reflection.py`** — 54 tests: construction, normalisation, `__eq__`, CRUD, dict interface, `setor1/setor2` semantics, cross-geometry key rejection, convenience wrapper
- **`docs/roadmap.md`** — section 2.3 checked; sections 2.4 (#25) and 2.5 (#26) appended

## Notes

- Angle keys are validated against the geometry's stage names at `add()` time
- `geometry_name` is recorded on every reflection for cross-geometry detection
- Deferred: SPEC #G1 format (#25), Sample dict (#26)

Contributed by: OpenCode (argo/claudesonnet46)