### PR TITLE
2.0 Motor-angle-to-phi-frame conversion

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,11 +87,11 @@ be implemented first.
 
 ### 2.0 Motor-angle-to-phi-frame conversion ([#4](https://github.com/prjemian/ad_hoc_diffractometer/issues/4))
 
-- [ ] Function `angles_to_phi_vector(geometry, hkl_or_q, **motor_angles)`
+- [x] Function `angles_to_phi_vector(geometry, **motor_angles)`
       that computes the scattering vector in the phi-axis frame from a set
       of motor angles
-- [ ] This is the missing link needed for U and UB computation
-- [ ] Reference: Busing & Levy (1967), You (1999)
+- [x] This is the missing link needed for U and UB computation
+- [x] Reference: Busing & Levy (1967), You (1999)
 
 ### 2.1 `ub_from_two_reflections_bl1967` (BL1967 eqs. 23-27) ([#5](https://github.com/prjemian/ad_hoc_diffractometer/issues/5))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -34,6 +34,7 @@ from .lattice import Lattice
 from .lattice import b_matrix
 from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
+from .orientation import angles_to_phi_vector
 from .orientation import ub_from_one_reflection
 from .orientation import ub_identity
 from .reflection import Reflection
@@ -70,6 +71,7 @@ __all__ = [
     "Sample",
     "SampleDict",
     # orientation
+    "angles_to_phi_vector",
     "ub_identity",
     "ub_from_one_reflection",
     # factories

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -3,14 +3,19 @@ orientation.py — U and UB matrix computation from orienting reflections.
 
 Functions
 ---------
-ub_identity(sample)
-    Set U = I, UB = B; return UB.  The crudest assumption.
+angles_to_phi_vector(geometry, **motor_angles)
+    Convert a set of motor angles to the scattering vector expressed in the
+    phi-axis (innermost sample-stage) frame.  This is the foundational
+    computation needed for U and UB matrix determination.
 
 ub_from_one_reflection(sample, reflection, reference_hkl, reference_stage)
     Compute a provisional U and UB from one reflection using the Rodrigues
     rotation that takes the crystal direction ``B @ reference_hkl`` to the
     lab direction given by ``reference_stage``.  Sets ``sample.U`` and
     ``sample.UB`` in-place; returns UB.
+
+ub_identity(sample)
+    Set U = I, UB = B; return UB.  The crudest assumption.
 
 Future functions (separate issues):
     ub_from_two_reflections_bl1967   — Busing & Levy 1967, eqs. 23-27  (#5)
@@ -19,6 +24,7 @@ Future functions (separate issues):
 References
 ----------
 Busing & Levy, Acta Cryst. 22, 457-464 (1967)
+You, J. Appl. Cryst. 32, 614-623 (1999)
 """
 
 from __future__ import annotations
@@ -29,27 +35,137 @@ from .rotation import rotation_matrix
 from .stage import Stage
 
 
-def ub_identity(sample) -> np.ndarray:
+def angles_to_phi_vector(geometry, **motor_angles: float) -> np.ndarray:
     """
-    Set U = I (identity) and UB = B; return UB.
+    Convert a set of motor angles to the scattering vector in the phi frame.
 
-    The crudest orientation assumption: crystal axes are aligned with the
-    lab axes.  Useful as a starting point when no reflection information
-    is available at all.
+    The "phi frame" is the coordinate system seen from the innermost sample
+    stage — the frame in which crystal reflections are expressed when
+    computing the orientation (U) matrix.
+
+    Algorithm (Busing & Levy 1967, section "The phi-axis frame"):
+
+    1. Temporarily set the supplied motor angles on their stages (preserving
+       the original values so the geometry is restored afterwards).
+    2. Compute the total sample rotation matrix ``Z`` (product of all sample
+       stage rotation matrices, floor-most first).
+    3. Compute the total detector rotation matrix ``D``.
+    4. The incident-beam unit vector in the lab frame is ``ŷ`` (longitudinal
+       direction, ``geometry.basis["longitudinal"]``).
+    5. The scattered-beam unit vector in the lab frame is ``D @ ŷ``.
+    6. The scattering vector in the lab frame is::
+
+           Q_lab = (2π / λ) * (D @ ŷ - ŷ)
+
+    7. Rotate Q_lab back through the sample stack::
+
+           Q_phi = Z⁻¹ @ Q_lab = Zᵀ @ Q_lab
+
+       (Z is orthogonal, so Z⁻¹ = Zᵀ.)
 
     Parameters
     ----------
-    sample : Sample
-        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+    geometry : AdHocDiffractometer
+        The diffractometer geometry.  Must have ``wavelength`` set (not None).
+    **motor_angles : float
+        Motor angles in degrees, keyed by stage name.  All stages present in
+        the geometry may be supplied; stages not supplied keep their current
+        ``angle`` attribute.  Only sample and detector stages affect the
+        result; other stages (if any) are ignored.
 
     Returns
     -------
-    UB : numpy.ndarray, shape (3, 3)
+    Q_phi : numpy.ndarray, shape (3,)
+        Scattering vector in the phi frame, in units of Å⁻¹.
+
+    Raises
+    ------
+    KeyError
+        If a supplied stage name does not exist in the geometry.
+    ValueError
+        If ``geometry.wavelength`` is None.
+    ValueError
+        If the geometry has no sample stages.
+    ValueError
+        If the geometry has no detector stages.
+
+    Notes
+    -----
+    The function modifies stage angles temporarily and restores them
+    afterwards, even if an exception is raised.  It is therefore safe to
+    call inside a ``try`` block or from multiple threads as long as each
+    call uses a separate geometry instance.
+
+    The scattering vector Q_phi is independent of which sample stage is
+    designated the "phi" axis; it is expressed in the frame of the *last*
+    sample stage in the stacking order (the one closest to the sample).
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.psic()
+    >>> g.wavelength = 1.5406          # Cu Kα in Å
+    >>> Q_phi = ahd.angles_to_phi_vector(
+    ...     g,
+    ...     mu=0, eta=20.97, chi=90, phi=0, nu=0, delta=41.94,
+    ... )
+    >>> Q_phi  # scattering vector for sapphire (006) in phi frame
+    array([...])
+
+    References
+    ----------
+    Busing & Levy, Acta Cryst. 22, 457-464 (1967) — phi-axis frame
+    You, J. Appl. Cryst. 32, 614-623 (1999) — psic geometry conventions
     """
-    B = sample.lattice.B
-    sample.U = np.eye(3)
-    sample.UB = B.copy()
-    return sample.UB
+    if geometry.wavelength is None:
+        raise ValueError(
+            "geometry.wavelength must be set before calling angles_to_phi_vector. "
+            "Set it with e.g. geometry.wavelength = 1.5406."
+        )
+    if not geometry.sample_stages:
+        raise ValueError(
+            f"Geometry {geometry.name!r} has no sample stages; "
+            "cannot compute a phi-frame vector."
+        )
+    if not geometry.detector_stages:
+        raise ValueError(
+            f"Geometry {geometry.name!r} has no detector stages; "
+            "cannot compute a phi-frame vector."
+        )
+
+    # Validate all supplied stage names up-front (raises KeyError for unknown)
+    for name in motor_angles:
+        geometry.stage(name)  # raises KeyError if not found
+
+    # Save current angles and apply the requested ones
+    saved: dict[str, float] = {}
+    try:
+        for name, angle in motor_angles.items():
+            saved[name] = geometry.stage(name).angle
+            geometry.set_angle(name, float(angle))
+
+        # Sample rotation matrix Z and detector rotation matrix D
+        Z = geometry.sample_rotation_matrix()
+        D = geometry.detector_rotation_matrix()
+
+    finally:
+        # Restore original angles unconditionally
+        for name, angle in saved.items():
+            geometry.set_angle(name, angle)
+
+    # Incident-beam direction: longitudinal basis vector (normalised)
+    y_hat = np.asarray(geometry.basis["longitudinal"], dtype=float)
+    y_norm = np.linalg.norm(y_hat)
+    y_hat = y_hat / y_norm
+
+    # Scattering vector in lab frame: Q_lab = (2π/λ) * (D @ ŷ - ŷ)
+    two_pi_over_lambda = 2.0 * np.pi / geometry.wavelength
+    Q_lab = two_pi_over_lambda * (D @ y_hat - y_hat)
+
+    # Rotate into phi frame: Q_phi = Z^T @ Q_lab  (Z is orthogonal)
+    Q_phi = Z.T @ Q_lab
+
+    return Q_phi
 
 
 def ub_from_one_reflection(
@@ -221,3 +337,26 @@ def ub_from_one_reflection(
     sample.U = U
     sample.UB = UB
     return UB
+
+
+def ub_identity(sample) -> np.ndarray:
+    """
+    Set U = I (identity) and UB = B; return UB.
+
+    The crudest orientation assumption: crystal axes are aligned with the
+    lab axes.  Useful as a starting point when no reflection information
+    is available at all.
+
+    Parameters
+    ----------
+    sample : Sample
+        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+
+    Returns
+    -------
+    UB : numpy.ndarray, shape (3, 3)
+    """
+    B = sample.lattice.B
+    sample.U = np.eye(3)
+    sample.UB = B.copy()
+    return sample.UB

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -9,14 +9,19 @@ Covers:
   - UB @ reference_hkl ≈ direction of reference_stage axis
   - sample.U and sample.UB updated in-place
   - reference_stage type handling (Stage, str, ndarray)
+  - angles_to_phi_vector(): zero angles, magnitude (Bragg law), geometry independence
+    of |Q| from sample rotations, angle restoration, error cases
 """
 
+import math
 import re
 
 import numpy as np
 import pytest
 
 from ad_hoc_diffractometer import Lattice
+from ad_hoc_diffractometer import angles_to_phi_vector
+from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import psic
 from ad_hoc_diffractometer import ub_from_one_reflection
 from ad_hoc_diffractometer import ub_identity
@@ -340,3 +345,195 @@ def test_ub_one_refl_bad_type_raises(sapphire_geom):
             42,
             reference_stage=g.stage("phi"),
         )
+
+
+# ---------------------------------------------------------------------------
+# angles_to_phi_vector()
+# ---------------------------------------------------------------------------
+
+# Sapphire (006) psic angles used throughout these tests
+_SAPPHIRE_ANGLES = {
+    "mu": 0.0,
+    "eta": 20.97,
+    "chi": 90.0,
+    "phi": 0.0,
+    "nu": 0.0,
+    "delta": 41.94,
+}
+
+# Expected |Q| for psic sapphire (006):
+# |Q| = (4π/λ) sin(2θ/2) = (4π/1.5406) sin(20.97°)
+_LAMBDA_CU_KA = 1.5406
+_DELTA_006 = 41.94
+_Q_MAG_SAPPHIRE_006 = (
+    4.0 * math.pi / _LAMBDA_CU_KA * math.sin(math.radians(_DELTA_006 / 2.0))
+)
+
+
+# --- basic return-value properties ------------------------------------------
+
+
+def test_angles_to_phi_vector_all_zero_gives_zero(psic_geom):
+    """All motor angles zero → no scattering → Q_phi = 0."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    Q = angles_to_phi_vector(psic_geom, mu=0, eta=0, chi=0, phi=0, nu=0, delta=0)
+    np.testing.assert_allclose(Q, np.zeros(3), atol=1e-12)
+
+
+def test_angles_to_phi_vector_returns_array_shape(psic_geom):
+    """Return value is a numpy array of shape (3,)."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    Q = angles_to_phi_vector(psic_geom, **_SAPPHIRE_ANGLES)
+    assert isinstance(Q, np.ndarray)
+    assert Q.shape == (3,)
+
+
+def test_angles_to_phi_vector_magnitude_bragg(psic_geom):
+    """|Q_phi| equals (4π/λ)·sin(2θ/2) — the Bragg scattering-vector magnitude."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    Q = angles_to_phi_vector(psic_geom, **_SAPPHIRE_ANGLES)
+    np.testing.assert_allclose(np.linalg.norm(Q), _Q_MAG_SAPPHIRE_006, rtol=1e-6)
+
+
+def test_angles_to_phi_vector_explicit_components_psic_sapphire(psic_geom):
+    """
+    Explicit component check for psic sapphire (006) at Cu Kα.
+
+    The expected values were computed from the implementation under review
+    and locked here as a regression guard.  Any future change to the
+    rotation convention must also update these numbers.
+    """
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    Q = angles_to_phi_vector(psic_geom, **_SAPPHIRE_ANGLES)
+    expected = np.array([0.37387713, -0.97550961, 2.72580786])
+    np.testing.assert_allclose(Q, expected, atol=1e-6)
+
+
+# --- invariance / dependence properties -------------------------------------
+
+
+def test_angles_to_phi_vector_magnitude_invariant_to_phi_rotation(psic_geom):
+    """|Q_phi| is independent of the phi motor angle."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    base = {**_SAPPHIRE_ANGLES}
+    norms = []
+    for phi_deg in (0.0, 30.0, 60.0, 90.0, 135.0, 180.0):
+        base["phi"] = phi_deg
+        norms.append(np.linalg.norm(angles_to_phi_vector(psic_geom, **base)))
+    np.testing.assert_allclose(norms, norms[0], rtol=1e-10)
+
+
+def test_angles_to_phi_vector_magnitude_invariant_to_sample_rotation(psic_geom):
+    """
+    |Q_phi| depends only on detector angles, not on sample angles.
+
+    Varying mu, eta, chi, phi while keeping nu and delta fixed must leave
+    |Q_phi| unchanged.
+    """
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    detector_angles = {"nu": 0.0, "delta": _DELTA_006}
+    sample_angle_sets = [
+        {"mu": 0.0, "eta": 20.97, "chi": 0.0, "phi": 0.0},
+        {"mu": 0.0, "eta": 20.97, "chi": 30.0, "phi": 15.0},
+        {"mu": 5.0, "eta": 20.97, "chi": 90.0, "phi": 45.0},
+        {"mu": 10.0, "eta": 20.97, "chi": 45.0, "phi": 120.0},
+    ]
+    norms = [
+        np.linalg.norm(angles_to_phi_vector(psic_geom, **{**detector_angles, **sample}))
+        for sample in sample_angle_sets
+    ]
+    np.testing.assert_allclose(norms, norms[0], rtol=1e-10)
+
+
+def test_angles_to_phi_vector_fourcv_all_zero_gives_zero():
+    """fourcv: all-zero angles → Q_phi = 0."""
+    g = fourcv()
+    g.wavelength = 1.0
+    Q = angles_to_phi_vector(g, omega=0, chi=0, phi=0, two_theta=0)
+    np.testing.assert_allclose(Q, np.zeros(3), atol=1e-12)
+
+
+def test_angles_to_phi_vector_fourcv_bisecting_magnitude():
+    """
+    fourcv bisecting geometry: |Q_phi| = (4π/λ)·sin(2θ/2).
+
+    With omega = 2θ/2 (bisecting), the sample and detector share the
+    same theta angle and the Q magnitude must satisfy the Bragg formula.
+    """
+    g = fourcv()
+    g.wavelength = _LAMBDA_CU_KA
+    two_theta = 28.4474  # Si (111) at Cu Kα
+    Q = angles_to_phi_vector(
+        g, omega=two_theta / 2.0, chi=0.0, phi=0.0, two_theta=two_theta
+    )
+    expected_mag = (
+        4.0 * math.pi / _LAMBDA_CU_KA * math.sin(math.radians(two_theta / 2.0))
+    )
+    np.testing.assert_allclose(np.linalg.norm(Q), expected_mag, rtol=1e-6)
+
+
+# --- angle restoration ------------------------------------------------------
+
+
+def test_angles_to_phi_vector_restores_stage_angles(psic_geom):
+    """Motor angles are restored to their original values after the call."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    psic_geom.set_angle("eta", 99.9)
+    psic_geom.set_angle("phi", 45.0)
+    psic_geom.set_angle("chi", 33.3)
+
+    angles_to_phi_vector(psic_geom, mu=0, eta=20.97, chi=90, phi=0, nu=0, delta=41.94)
+
+    assert psic_geom.stage("eta").angle == pytest.approx(99.9)
+    assert psic_geom.stage("phi").angle == pytest.approx(45.0)
+    assert psic_geom.stage("chi").angle == pytest.approx(33.3)
+
+
+def test_angles_to_phi_vector_restores_angles_on_error(psic_geom):
+    """Stage angles are restored even when an exception is raised mid-call."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    psic_geom.set_angle("eta", 55.5)
+
+    # Trigger KeyError by supplying an unknown stage name; the KeyError is
+    # raised before any angle is set, so eta should still be 55.5.
+    with pytest.raises(KeyError):
+        angles_to_phi_vector(psic_geom, eta=20, no_such_stage=0)
+
+    assert psic_geom.stage("eta").angle == pytest.approx(55.5)
+
+
+# --- partial motor-angle sets -----------------------------------------------
+
+
+def test_angles_to_phi_vector_partial_angles_uses_current(psic_geom):
+    """Stages not supplied in **motor_angles keep their current angle."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    # Set all angles to the sapphire values directly on the geometry
+    for name, angle in _SAPPHIRE_ANGLES.items():
+        psic_geom.set_angle(name, angle)
+
+    # Call with no keyword arguments — should use the already-set angles
+    Q_none = angles_to_phi_vector(psic_geom)
+
+    # Should equal the result when all angles are passed explicitly
+    Q_explicit = angles_to_phi_vector(psic_geom, **_SAPPHIRE_ANGLES)
+
+    np.testing.assert_allclose(Q_none, Q_explicit, atol=1e-12)
+
+
+# --- error cases ------------------------------------------------------------
+
+
+def test_angles_to_phi_vector_no_wavelength_raises(psic_geom):
+    """Raises ValueError when wavelength is not set."""
+    # wavelength defaults to None
+    assert psic_geom.wavelength is None
+    with pytest.raises(ValueError, match=re.escape("wavelength must be set")):
+        angles_to_phi_vector(psic_geom, mu=0, eta=0, chi=0, phi=0, nu=0, delta=0)
+
+
+def test_angles_to_phi_vector_unknown_stage_raises(psic_geom):
+    """Raises KeyError for a stage name not in the geometry."""
+    psic_geom.wavelength = _LAMBDA_CU_KA
+    with pytest.raises(KeyError):
+        angles_to_phi_vector(psic_geom, no_such_stage=0.0)


### PR DESCRIPTION
## Summary

- Implement `angles_to_phi_vector(geometry, **motor_angles)` in `orientation.py`: converts a set of motor angles to the scattering vector in the phi-axis frame (Busing & Levy 1967, You 1999)
- Export `angles_to_phi_vector` from the public API (`__init__.py`)
- 13 new tests covering: zero-angle case, Bragg-law magnitude, sample-rotation invariance of |Q|, phi invariance, fourcv bisecting geometry, angle restoration on normal and error paths, partial angle sets, and error cases
- Functions in `orientation.py` sorted alphabetically; module docstring updated to match
- Roadmap section 2.0 checked off

- closes #4

Contributed by: OpenCode (argo/claudesonnet46)