### PR TITLE
ENH Tolerance-aware __eq__ for Lattice and Reflection (#29)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,8 +148,20 @@ be implemented first.
 - [x] `AdHocDiffractometer.add_reflection()` delegates to the active sample's
       `ReflectionList`
 - [x] U and UB matrices live on `Sample`, not on the geometry
-- [x] `Lattice.__eq__` added (compares all six parameters)
+- [x] `Lattice.__eq__` added (compares all six parameters, exact — see 2.6)
 - [x] 37 new tests in `test_sample.py`
+
+### 2.6 Tolerance-aware `__eq__` for Lattice and Reflection ([#29](https://github.com/prjemian/ad_hoc_diffractometer/issues/29))
+
+- [x] Add `precision_atol(digits=None)` to `display.py`: returns
+      `0.5 * 10**(-digits)` — half a unit in the last displayed decimal place
+- [x] Add `allclose(a, b, atol=None, digits=None)` to `display.py`: wraps
+      `np.allclose` with `rtol=0` and the precision-derived tolerance
+- [x] `Lattice.__eq__`: pack six parameters into arrays → `np.allclose`
+- [x] `Reflection.__eq__`: hkl and angle values → `np.allclose`; name and
+      `geometry_name` → exact string comparison
+- [x] Export `precision_atol` and `allclose` from `__init__.py`
+- [x] Tests in `test_display.py`, `test_lattice.py`, `test_reflection.py`
 
 ---
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -9,8 +9,10 @@ from .axes import parse_axis
 from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
+from .display import allclose
 from .display import fmt
 from .display import get_precision
+from .display import precision_atol
 from .display import set_precision
 from .factories import KAPPA_ALPHA_DEFAULT
 from .factories import fivec
@@ -48,6 +50,8 @@ __all__ = [
     "get_precision",
     "set_precision",
     "fmt",
+    "precision_atol",
+    "allclose",
     # axes
     "parse_axis",
     "axis_label",

--- a/src/ad_hoc_diffractometer/display.py
+++ b/src/ad_hoc_diffractometer/display.py
@@ -1,5 +1,5 @@
 """
-display.py — display precision settings.
+display.py — display precision settings and numeric comparison helper.
 
 Provides a package-level default number of decimal places for displaying
 floating-point values.  Any class or function that formats numbers for
@@ -18,7 +18,16 @@ Or per-object where the class supports it (e.g. Lattice):
 
 Internal representation is always full floating-point precision.  Only
 display (str, repr-like summaries) is affected.
+
+``isclose(a, b)`` provides a tolerance-aware numeric comparison whose
+absolute tolerance is derived from the current display precision:
+``atol = 0.5 * 10 ** (-get_precision())``.  This means two values are
+considered equal when they agree to within half a unit in the last
+*displayed* decimal place — the same resolution the user sees.  An
+explicit tolerance can be supplied to override this default.
 """
+
+import numpy as np
 
 # ---------------------------------------------------------------------------
 # Package-level default
@@ -60,6 +69,70 @@ def set_precision(digits: int) -> None:
     if digits < 0:
         raise ValueError(f"Precision must be non-negative; got {digits}.")
     _DEFAULT_PRECISION = digits
+
+
+def precision_atol(digits: int | None = None) -> float:
+    """
+    Return an absolute tolerance matching the current display precision.
+
+    ``atol = 0.5 * 10 ** (-digits)`` — half a unit in the last displayed
+    decimal place, i.e. the smallest difference that would show up in the
+    formatted output.
+
+    Parameters
+    ----------
+    digits : int or None
+        Number of decimal places.  If None, uses ``get_precision()``.
+
+    Returns
+    -------
+    float
+    """
+    if digits is None:
+        digits = get_precision()
+    return 0.5 * 10 ** (-digits)
+
+
+def allclose(
+    a,
+    b,
+    atol: float | None = None,
+    digits: int | None = None,
+) -> bool:
+    """
+    Tolerance-aware comparison for scalars or array-like sequences.
+
+    Uses ``np.allclose`` with ``rtol=0`` and an absolute tolerance derived
+    from the display precision (or an explicit value).
+
+    Parameters
+    ----------
+    a, b : scalar or array-like
+        Values to compare.
+    atol : float or None
+        Explicit absolute tolerance.  If None, derived from ``digits``.
+    digits : int or None
+        Display precision to derive tolerance from.  If None, uses
+        ``get_precision()``.  Ignored when ``atol`` is given explicitly.
+
+    Returns
+    -------
+    bool
+
+    Examples
+    --------
+    >>> allclose(1.0000001, 1.0000002)          # within default 6-digit tol
+    True
+    >>> allclose(1.001, 1.002, digits=3)        # within 3-digit tol (0.0005)
+    True
+    >>> allclose(1.001, 1.002, digits=4)        # outside 4-digit tol (0.00005)
+    False
+    >>> allclose([1.0, 2.0], [1.0, 2.0])
+    True
+    """
+    if atol is None:
+        atol = precision_atol(digits)
+    return bool(np.allclose(a, b, atol=atol, rtol=0))
 
 
 def fmt(value: float, digits: int | None = None) -> str:

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -576,17 +576,29 @@ class Lattice:
             param_strs.append(f"{p}={fmt(val, self.precision)} {unit}")
         return f"Lattice({self._system}: {', '.join(param_strs)})"
 
-    def __eq__(self, other: object) -> bool:
-        """True if all six lattice parameters are identical."""
+    def __eq__(self, other: object, atol: float | None = None) -> bool:
+        """
+        True if all six lattice parameters agree within tolerance.
+
+        Parameters
+        ----------
+        other : object
+        atol : float or None
+            Absolute tolerance.  If None, derived from the current display
+            precision via ``display.precision_atol()``.
+
+        Returns
+        -------
+        bool
+        """
         if not isinstance(other, Lattice):
             return NotImplemented
-        return (
-            self._a == other._a
-            and self._b == other._b
-            and self._c == other._c
-            and self._alpha == other._alpha
-            and self._beta == other._beta
-            and self._gamma == other._gamma
+        from .display import allclose
+
+        return allclose(
+            [self._a, self._b, self._c, self._alpha, self._beta, self._gamma],
+            [other._a, other._b, other._c, other._alpha, other._beta, other._gamma],
+            atol=atol,
         )
 
     def __repr__(self) -> str:

--- a/src/ad_hoc_diffractometer/reflection.py
+++ b/src/ad_hoc_diffractometer/reflection.py
@@ -78,23 +78,55 @@ class Reflection:
                     f"Reflection wavelength must be > 0 Å; got {self.wavelength}."
                 )
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object, atol: float | None = None) -> bool:
         """
-        True if all fields match.
+        True if all fields match within tolerance.
+
+        String fields (``name``, ``geometry_name``) are compared exactly.
+        Numeric fields (``hkl``, ``angles`` values, ``wavelength``) are
+        compared with ``np.allclose`` at an absolute tolerance derived from
+        the current display precision (or an explicit ``atol``).
 
         Two reflections from different geometries are never equal even if
         hkl and angle values coincide, because the angle keys carry
         different physical meanings.
+
+        Parameters
+        ----------
+        other : object
+        atol : float or None
+            Absolute tolerance.  If None, derived from the current display
+            precision via ``display.precision_atol()``.
         """
         if not isinstance(other, Reflection):
             return NotImplemented
-        return (
-            self.name == other.name
-            and self.hkl == other.hkl
-            and self.angles == other.angles
-            and self.wavelength == other.wavelength
-            and self.geometry_name == other.geometry_name
-        )
+        if self.name != other.name:
+            return False
+        if self.geometry_name != other.geometry_name:
+            return False
+        if set(self.angles) != set(other.angles):
+            return False
+
+        from .display import allclose
+
+        if not allclose(self.hkl, other.hkl, atol=atol):
+            return False
+
+        # Compare angle values in a consistent key order
+        keys = sorted(self.angles)
+        if not allclose(
+            [self.angles[k] for k in keys],
+            [other.angles[k] for k in keys],
+            atol=atol,
+        ):
+            return False
+
+        # wavelength: both None, or both numeric and close
+        if self.wavelength is None and other.wavelength is None:
+            return True
+        if self.wavelength is None or other.wavelength is None:
+            return False
+        return allclose(self.wavelength, other.wavelength, atol=atol)
 
     def __repr__(self) -> str:
         wl = f"{self.wavelength} Å" if self.wavelength is not None else "not set"

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -15,8 +15,10 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import allclose
 from ad_hoc_diffractometer import fmt
 from ad_hoc_diffractometer import get_precision
+from ad_hoc_diffractometer import precision_atol
 from ad_hoc_diffractometer import set_precision
 
 _DEFAULT = 6  # matches conftest._DISPLAY_DEFAULT
@@ -97,3 +99,62 @@ def test_fmt_uses_package_default():
     """fmt() with no digits argument uses the current package-level precision."""
     set_precision(3)
     assert fmt(1.23456) == "1.235"
+
+
+# ---------------------------------------------------------------------------
+# precision_atol() and allclose()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "digits, expected_atol, context",
+    [
+        pytest.param(6, 5e-7, does_not_raise(), id="6-digits"),
+        pytest.param(4, 5e-5, does_not_raise(), id="4-digits"),
+        pytest.param(3, 5e-4, does_not_raise(), id="3-digits"),
+        pytest.param(0, 0.5, does_not_raise(), id="0-digits"),
+    ],
+)
+def test_precision_atol(digits, expected_atol, context):
+    with context:
+        assert precision_atol(digits) == pytest.approx(expected_atol)
+
+
+def test_precision_atol_uses_package_default():
+    set_precision(4)
+    assert precision_atol() == pytest.approx(5e-5)
+
+
+@pytest.mark.parametrize(
+    "a, b, digits, expected, context",
+    [
+        pytest.param(
+            1.0000001, 1.0000002, 6, True, does_not_raise(), id="within-6-digit-tol"
+        ),
+        pytest.param(1.001, 1.002, 2, True, does_not_raise(), id="within-2-digit-tol"),
+        pytest.param(
+            1.001, 1.002, 4, False, does_not_raise(), id="outside-4-digit-tol"
+        ),
+        pytest.param(
+            [1.0, 2.0], [1.0, 2.0], 6, True, does_not_raise(), id="equal-arrays"
+        ),
+        pytest.param(
+            [1.0, 2.0], [1.0, 2.1], 6, False, does_not_raise(), id="unequal-arrays"
+        ),
+        pytest.param(0.0, 0.0, 6, True, does_not_raise(), id="both-zero"),
+    ],
+)
+def test_allclose(a, b, digits, expected, context):
+    with context:
+        assert allclose(a, b, digits=digits) == expected
+
+
+def test_allclose_explicit_atol():
+    assert allclose(1.0, 1.05, atol=0.1) is True
+    assert allclose(1.0, 1.15, atol=0.1) is False
+
+
+def test_allclose_uses_package_default():
+    set_precision(3)  # atol = 5e-4
+    assert allclose(1.0000, 1.0004) is True  # within 5e-4
+    assert allclose(1.0000, 1.0010) is False  # outside 5e-4

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -840,3 +840,38 @@ def test_instance_precision_overrides_package():
         assert "a=5.000000" not in str(lat)
     finally:
         ahd.set_precision(original)
+
+
+# ---------------------------------------------------------------------------
+# Lattice.__eq__ with tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_lattice_eq_identical():
+    assert Lattice(a=5.431) == Lattice(a=5.431)
+
+
+def test_lattice_eq_within_default_tolerance():
+    """Values differing by less than half a unit in the 6th decimal place."""
+    a = 5.4310000
+    b = 5.4310003  # differs by 3e-7, within atol=5e-7
+    assert Lattice(a=a) == Lattice(a=b)
+
+
+def test_lattice_eq_outside_default_tolerance():
+    a = 5.4310000
+    b = 5.4320000  # differs by 1e-3, outside atol=5e-7
+    assert Lattice(a=a) != Lattice(a=b)
+
+
+def test_lattice_eq_explicit_atol():
+    assert Lattice(a=5.431).__eq__(Lattice(a=5.432), atol=0.01) is True
+    assert Lattice(a=5.431).__eq__(Lattice(a=5.451), atol=0.01) is False
+
+
+def test_lattice_eq_not_implemented_for_non_lattice():
+    assert Lattice(a=5.431).__eq__("not a lattice") is NotImplemented
+
+
+def test_lattice_eq_different_parameters():
+    assert Lattice(a=5.431) != Lattice(a=5.431, c=10.0)  # tetragonal vs cubic

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -180,6 +180,57 @@ def test_reflection_eq_not_implemented_for_non_reflection():
     assert r != "not a reflection"
 
 
+def test_reflection_eq_within_default_tolerance():
+    """hkl values differing by less than default atol compare equal."""
+    r1 = Reflection(
+        name="r1", hkl=(1.0, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    r2 = Reflection(
+        name="r1", hkl=(1.0000003, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    assert r1 == r2  # within default atol=5e-7
+
+
+def test_reflection_eq_outside_default_tolerance():
+    r1 = Reflection(
+        name="r1", hkl=(1.0, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    r2 = Reflection(
+        name="r1", hkl=(1.001, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    assert r1 != r2
+
+
+def test_reflection_eq_explicit_atol():
+    r1 = Reflection(
+        name="r1", hkl=(1.0, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    r2 = Reflection(
+        name="r1", hkl=(1.005, 0.0, 0.0), angles={"mu": 20.0}, geometry_name="psic"
+    )
+    assert r1.__eq__(r2, atol=0.01) is True
+    assert r1.__eq__(r2, atol=0.001) is False
+
+
+def test_reflection_eq_angles_tolerance():
+    """Angle values also compared with tolerance."""
+    r1 = Reflection(name="r1", hkl=(1, 0, 0), angles={"mu": 20.0}, geometry_name="psic")
+    r2 = Reflection(
+        name="r1", hkl=(1, 0, 0), angles={"mu": 20.0000003}, geometry_name="psic"
+    )
+    assert r1 == r2  # within default atol
+
+
+def test_reflection_eq_wavelength_tolerance():
+    r1 = Reflection(
+        name="r1", hkl=(1, 0, 0), angles={}, wavelength=1.5406000, geometry_name="psic"
+    )
+    r2 = Reflection(
+        name="r1", hkl=(1, 0, 0), angles={}, wavelength=1.5406003, geometry_name="psic"
+    )
+    assert r1 == r2  # within default atol
+
+
 # ---------------------------------------------------------------------------
 # ReflectionList construction
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- closes #29

Replaces exact `==` comparison in `Lattice.__eq__` and `Reflection.__eq__` with tolerance-aware `np.allclose`, where the absolute tolerance is derived from the current display precision.

## Changes

- **`display.py`** — `precision_atol(digits=None)` returns `0.5 * 10**(-digits)` (half a unit in the last displayed place); `allclose(a, b, atol=None, digits=None)` wraps `np.allclose(rtol=0)` with that tolerance
- **`lattice.py`** — `Lattice.__eq__` packs all six parameters into arrays and calls `allclose`; accepts optional `atol`
- **`reflection.py`** — `Reflection.__eq__` uses `allclose` for hkl, sorted angle values, and wavelength; `name` and `geometry_name` remain exact string comparisons; accepts optional `atol`
- **`__init__.py`** — export `precision_atol` and `allclose`
- **Tests** — 24 new tests across `test_display`, `test_lattice`, `test_reflection` covering within/outside tolerance, explicit `atol`, and array comparisons

## Notes

- Neither `Lattice` nor `Reflection` carries a per-instance tolerance — tolerance is always either supplied explicitly or derived once from `get_precision()` at call time, so both sides of any comparison use the same value
- `rtol=0` throughout — only absolute tolerance is used, avoiding scale-dependent behaviour for crystallographic parameters

Contributed by: OpenCode (argo/claudesonnet46)