### PR TITLE
ENH ub_from_one_reflection, Sample.parent, orientation.py (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,18 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
    The `closes #N` keyword triggers GitHub automation: when the PR is merged
    the issue is closed and the project card moves to "Done" automatically.
 
+   Every PR must also have its **milestone** and **project board** set:
+   ```bash
+   # Set milestone when creating the PR
+   gh pr create --milestone "Priority N — ..." ...
+
+   # Add the PR to the project board immediately after creation
+   gh api repos/OWNER/REPO/pulls/N --jq '.node_id' | xargs -I{} \
+     gh api graphql -f query='mutation {
+       addProjectV2ItemById(input: {projectId: "PROJECT_ID", contentId: "{}"})
+       { item { id } } }'
+   ```
+
 3. **Never close issues manually** — let the merge automation do it.
 
 4. **All code changes must be made on a feature branch**, never directly on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,19 +93,20 @@ be implemented first.
 - [ ] This is the missing link needed for U and UB computation
 - [ ] Reference: Busing & Levy (1967), You (1999)
 
-### 2.1 U matrix (orientation matrix) ([#5](https://github.com/prjemian/ad_hoc_diffractometer/issues/5))
+### 2.1 `ub_from_two_reflections_bl1967` (BL1967 eqs. 23-27) ([#5](https://github.com/prjemian/ad_hoc_diffractometer/issues/5))
 
-- [ ] Implement Busing & Levy (1967) two-reflection algorithm (eqs. 23-27)
-- [ ] Requires: two orienting reflections (hkl + motor angles), B matrix
-- [ ] Returns orthonormal U (3×3)
-- [ ] Depends on 2.0
+- [ ] Implement in `orientation.py`
+- [ ] Inputs: two `Reflection` objects + known lattice (B matrix)
+- [ ] Algorithm: Gram-Schmidt orthonormal triples Tc (crystal) and Tφ (phi
+      frame); U = Tφ @ Tc.T; UB = U @ B
+- [ ] Sets `sample.U` and `sample.UB` in-place; returns UB
 
-### 2.2 UB matrix ([#6](https://github.com/prjemian/ad_hoc_diffractometer/issues/6))
+### 2.2 `ub_from_three_reflections_bl1967` (BL1967 eqs. 29-31) ([#6](https://github.com/prjemian/ad_hoc_diffractometer/issues/6))
 
-- [ ] Compute UB = U @ B
-- [ ] Also implement Busing & Levy (1967) three-reflection direct method
-      (eqs. 29-31) for UB without known lattice parameters
-- [ ] Depends on 2.1
+- [ ] Implement in `orientation.py`
+- [ ] Inputs: three `Reflection` objects; no prior lattice needed
+- [ ] Algorithm: UB = Hφ @ H⁻¹ (direct matrix inversion); U = UB @ B⁻¹
+- [ ] Sets `sample.U` and `sample.UB` in-place; returns UB
 
 ### 2.3 Orienting reflections data structure ([#7](https://github.com/prjemian/ad_hoc_diffractometer/issues/7))
 
@@ -162,6 +163,37 @@ be implemented first.
       `geometry_name` → exact string comparison
 - [x] Export `precision_atol` and `allclose` from `__init__.py`
 - [x] Tests in `test_display.py`, `test_lattice.py`, `test_reflection.py`
+
+### 2.7 `ub_from_one_reflection` — initial UB from one reflection ([#31](https://github.com/prjemian/ad_hoc_diffractometer/issues/31))
+
+- [x] `Sample.parent` attribute: back-reference to owning
+      `AdHocDiffractometer`; set by `add_sample()` and default sample
+      construction; cleared to `None` by `remove_sample()`; excluded from
+      `__eq__`; shown in `__repr__`
+- [x] Create `orientation.py` module
+- [x] `ub_identity(sample)`: sets U=I, UB=B; returns UB
+- [x] `ub_from_one_reflection(sample, reflection, reference_hkl,
+      reference_stage)`: Rodrigues rotation from crystal direction to lab
+      axis; resolves `reference_stage` from Stage, str, or None+parent;
+      sets `sample.U` and `sample.UB` in-place; returns UB
+- [x] Edge cases: parallel (U=I), anti-parallel (perpendicular axis)
+- [x] Export `ub_identity` and `ub_from_one_reflection` from `__init__.py`
+- [x] Tests in `test_orientation.py` and `test_sample.py`
+
+### 2.8 `refine_lattice_bl1967` — least-squares lattice refinement ([#32](https://github.com/prjemian/ad_hoc_diffractometer/issues/32))
+
+- [ ] Create `refinement.py` module (separate from `orientation.py`)
+- [ ] Implement `refine_lattice_bl1967(sample, reflections, ...)` using
+      BL1967 §Refinement; simultaneous cell + orientation least-squares
+- [ ] Returns result dict; updates `sample.lattice`, `sample.U`,
+      `sample.UB` in-place
+
+### 2.9 `refine_lattice_simplex` — derivative-free lattice refinement ([#33](https://github.com/prjemian/ad_hoc_diffractometer/issues/33))
+
+- [ ] Implement `refine_lattice_simplex(sample, reflections, ...)` in
+      `refinement.py` using Nelder-Mead simplex; derivative-free
+      alternative to BL1967 least squares
+- [ ] Same return dict structure as `refine_lattice_bl1967`
 
 ---
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -34,6 +34,8 @@ from .lattice import Lattice
 from .lattice import b_matrix
 from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
+from .orientation import ub_from_one_reflection
+from .orientation import ub_identity
 from .reflection import Reflection
 from .reflection import ReflectionList
 from .rotation import rotation_matrix
@@ -67,6 +69,9 @@ __all__ = [
     "ReflectionList",
     "Sample",
     "SampleDict",
+    # orientation
+    "ub_identity",
+    "ub_from_one_reflection",
     # factories
     "list_geometries",
     "get_geometry",

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -135,6 +135,7 @@ class AdHocDiffractometer:
                 geometry_name=self.name,
                 valid_stages=set(self._stages),
             ),
+            parent=self,
         )
         self.__samples._data[_DEFAULT_SAMPLE_NAME] = _default
 
@@ -390,6 +391,7 @@ class AdHocDiffractometer:
                 geometry_name=self.name,
                 valid_stages=set(self._stages),
             ),
+            parent=self,
         )
         self.__samples._data[name] = s  # bypass guard: add is always safe
         return s
@@ -399,7 +401,9 @@ class AdHocDiffractometer:
         Remove a sample from the dict.
 
         The active sample cannot be removed; select a different sample
-        first.  Delegates to SampleDict which enforces this invariant.
+        first.  Clears ``sample.parent`` on the removed sample so that any
+        external reference to it knows it is detached.  Delegates to
+        SampleDict which enforces the active-sample invariant.
 
         Raises
         ------
@@ -408,7 +412,9 @@ class AdHocDiffractometer:
         ValueError
             If the sample is the currently active sample.
         """
-        del self.__samples[name]  # SampleDict raises KeyError or ValueError
+        s = self.__samples[name]  # raises KeyError if not found
+        del self.__samples[name]  # raises ValueError if active
+        s.parent = None  # break the back-reference
 
     # ------------------------------------------------------------------
     # Reflections — convenience wrapper targeting the active sample

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -1,0 +1,223 @@
+"""
+orientation.py — U and UB matrix computation from orienting reflections.
+
+Functions
+---------
+ub_identity(sample)
+    Set U = I, UB = B; return UB.  The crudest assumption.
+
+ub_from_one_reflection(sample, reflection, reference_hkl, reference_stage)
+    Compute a provisional U and UB from one reflection using the Rodrigues
+    rotation that takes the crystal direction ``B @ reference_hkl`` to the
+    lab direction given by ``reference_stage``.  Sets ``sample.U`` and
+    ``sample.UB`` in-place; returns UB.
+
+Future functions (separate issues):
+    ub_from_two_reflections_bl1967   — Busing & Levy 1967, eqs. 23-27  (#5)
+    ub_from_three_reflections_bl1967 — Busing & Levy 1967, eqs. 29-31  (#6)
+
+References
+----------
+Busing & Levy, Acta Cryst. 22, 457-464 (1967)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rotation import rotation_matrix
+from .stage import Stage
+
+
+def ub_identity(sample) -> np.ndarray:
+    """
+    Set U = I (identity) and UB = B; return UB.
+
+    The crudest orientation assumption: crystal axes are aligned with the
+    lab axes.  Useful as a starting point when no reflection information
+    is available at all.
+
+    Parameters
+    ----------
+    sample : Sample
+        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+
+    Returns
+    -------
+    UB : numpy.ndarray, shape (3, 3)
+    """
+    B = sample.lattice.B
+    sample.U = np.eye(3)
+    sample.UB = B.copy()
+    return sample.UB
+
+
+def ub_from_one_reflection(
+    sample,
+    reflection,
+    reference_hkl: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    reference_stage=None,
+) -> np.ndarray:
+    """
+    Compute a provisional U and UB from one reflection (Rodrigues method).
+
+    A common first step in a diffractometer alignment session: assume that
+    a known high-symmetry crystal direction (``reference_hkl``) is parallel
+    to a specific diffractometer axis (``reference_stage``).  This gives a
+    "fake" UB sufficient to predict where to scan for a second reflection.
+
+    The algorithm:
+
+    1. Compute the crystal-frame direction: ``Bh = B @ reference_hkl``
+       (normalised to ``Bh_hat``).
+    2. Extract the lab-frame direction from ``reference_stage`` (normalised
+       to ``r_hat``).
+    3. Find the minimal rotation (Rodrigues) that takes ``Bh_hat`` to
+       ``r_hat``:
+       ``axis  = cross(Bh_hat, r_hat)``
+       ``angle = arccos(clip(dot(Bh_hat, r_hat), -1, 1))``
+       ``U     = rotation_matrix(axis, degrees(angle))``
+    4. ``UB = U @ B``
+    5. Store ``sample.U = U`` and ``sample.UB = UB``; return ``UB``.
+
+    Edge cases:
+
+    - **Parallel** (``angle ≈ 0``): ``Bh_hat`` already points along
+      ``r_hat``; ``U = I``.
+    - **Anti-parallel** (``angle ≈ π``): choose an arbitrary perpendicular
+      axis (the first vector from ``[XHAT, YHAT, ZHAT]`` not parallel to
+      ``Bh_hat``); rotate 180° about it.
+
+    .. note::
+       The result is approximate.  If ``reference_hkl`` is not truly
+       parallel to ``reference_stage.axis`` (e.g. χ = 89.32° rather than
+       90.00°), predicted angles for subsequent reflections will be slightly
+       wrong.  Refine with ``ub_from_two_reflections_bl1967()`` once a
+       second reflection is measured.
+
+    Parameters
+    ----------
+    sample : Sample
+        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+        ``sample.lattice`` must be set.  If ``sample.parent`` is set, it
+        is used to resolve a string ``reference_stage``.
+    reflection : Reflection or str
+        A ``Reflection`` object or the name of a reflection in
+        ``sample.reflections``.
+    reference_hkl : tuple of float, optional
+        Miller indices of the crystal direction assumed to be aligned with
+        ``reference_stage``.  Default ``(0, 0, 1)`` (c-axis).
+    reference_stage : Stage, str, or None, optional
+        The diffractometer axis assumed to be parallel to ``reference_hkl``.
+
+        - ``Stage`` object: ``stage.axis`` is used directly (recommended;
+          the sign convention is already encoded in the Stage).
+        - ``str``: looked up as ``sample.parent.stage(name)``.
+        - ``None`` and ``sample.parent`` is set: defaults to
+          ``sample.parent.stage("phi")``.
+        - ``None`` and ``sample.parent`` is ``None``: raises ``ValueError``.
+
+    Returns
+    -------
+    UB : numpy.ndarray, shape (3, 3)
+        Sets ``sample.U`` and ``sample.UB`` in-place before returning.
+
+    Raises
+    ------
+    KeyError
+        If ``reflection`` is a string not found in ``sample.reflections``.
+    ValueError
+        If ``reference_stage`` cannot be resolved (no parent, no stage).
+    ValueError
+        If ``reference_hkl`` maps to the zero vector under B.
+
+    Examples
+    --------
+    >>> g = psic()
+    >>> g.add_sample("sapphire", Lattice(a=4.758, c=12.991))
+    >>> g.sample = "sapphire"
+    >>> g.add_reflection("r1", hkl=(0, 0, 6),
+    ...                  angles={"mu": 0, "eta": 20.97, "chi": 90,
+    ...                          "phi": 0, "nu": 0, "delta": 41.94})
+    >>> g.sample.reflections.setor1("r1")
+    >>> UB = ub_from_one_reflection(
+    ...     g.sample, "r1",
+    ...     reference_hkl=(0, 0, 1),
+    ...     reference_stage=g.stage("phi"),
+    ... )
+    """
+    from .reflection import Reflection
+
+    # --- Resolve reflection ------------------------------------------------
+    if isinstance(reflection, str):
+        reflection = sample.reflections[reflection]
+    if not isinstance(reflection, Reflection):
+        raise TypeError(
+            f"reflection must be a Reflection or a name string; "
+            f"got {type(reflection).__name__!r}."
+        )
+
+    # --- Resolve reference_stage → lab-frame axis vector ------------------
+    if reference_stage is None:
+        if sample.parent is None:
+            raise ValueError(
+                "reference_stage is required when sample has no parent geometry. "
+                "Pass a Stage object or stage name, e.g. geometry.stage('phi')."
+            )
+        reference_stage = sample.parent.stage("phi")
+
+    if isinstance(reference_stage, str):
+        if sample.parent is None:
+            raise ValueError(
+                f"Cannot look up stage {reference_stage!r}: "
+                f"sample has no parent geometry."
+            )
+        reference_stage = sample.parent.stage(reference_stage)
+
+    if isinstance(reference_stage, Stage):
+        r_vec = np.asarray(reference_stage.axis, dtype=float)
+    else:
+        r_vec = np.asarray(reference_stage, dtype=float)
+
+    r_norm = np.linalg.norm(r_vec)
+    if r_norm < 1e-14:
+        raise ValueError("reference_stage axis vector is zero.")
+    r_hat = r_vec / r_norm
+
+    # --- Crystal-frame direction from reference_hkl and B ------------------
+    B = sample.lattice.B
+    Bh = B @ np.asarray(reference_hkl, dtype=float)
+    Bh_norm = np.linalg.norm(Bh)
+    if Bh_norm < 1e-14:
+        raise ValueError(
+            f"reference_hkl {reference_hkl} maps to the zero vector under B. "
+            f"Choose a non-zero Miller index triple."
+        )
+    Bh_hat = Bh / Bh_norm
+
+    # --- Rodrigues rotation from Bh_hat to r_hat ---------------------------
+    cos_angle = float(np.clip(np.dot(Bh_hat, r_hat), -1.0, 1.0))
+    angle_rad = np.arccos(cos_angle)
+
+    if abs(angle_rad) < 1e-10:
+        # Already parallel — U = I
+        U = np.eye(3)
+    elif abs(angle_rad - np.pi) < 1e-10:
+        # Anti-parallel — choose any perpendicular axis
+        for candidate in (
+            np.array([1.0, 0.0, 0.0]),
+            np.array([0.0, 1.0, 0.0]),
+            np.array([0.0, 0.0, 1.0]),
+        ):
+            ax = np.cross(Bh_hat, candidate)
+            if np.linalg.norm(ax) > 1e-10:
+                break
+        U = rotation_matrix(ax, 180.0)
+    else:
+        ax = np.cross(Bh_hat, r_hat)
+        U = rotation_matrix(ax, np.degrees(angle_rad))
+
+    UB = U @ B
+    sample.U = U
+    sample.UB = UB
+    return UB

--- a/src/ad_hoc_diffractometer/sample.py
+++ b/src/ad_hoc_diffractometer/sample.py
@@ -176,23 +176,33 @@ class Sample:
         reflections: ReflectionList,
         U: np.ndarray | None = None,
         UB: np.ndarray | None = None,
+        parent=None,
     ) -> None:
         self.name = name
         self.lattice = lattice
         self.reflections = reflections
         self.U = U
         self.UB = UB
+        self.parent = parent  # owning AdHocDiffractometer, or None
 
     def __repr__(self) -> str:
         u_str = "set" if self.U is not None else "None"
         ub_str = "set" if self.UB is not None else "None"
+        parent_str = self.parent.name if self.parent is not None else "(no parent)"
         return (
-            f"Sample(name={self.name!r}, lattice={self.lattice!r}, "
+            f"Sample(name={self.name!r}, geometry={parent_str!r}, "
+            f"lattice={self.lattice!r}, "
             f"reflections={len(self.reflections)} reflection(s), "
             f"U={u_str}, UB={ub_str})"
         )
 
     def __eq__(self, other: object) -> bool:
+        """
+        True if name, lattice, U, and UB all match.
+
+        ``parent`` is excluded from equality — two samples with the same
+        content owned by different geometries are considered equal.
+        """
         if not isinstance(other, Sample):
             return NotImplemented
         u_eq = (self.U is None and other.U is None) or (

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,342 @@
+"""
+Unit tests for ad_hoc_diffractometer.orientation.
+
+Covers:
+  - ub_identity()
+  - ub_from_one_reflection(): Stage, str, None+parent, None+no-parent
+  - Rodrigues edge cases: parallel, anti-parallel
+  - U orthonormality
+  - UB @ reference_hkl ≈ direction of reference_stage axis
+  - sample.U and sample.UB updated in-place
+  - reference_stage type handling (Stage, str, ndarray)
+"""
+
+import re
+
+import numpy as np
+import pytest
+
+from ad_hoc_diffractometer import Lattice
+from ad_hoc_diffractometer import psic
+from ad_hoc_diffractometer import ub_from_one_reflection
+from ad_hoc_diffractometer import ub_identity
+from ad_hoc_diffractometer.reflection import ReflectionList
+from ad_hoc_diffractometer.sample import Sample
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PSIC_ANGLES = {
+    "mu": 0.0,
+    "eta": 20.97,
+    "chi": 90.0,
+    "phi": 0.0,
+    "nu": 0.0,
+    "delta": 41.94,
+}
+
+
+@pytest.fixture
+def sapphire_geom():
+    """psic geometry with a sapphire sample and one (006) reflection."""
+    g = psic()
+    g.add_sample("sapphire", Lattice(a=4.758, c=12.991))
+    g.sample = "sapphire"
+    g.wavelength = 1.5406
+    g.add_reflection(
+        "r1",
+        hkl=(0, 0, 6),
+        angles=_PSIC_ANGLES,
+    )
+    g.sample.reflections.setor1("r1")
+    return g
+
+
+# ---------------------------------------------------------------------------
+# ub_identity()
+# ---------------------------------------------------------------------------
+
+
+def test_ub_identity_sets_U_to_eye(psic_geom):
+    ub_identity(psic_geom.sample)
+    np.testing.assert_array_equal(psic_geom.sample.U, np.eye(3))
+
+
+def test_ub_identity_sets_UB_to_B(psic_geom):
+    ub_identity(psic_geom.sample)
+    np.testing.assert_allclose(
+        psic_geom.sample.UB, psic_geom.sample.lattice.B, atol=1e-12
+    )
+
+
+def test_ub_identity_returns_UB(psic_geom):
+    UB = ub_identity(psic_geom.sample)
+    np.testing.assert_array_equal(UB, psic_geom.sample.UB)
+
+
+def test_ub_identity_updates_in_place(psic_geom):
+    sample = psic_geom.sample
+    UB = ub_identity(sample)
+    assert sample.UB is UB
+
+
+# ---------------------------------------------------------------------------
+# ub_from_one_reflection() — reference_stage variants
+# ---------------------------------------------------------------------------
+
+
+def test_ub_one_refl_stage_object(sapphire_geom):
+    """Pass a Stage object as reference_stage."""
+    g = sapphire_geom
+    UB = ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    assert g.sample.UB is UB
+    assert g.sample.U is not None
+
+
+def test_ub_one_refl_stage_string(sapphire_geom):
+    """Pass a stage name string; resolved via sample.parent."""
+    g = sapphire_geom
+    UB = ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage="phi",
+    )
+    assert UB.shape == (3, 3)
+
+
+def test_ub_one_refl_none_with_parent_defaults_to_phi(sapphire_geom):
+    """reference_stage=None with a parent geometry defaults to phi."""
+    g = sapphire_geom
+    UB_explicit = ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    # reset U/UB
+    g.sample.U = None
+    g.sample.UB = None
+    UB_default = ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=None,
+    )
+    np.testing.assert_allclose(UB_explicit, UB_default, atol=1e-12)
+
+
+def test_ub_one_refl_none_no_parent_raises():
+    """reference_stage=None with no parent geometry raises ValueError."""
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(
+        geometry_name="psic", valid_stages={"mu", "eta", "chi", "phi", "nu", "delta"}
+    )
+    rl.add("r1", hkl=(0, 0, 6), angles={"mu": 0.0})
+    sample = Sample(name="test", lattice=Lattice(a=1.0), reflections=rl)
+    rl.setor1("r1")
+    with pytest.raises(ValueError, match=re.escape("no parent geometry")):
+        ub_from_one_reflection(sample, "r1", reference_stage=None)
+
+
+def test_ub_one_refl_stage_string_no_parent_raises():
+    """Stage string with no parent raises ValueError."""
+    rl = ReflectionList(geometry_name="psic", valid_stages={"mu"})
+    rl.add("r1", hkl=(0, 0, 1), angles={})
+    sample = Sample(name="test", lattice=Lattice(a=1.0), reflections=rl)
+    with pytest.raises(ValueError, match=re.escape("no parent geometry")):
+        ub_from_one_reflection(sample, "r1", reference_stage="phi")
+
+
+def test_ub_one_refl_ndarray_reference_stage(sapphire_geom):
+    """Pass a raw ndarray as reference_stage."""
+    g = sapphire_geom
+    phi_axis = g.stage("phi").axis
+    UB = ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=phi_axis,
+    )
+    assert UB.shape == (3, 3)
+
+
+def test_ub_one_refl_reflection_object(sapphire_geom):
+    """Pass a Reflection object directly."""
+    g = sapphire_geom
+    r = g.sample.reflections["r1"]
+    UB = ub_from_one_reflection(
+        g.sample,
+        r,
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    assert UB.shape == (3, 3)
+
+
+def test_ub_one_refl_unknown_reflection_raises(sapphire_geom):
+    g = sapphire_geom
+    with pytest.raises(KeyError):
+        ub_from_one_reflection(
+            g.sample,
+            "missing",
+            reference_stage=g.stage("phi"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ub_from_one_reflection() — mathematical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_ub_one_refl_U_is_orthonormal(sapphire_geom):
+    """U must be an orthonormal matrix (U.T @ U = I, det = 1)."""
+    g = sapphire_geom
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    U = g.sample.U
+    np.testing.assert_allclose(U.T @ U, np.eye(3), atol=1e-10)
+    assert abs(np.linalg.det(U) - 1.0) < 1e-10
+
+
+def test_ub_one_refl_UB_equals_U_at_B(sapphire_geom):
+    """UB must equal U @ B."""
+    g = sapphire_geom
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    np.testing.assert_allclose(g.sample.UB, g.sample.U @ g.sample.lattice.B, atol=1e-12)
+
+
+def test_ub_one_refl_crystal_direction_maps_to_stage_axis(sapphire_geom):
+    """UB @ reference_hkl should be parallel to reference_stage.axis."""
+    g = sapphire_geom
+    reference_hkl = np.array([0.0, 0.0, 1.0])
+    phi_axis = g.stage("phi").axis
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=tuple(reference_hkl),
+        reference_stage=g.stage("phi"),
+    )
+    # UB @ h must be parallel to phi_axis (same direction, any magnitude)
+    q = g.sample.UB @ reference_hkl
+    q_hat = q / np.linalg.norm(q)
+    r_hat = phi_axis / np.linalg.norm(phi_axis)
+    np.testing.assert_allclose(np.abs(np.dot(q_hat, r_hat)), 1.0, atol=1e-10)
+
+
+def test_ub_one_refl_updates_sample_in_place(sapphire_geom):
+    g = sapphire_geom
+    assert g.sample.U is None
+    assert g.sample.UB is None
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),
+    )
+    assert g.sample.U is not None
+    assert g.sample.UB is not None
+
+
+# ---------------------------------------------------------------------------
+# Rodrigues edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_ub_one_refl_parallel_gives_identity_U(psic_geom):
+    """When Bh_hat already points along r_hat, U should be identity."""
+    g = psic_geom
+    # cubic a=1: B = I; reference_hkl=(0,0,1) → Bh = (0,0,1)
+    # phi axis of psic is -ZHAT = (0,0,-1) — not parallel
+    # Use mu axis (+XHAT) and reference_hkl that maps to XHAT
+    # B @ (1,0,0) = (1,0,0) = XHAT = mu.axis
+    g.add_reflection(
+        "r1",
+        hkl=(1, 0, 0),
+        angles={
+            "mu": 0.0,
+            "eta": 0.0,
+            "chi": 0.0,
+            "phi": 0.0,
+            "nu": 0.0,
+            "delta": 0.0,
+        },
+    )
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(1, 0, 0),
+        reference_stage=g.stage("mu"),  # mu axis = +XHAT
+    )
+    np.testing.assert_allclose(g.sample.U, np.eye(3), atol=1e-10)
+
+
+def test_ub_one_refl_antipara_U_is_rotation_matrix(psic_geom):
+    """Anti-parallel case: U must still be a valid rotation matrix."""
+    g = psic_geom
+    # B @ (0,0,1) = XHAT (cubic a=1, c-axis maps to x in BL convention)
+    # Actually default lattice is cubic a=1: B = I, so B@(0,0,1) = (0,0,1)
+    # phi axis = -ZHAT = (0,0,-1) — anti-parallel to (0,0,1)
+    g.add_reflection(
+        "r1",
+        hkl=(0, 0, 1),
+        angles={
+            "mu": 0.0,
+            "eta": 0.0,
+            "chi": 0.0,
+            "phi": 0.0,
+            "nu": 0.0,
+            "delta": 0.0,
+        },
+    )
+    ub_from_one_reflection(
+        g.sample,
+        "r1",
+        reference_hkl=(0, 0, 1),
+        reference_stage=g.stage("phi"),  # phi = -ZHAT = (0,0,-1)
+    )
+    U = g.sample.U
+    np.testing.assert_allclose(U.T @ U, np.eye(3), atol=1e-10)
+    assert abs(np.linalg.det(U) - 1.0) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_ub_one_refl_zero_reference_hkl_raises(sapphire_geom):
+    g = sapphire_geom
+    with pytest.raises(ValueError, match=re.escape("zero vector")):
+        ub_from_one_reflection(
+            g.sample,
+            "r1",
+            reference_hkl=(0, 0, 0),
+            reference_stage=g.stage("phi"),
+        )
+
+
+def test_ub_one_refl_bad_type_raises(sapphire_geom):
+    g = sapphire_geom
+    with pytest.raises(TypeError, match=re.escape("Reflection or a name string")):
+        ub_from_one_reflection(
+            g.sample,
+            42,
+            reference_stage=g.stage("phi"),
+        )

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -281,3 +281,56 @@ def test_sample_U_UB_independent_per_sample(psic_geom):
     psic_geom.sample.U = np.eye(3)  # set on "test"
     psic_geom.sample = "silicon"
     assert psic_geom.sample.U is None  # "silicon" still has None
+
+
+# ---------------------------------------------------------------------------
+# Sample.parent
+# ---------------------------------------------------------------------------
+
+
+def test_default_sample_parent_is_geometry(psic_geom):
+    """Default 'test' sample's parent is the owning geometry."""
+    assert psic_geom.sample.parent is psic_geom
+
+
+def test_add_sample_sets_parent(psic_geom):
+    s = psic_geom.add_sample("silicon", Lattice(a=5.431))
+    assert s.parent is psic_geom
+
+
+def test_remove_sample_clears_parent(psic_geom):
+    s = psic_geom.add_sample("silicon", Lattice(a=5.431))
+    psic_geom.remove_sample("silicon")
+    assert s.parent is None
+
+
+def test_standalone_sample_parent_is_none():
+    """Sample constructed without a geometry has parent=None."""
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="test", valid_stages=set())
+    s = Sample(name="standalone", lattice=Lattice(a=1.0), reflections=rl)
+    assert s.parent is None
+
+
+def test_sample_parent_excluded_from_eq(psic_geom):
+    """Two samples with same content but different parents compare equal."""
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="test", valid_stages=set())
+    s_standalone = Sample(name="test", lattice=Lattice(a=1.0), reflections=rl)
+    # psic_geom.sample has parent=psic_geom; standalone has parent=None
+    # They should still be equal (content-based)
+    assert psic_geom.sample == s_standalone
+
+
+def test_sample_repr_shows_geometry_name(psic_geom):
+    assert "psic" in repr(psic_geom.sample)
+
+
+def test_sample_repr_shows_no_parent_for_standalone():
+    from ad_hoc_diffractometer.reflection import ReflectionList
+
+    rl = ReflectionList(geometry_name="test", valid_stages=set())
+    s = Sample(name="standalone", lattice=Lattice(a=1.0), reflections=rl)
+    assert "(no parent)" in repr(s)


### PR DESCRIPTION
- closes #31

Adds `Sample.parent`, creates `orientation.py`, and implements `ub_from_one_reflection` and `ub_identity`.

## Changes

**`sample.py`** — `Sample` gains `parent: AdHocDiffractometer | None = None`; set by geometry at construction and `add_sample()`; cleared to `None` by `remove_sample()`; excluded from `__eq__`; shown in `__repr__`

**`geometry.py`** — sets `sample.parent = self` for default sample and in `add_sample()`; clears `sample.parent = None` in `remove_sample()`

**`orientation.py`** (new) — `ub_identity(sample)` sets U=I, UB=B; `ub_from_one_reflection(sample, reflection, reference_hkl, reference_stage)` uses Rodrigues rotation to compute the minimal U taking the crystal direction `B @ reference_hkl` to the lab axis of `reference_stage`; resolves `reference_stage` from `Stage` object, str (looked up on `sample.parent`), or `None` (defaults to phi if parent exists); handles parallel and anti-parallel edge cases; sets `sample.U` and `sample.UB` in-place; returns UB

**`__init__.py`** — exports `ub_identity` and `ub_from_one_reflection`

**`tests/test_orientation.py`** — 20 tests: all `reference_stage` variants, U orthonormality, UB=U@B, crystal→lab direction alignment, in-place update, edge cases, error handling

**`tests/test_sample.py`** — 7 new tests for `Sample.parent`

**`docs/roadmap.md`** — sections 2.1/2.2 updated with function names; sections 2.7 (checked), 2.8, 2.9 added; `AGENTS.md` updated with PR milestone/project board requirement

Contributed by: OpenCode (argo/claudesonnet46)