### PR TITLE
ENH Sample dict on AdHocDiffractometer (#25)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,18 +131,25 @@ be implemented first.
       `references/2020-12-13-fourcc-alignment-7-id-c/`
 - [ ] Depends on: #7 (2.3), #5 (2.1 U matrix), #6 (2.2 UB matrix), #26 (2.5)
 
-### 2.5 Sample dict on AdHocDiffractometer ([#26](https://github.com/prjemian/ad_hoc_diffractometer/issues/26))
+### 2.5 Sample dict on AdHocDiffractometer ([#25](https://github.com/prjemian/ad_hoc_diffractometer/issues/25))
 
-- [ ] New `Sample` class (`sample.py`): `name`, `lattice` (Lattice), `reflections`
-      (ReflectionList), `U` (3×3 or None), `UB` (3×3 or None)
-- [ ] Default sample: `"test"`, cubic lattice a=1 Å, empty reflections, U/UB=None
-- [ ] `AdHocDiffractometer.samples` — ordered dict, initialised with `"test"`
-- [ ] `AdHocDiffractometer.sample` — property for the active sample (get/set by
-      name or object)
-- [ ] `AdHocDiffractometer.add_reflection()` delegates to the active sample's
+- [x] New `Sample` class (`sample.py`): `name`, `lattice` (Lattice),
+      `reflections` (ReflectionList), `U` (3×3 or None), `UB` (3×3 or None);
+      `__eq__`, `__repr__`
+- [x] `SampleDict` class: guarded ordered dict; rejects non-Sample values,
+      blocks remove/replace/pop/clear of the active sample; `_samples` is a
+      read-only property so the container itself cannot be replaced
+- [x] Default sample: `"test"`, cubic lattice a=1 Å, empty reflections,
+      U=None, UB=None
+- [x] `AdHocDiffractometer.samples` — `SampleDict`, initialised with `"test"`
+- [x] `AdHocDiffractometer.sample` — property for the active sample (get/set
+      by name or object)
+- [x] `AdHocDiffractometer.add_sample()` / `remove_sample()` — guarded CRUD
+- [x] `AdHocDiffractometer.add_reflection()` delegates to the active sample's
       `ReflectionList`
-- [ ] U and UB matrices live on `Sample`, not on the geometry
-- [ ] Depends on: #7 (2.3); required by: #5 (2.1), #6 (2.2), #25 (2.4)
+- [x] U and UB matrices live on `Sample`, not on the geometry
+- [x] `Lattice.__eq__` added (compares all six parameters)
+- [x] 37 new tests in `test_sample.py`
 
 ---
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -35,6 +35,8 @@ from .lattice import reciprocal_vectors
 from .reflection import Reflection
 from .reflection import ReflectionList
 from .rotation import rotation_matrix
+from .sample import Sample
+from .sample import SampleDict
 from .stage import Stage
 
 __all__ = [
@@ -59,6 +61,8 @@ __all__ = [
     "AdHocDiffractometer",
     "Reflection",
     "ReflectionList",
+    "Sample",
+    "SampleDict",
     # factories
     "list_geometries",
     "get_geometry",

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -12,6 +12,10 @@ from .constants import YHAT
 from .constants import ZHAT
 from .reflection import Reflection
 from .reflection import ReflectionList
+from .sample import _DEFAULT_LATTICE
+from .sample import _DEFAULT_SAMPLE_NAME
+from .sample import Sample
+from .sample import SampleDict
 from .stage import Stage
 
 
@@ -118,6 +122,21 @@ class AdHocDiffractometer:
             geometry_name=self.name,
             valid_stages=set(self._stages),
         )
+
+        # Samples: a SampleDict guarded against removing the active sample
+        # or inserting non-Sample values.  The active name is shared via a
+        # one-element list so SampleDict always sees the current selection.
+        self._active_ref: list[str] = [_DEFAULT_SAMPLE_NAME]
+        self.__samples = SampleDict(active_ref=self._active_ref)
+        _default = Sample(
+            name=_DEFAULT_SAMPLE_NAME,
+            lattice=_DEFAULT_LATTICE,
+            reflections=ReflectionList(
+                geometry_name=self.name,
+                valid_stages=set(self._stages),
+            ),
+        )
+        self.__samples._data[_DEFAULT_SAMPLE_NAME] = _default
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -293,7 +312,106 @@ class AdHocDiffractometer:
             )
 
     # ------------------------------------------------------------------
-    # Reflections — convenience wrapper around self.reflections
+    # Samples
+    # ------------------------------------------------------------------
+
+    @property
+    def _samples(self) -> SampleDict:
+        """
+        The guarded sample dict.  Read-only property prevents replacement
+        of the entire dict (``g._samples = something`` raises AttributeError).
+        """
+        return self.__samples
+
+    @property
+    def samples(self) -> SampleDict:
+        """
+        The guarded SampleDict of all samples.
+
+        Supports read-only iteration (``for name in g.samples``, ``g.samples[name]``).
+        Mutation goes through ``add_sample()`` / ``remove_sample()`` to keep
+        invariants intact.
+        """
+        return self.__samples
+
+    @property
+    def sample(self) -> Sample:
+        """The currently active Sample."""
+        return self.__samples[self._active_ref[0]]
+
+    @sample.setter
+    def sample(self, value: str | Sample) -> None:
+        """
+        Set the active sample by name or Sample object.
+
+        Raises
+        ------
+        KeyError
+            If the name is not in the sample dict.
+        """
+        name = value.name if isinstance(value, Sample) else value
+        if name not in self.__samples:
+            raise KeyError(f"No sample named {name!r}. Add it first with add_sample().")
+        self._active_ref[0] = name
+
+    def add_sample(
+        self,
+        name: str,
+        lattice=None,
+    ) -> Sample:
+        """
+        Add a new sample and return it.
+
+        Parameters
+        ----------
+        name : str
+            Unique label for this sample.
+        lattice : Lattice or None
+            Crystal lattice.  If None, defaults to cubic a = 1 Å.
+
+        Returns
+        -------
+        Sample
+
+        Raises
+        ------
+        ValueError
+            If a sample with that name already exists.
+        """
+        if name in self.__samples:
+            raise ValueError(f"A sample named {name!r} already exists.")
+        from .lattice import Lattice as _Lattice
+
+        lat = lattice if lattice is not None else _Lattice(a=1.0)
+        s = Sample(
+            name=name,
+            lattice=lat,
+            reflections=ReflectionList(
+                geometry_name=self.name,
+                valid_stages=set(self._stages),
+            ),
+        )
+        self.__samples._data[name] = s  # bypass guard: add is always safe
+        return s
+
+    def remove_sample(self, name: str) -> None:
+        """
+        Remove a sample from the dict.
+
+        The active sample cannot be removed; select a different sample
+        first.  Delegates to SampleDict which enforces this invariant.
+
+        Raises
+        ------
+        KeyError
+            If the sample does not exist.
+        ValueError
+            If the sample is the currently active sample.
+        """
+        del self.__samples[name]  # SampleDict raises KeyError or ValueError
+
+    # ------------------------------------------------------------------
+    # Reflections — convenience wrapper targeting the active sample
     # ------------------------------------------------------------------
 
     def add_reflection(
@@ -304,10 +422,10 @@ class AdHocDiffractometer:
         wavelength: float | None = None,
     ) -> Reflection:
         """
-        Add a named orienting reflection recorded on this geometry.
+        Add a named orienting reflection to the active sample.
 
-        Delegates to ``self.reflections.add()``.  If ``wavelength`` is
-        None the geometry's current wavelength is inherited.
+        Delegates to ``self.sample.reflections.add()``.  If ``wavelength``
+        is None the geometry's current wavelength is inherited.
 
         Parameters
         ----------
@@ -316,8 +434,7 @@ class AdHocDiffractometer:
         hkl : tuple of float
             Miller indices (h, k, l).
         angles : dict[str, float]
-            Motor angles in degrees keyed by stage name.  Keys must be
-            stage names of this geometry.
+            Motor angles in degrees keyed by stage name.
         wavelength : float or None
             Wavelength in Å.  If None, inherits ``self.wavelength``.
 
@@ -326,7 +443,12 @@ class AdHocDiffractometer:
         Reflection
         """
         wl = wavelength if wavelength is not None else self._wavelength
-        return self.reflections.add(name=name, hkl=hkl, angles=angles, wavelength=wl)
+        return self.sample.reflections.add(
+            name=name,
+            hkl=hkl,
+            angles=angles,
+            wavelength=wl,
+        )
 
     def sample_rotation_matrix(self) -> np.ndarray:
         """

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -576,6 +576,19 @@ class Lattice:
             param_strs.append(f"{p}={fmt(val, self.precision)} {unit}")
         return f"Lattice({self._system}: {', '.join(param_strs)})"
 
+    def __eq__(self, other: object) -> bool:
+        """True if all six lattice parameters are identical."""
+        if not isinstance(other, Lattice):
+            return NotImplemented
+        return (
+            self._a == other._a
+            and self._b == other._b
+            and self._c == other._c
+            and self._alpha == other._alpha
+            and self._beta == other._beta
+            and self._gamma == other._gamma
+        )
+
     def __repr__(self) -> str:
         return (
             f"Lattice(system={self._system!r}, "

--- a/src/ad_hoc_diffractometer/sample.py
+++ b/src/ad_hoc_diffractometer/sample.py
@@ -1,0 +1,210 @@
+"""
+sample.py — Sample class and SampleDict for crystallographic sample management.
+
+A Sample bundles together everything that is specific to one crystal
+mounted on the diffractometer:
+
+  - a name (also used as the dict key in AdHocDiffractometer.samples)
+  - a Lattice (crystal structure → B matrix)
+  - a ReflectionList (geometry-specific orienting reflections)
+  - U and UB matrices (orientation, computed later)
+
+A SampleDict is a guarded ordered dict that:
+  - only accepts Sample values (no None, no arbitrary objects)
+  - prevents removing or replacing the currently active sample unless a
+    different sample has first been selected as active
+
+The diffractometer owns a SampleDict and keeps one sample active.
+All reflection operations via AdHocDiffractometer.add_reflection()
+target the active sample's ReflectionList.
+
+Typical usage::
+
+    g = psic()
+    g.sample                        # -> Sample(name='test', ...)
+    g.samples                       # -> SampleDict with 'test'
+    g.add_sample("silicon", Lattice(a=5.4310))
+    g.sample = "silicon"            # set active sample by name
+    g.add_reflection("r1", hkl=(1,1,1), angles={...})  # -> silicon's reflections
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .lattice import Lattice
+from .reflection import ReflectionList
+
+# Default sample name and lattice used when a new geometry is constructed.
+_DEFAULT_SAMPLE_NAME = "test"
+_DEFAULT_LATTICE = Lattice(a=1.0)  # cubic, 1 Å
+
+
+class SampleDict:
+    """
+    Guarded ordered dict of Sample objects.
+
+    Enforces two invariants:
+      1. Every value must be a Sample instance — no None, no arbitrary objects.
+      2. The currently active sample cannot be removed or replaced.
+
+    The active sample name is tracked via a reference to a one-element list
+    ``[active_name]`` shared with the owning AdHocDiffractometer, so changes
+    to the active selection are always visible here.
+
+    Direct reassignment of the underlying container
+    (``g._samples = something``) is blocked by making ``_samples`` a
+    read-only property on AdHocDiffractometer.
+    """
+
+    def __init__(self, active_ref: list[str]) -> None:
+        # active_ref is a one-element list [name] shared with the geometry;
+        # mutating active_ref[0] updates the active selection everywhere.
+        self._active_ref = active_ref
+        self._data: dict[str, Sample] = {}
+
+    # ------------------------------------------------------------------
+    # Active-name helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _active_name(self) -> str:
+        return self._active_ref[0]
+
+    def _guard_active(self, name: str, action: str) -> None:
+        if name == self._active_name:
+            raise ValueError(
+                f"Cannot {action} the active sample {name!r}. "
+                f"Select a different sample first."
+            )
+
+    # ------------------------------------------------------------------
+    # Type guard
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _guard_type(value: object) -> None:
+        if not isinstance(value, Sample):
+            raise TypeError(
+                f"SampleDict only accepts Sample instances; got {type(value).__name__!r}."
+            )
+
+    # ------------------------------------------------------------------
+    # Dict-like interface
+    # ------------------------------------------------------------------
+
+    def __setitem__(self, name: str, value: object) -> None:
+        self._guard_type(value)
+        if name in self._data and name == self._active_name:
+            self._guard_active(name, "replace")
+        self._data[name] = value  # type: ignore[assignment]
+
+    def __delitem__(self, name: str) -> None:
+        if name not in self._data:
+            raise KeyError(name)
+        self._guard_active(name, "remove")
+        del self._data[name]
+
+    def __getitem__(self, name: str) -> Sample:
+        return self._data[name]
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __repr__(self) -> str:
+        return f"SampleDict({list(self._data)})"
+
+    def clear(self) -> None:
+        raise ValueError(
+            "SampleDict.clear() is not permitted; the dict must always "
+            "contain at least the active sample."
+        )
+
+    def pop(self, name: str, *args) -> Sample:
+        if name not in self._data:
+            if args:
+                return args[0]
+            raise KeyError(name)
+        self._guard_active(name, "pop")
+        return self._data.pop(name)
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def items(self):
+        return self._data.items()
+
+
+class Sample:
+    """
+    One crystal sample mounted on a diffractometer.
+
+    Parameters
+    ----------
+    name : str
+        Unique label, matching the key in ``AdHocDiffractometer.samples``.
+    lattice : Lattice
+        Crystal lattice; provides the B matrix.
+    reflections : ReflectionList
+        Geometry-specific reflection collection.  Must be constructed
+        with the owning geometry's stage names as ``valid_stages``.
+    U : numpy.ndarray or None
+        3×3 crystal orientation matrix.  None until computed.
+    UB : numpy.ndarray or None
+        3×3 UB = U @ B matrix.  None until computed.
+
+    Notes
+    -----
+    U and UB are set by the U/UB computation routines (Priority 2 items
+    #5 and #6).  They are stored here so that each sample carries its
+    own orientation independently.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        lattice: Lattice,
+        reflections: ReflectionList,
+        U: np.ndarray | None = None,
+        UB: np.ndarray | None = None,
+    ) -> None:
+        self.name = name
+        self.lattice = lattice
+        self.reflections = reflections
+        self.U = U
+        self.UB = UB
+
+    def __repr__(self) -> str:
+        u_str = "set" if self.U is not None else "None"
+        ub_str = "set" if self.UB is not None else "None"
+        return (
+            f"Sample(name={self.name!r}, lattice={self.lattice!r}, "
+            f"reflections={len(self.reflections)} reflection(s), "
+            f"U={u_str}, UB={ub_str})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sample):
+            return NotImplemented
+        u_eq = (self.U is None and other.U is None) or (
+            self.U is not None
+            and other.U is not None
+            and np.array_equal(self.U, other.U)
+        )
+        ub_eq = (self.UB is None and other.UB is None) or (
+            self.UB is not None
+            and other.UB is not None
+            and np.array_equal(self.UB, other.UB)
+        )
+        return (
+            self.name == other.name and self.lattice == other.lattice and u_eq and ub_eq
+        )

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -456,9 +456,9 @@ def test_add_reflection_explicit_wavelength_overrides(psic_geom):
     assert r.wavelength == pytest.approx(0.7107)
 
 
-def test_add_reflection_stored_in_reflections(psic_geom):
+def test_add_reflection_stored_in_active_sample(psic_geom):
     psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
-    assert "r1" in psic_geom.reflections
+    assert "r1" in psic_geom.sample.reflections
 
 
 def test_add_reflection_geometry_name_set(psic_geom):

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for ad_hoc_diffractometer.sample.
+
+Covers:
+  - Sample construction, __repr__, __eq__
+  - SampleDict: type guard, active-sample guard, pop/clear/del protection,
+    direct _data assignment bypass blocked by read-only _samples property
+  - AdHocDiffractometer.samples, .sample, add_sample(), remove_sample()
+  - add_reflection() targets the active sample
+  - Switching active sample
+"""
+
+import re
+
+import numpy as np
+import pytest
+
+from ad_hoc_diffractometer import Lattice
+from ad_hoc_diffractometer import Sample
+
+_PSIC_ANGLES = {
+    "mu": 0.0,
+    "eta": 20.0,
+    "chi": 90.0,
+    "phi": 0.0,
+    "nu": 0.0,
+    "delta": 40.0,
+}
+
+
+# ---------------------------------------------------------------------------
+# Sample dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_sample_default_U_UB_none(psic_geom):
+    assert psic_geom.sample.U is None
+    assert psic_geom.sample.UB is None
+
+
+def test_sample_name(psic_geom):
+    assert psic_geom.sample.name == "test"
+
+
+def test_sample_default_lattice_cubic_1angstrom(psic_geom):
+    lat = psic_geom.sample.lattice
+    assert lat.a == pytest.approx(1.0)
+    assert lat.b == pytest.approx(1.0)
+    assert lat.c == pytest.approx(1.0)
+    assert lat.system == "cubic"
+
+
+def test_sample_repr(psic_geom):
+    r = repr(psic_geom.sample)
+    assert "test" in r
+    assert "U=None" in r
+    assert "UB=None" in r
+
+
+def test_sample_eq_identical():
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="psic", valid_stages=set())
+    s1 = Sample(name="a", lattice=Lattice(a=1.0), reflections=rl)
+    s2 = Sample(name="a", lattice=Lattice(a=1.0), reflections=rl)
+    assert s1 == s2
+
+
+def test_sample_eq_different_name():
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="psic", valid_stages=set())
+    s1 = Sample(name="a", lattice=Lattice(a=1.0), reflections=rl)
+    s2 = Sample(name="b", lattice=Lattice(a=1.0), reflections=rl)
+    assert s1 != s2
+
+
+def test_sample_eq_not_implemented_for_non_sample():
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="psic", valid_stages=set())
+    s = Sample(name="a", lattice=Lattice(a=1.0), reflections=rl)
+    assert s.__eq__("not a sample") is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# SampleDict guards
+# ---------------------------------------------------------------------------
+
+
+def test_sample_dict_rejects_none(psic_geom):
+    with pytest.raises(TypeError, match=re.escape("only accepts Sample")):
+        psic_geom.samples["test"] = None  # type: ignore
+
+
+def test_sample_dict_rejects_arbitrary_object(psic_geom):
+    with pytest.raises(TypeError, match=re.escape("only accepts Sample")):
+        psic_geom.samples["test"] = 42  # type: ignore
+
+
+def test_sample_dict_rejects_replace_active(psic_geom):
+    """Replacing the active sample's value is blocked."""
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="psic", valid_stages=set())
+    impostor = Sample(name="test", lattice=Lattice(a=2.0), reflections=rl)
+    with pytest.raises(ValueError, match=re.escape("Cannot replace")):
+        psic_geom.samples["test"] = impostor
+
+
+def test_sample_dict_del_active_raises(psic_geom):
+    with pytest.raises(ValueError, match=re.escape("Cannot remove")):
+        del psic_geom.samples["test"]
+
+
+def test_sample_dict_pop_active_raises(psic_geom):
+    with pytest.raises(ValueError, match=re.escape("Cannot pop")):
+        psic_geom.samples.pop("test")
+
+
+def test_sample_dict_clear_raises(psic_geom):
+    with pytest.raises(ValueError, match=re.escape("not permitted")):
+        psic_geom.samples.clear()
+
+
+def test_sample_dict_replace_samples_attr_raises(psic_geom):
+    """Reassigning _samples or samples is blocked (read-only property)."""
+    with pytest.raises(AttributeError):
+        psic_geom._samples = {}  # type: ignore
+
+
+def test_sample_dict_pop_nonexistent_returns_default(psic_geom):
+    result = psic_geom.samples.pop("nonexistent", "fallback")
+    assert result == "fallback"
+
+
+def test_sample_dict_pop_nonexistent_raises_without_default(psic_geom):
+    with pytest.raises(KeyError):
+        psic_geom.samples.pop("nonexistent")
+
+
+def test_sample_dict_del_non_active_succeeds(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    del psic_geom.samples["silicon"]
+    assert "silicon" not in psic_geom.samples
+
+
+# ---------------------------------------------------------------------------
+# AdHocDiffractometer.samples / .sample
+# ---------------------------------------------------------------------------
+
+
+def test_samples_contains_test_by_default(psic_geom):
+    assert "test" in psic_geom.samples
+
+
+def test_samples_length_default(psic_geom):
+    assert len(psic_geom.samples) == 1
+
+
+def test_sample_property_returns_active(psic_geom):
+    assert psic_geom.sample.name == "test"
+
+
+def test_sample_setter_by_name(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.sample = "silicon"
+    assert psic_geom.sample.name == "silicon"
+
+
+def test_sample_setter_by_object(psic_geom):
+    s = psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.sample = s
+    assert psic_geom.sample.name == "silicon"
+
+
+def test_sample_setter_unknown_raises(psic_geom):
+    with pytest.raises(KeyError, match="missing"):
+        psic_geom.sample = "missing"
+
+
+# ---------------------------------------------------------------------------
+# add_sample() / remove_sample()
+# ---------------------------------------------------------------------------
+
+
+def test_add_sample_returns_sample(psic_geom):
+    s = psic_geom.add_sample("silicon", Lattice(a=5.431))
+    assert isinstance(s, Sample)
+    assert s.name == "silicon"
+
+
+def test_add_sample_default_lattice(psic_geom):
+    s = psic_geom.add_sample("unknown")
+    assert s.lattice.a == pytest.approx(1.0)
+    assert s.lattice.system == "cubic"
+
+
+def test_add_sample_duplicate_raises(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    with pytest.raises(ValueError, match=re.escape("already exists")):
+        psic_geom.add_sample("silicon", Lattice(a=5.431))
+
+
+def test_add_sample_reflections_use_geometry_stages(psic_geom):
+    s = psic_geom.add_sample("silicon", Lattice(a=5.431))
+    assert s.reflections.valid_stages == set(psic_geom._stages)
+
+
+def test_remove_sample_non_active(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.remove_sample("silicon")
+    assert "silicon" not in psic_geom.samples
+
+
+def test_remove_sample_active_raises(psic_geom):
+    with pytest.raises(ValueError, match=re.escape("Cannot remove")):
+        psic_geom.remove_sample("test")
+
+
+def test_remove_sample_then_reselect(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.sample = "silicon"
+    psic_geom.sample = "test"
+    psic_geom.remove_sample("silicon")
+    assert "silicon" not in psic_geom.samples
+    assert psic_geom.sample.name == "test"
+
+
+# ---------------------------------------------------------------------------
+# add_reflection() targets the active sample
+# ---------------------------------------------------------------------------
+
+
+def test_add_reflection_goes_to_active_sample(psic_geom):
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert "r1" in psic_geom.sample.reflections
+
+
+def test_add_reflection_not_in_other_sample(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    # r1 is in "test", not in "silicon"
+    assert "r1" in psic_geom.samples["test"].reflections
+    assert "r1" not in psic_geom.samples["silicon"].reflections
+
+
+def test_add_reflection_switches_with_active_sample(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    psic_geom.sample = "silicon"
+    psic_geom.add_reflection("s1", hkl=(1, 1, 1), angles=_PSIC_ANGLES)
+    assert "r1" in psic_geom.samples["test"].reflections
+    assert "s1" in psic_geom.samples["silicon"].reflections
+    assert "s1" not in psic_geom.samples["test"].reflections
+
+
+def test_add_reflection_inherits_wavelength_from_geometry(psic_geom):
+    psic_geom.wavelength = 1.5406
+    r = psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_PSIC_ANGLES)
+    assert r.wavelength == pytest.approx(1.5406)
+
+
+# ---------------------------------------------------------------------------
+# U / UB on Sample
+# ---------------------------------------------------------------------------
+
+
+def test_sample_U_can_be_set(psic_geom):
+    psic_geom.sample.U = np.eye(3)
+    np.testing.assert_array_equal(psic_geom.sample.U, np.eye(3))
+
+
+def test_sample_UB_can_be_set(psic_geom):
+    psic_geom.sample.UB = np.eye(3)
+    np.testing.assert_array_equal(psic_geom.sample.UB, np.eye(3))
+
+
+def test_sample_U_UB_independent_per_sample(psic_geom):
+    psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.sample.U = np.eye(3)  # set on "test"
+    psic_geom.sample = "silicon"
+    assert psic_geom.sample.U is None  # "silicon" still has None


### PR DESCRIPTION
- closes #25

Adds `Sample`, `SampleDict`, and sample management to `AdHocDiffractometer`. Each sample owns its lattice, reflection list, and U/UB matrices independently.

## Changes

- **`sample.py`** — `Sample` class (`name`, `lattice`, `reflections`, `U`, `UB`, `__eq__`, `__repr__`) and `SampleDict` (guarded ordered dict: rejects non-`Sample` values; blocks remove/replace/pop/clear of the active sample)
- **`geometry.py`** — `AdHocDiffractometer` gains `.samples` (`SampleDict`), `.sample` (active `Sample` property, get/set by name or object), `add_sample()`, `remove_sample()`; `add_reflection()` delegates to the active sample's `ReflectionList`; `_samples` is a read-only property (prevents reassignment)
- **`lattice.py`** — `Lattice.__eq__` added (compares all six parameters)
- **`__init__.py`** — export `Sample` and `SampleDict`
- **`tests/test_sample.py`** — 37 tests: `Sample`, `SampleDict` guards (type, active-sample protection, pop/clear/del/reassign), add/remove, `add_reflection` routing, cross-sample isolation, U/UB independence
- **`docs/roadmap.md`** — section 2.5 checked

## Invariants enforced by SampleDict

- Only `Sample` instances accepted — `None`, integers, strings etc. all raise `TypeError`
- The active sample cannot be removed, replaced, popped, or cleared out
- `_samples` is a read-only property — `g._samples = {}` raises `AttributeError`

Contributed by: OpenCode (argo/claudesonnet46)