### PR TITLE
feat: implement ub_from_two_reflections_bl1967 (BL1967 eqs. 23-27)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,11 +95,11 @@ be implemented first.
 
 ### 2.1 `ub_from_two_reflections_bl1967` (BL1967 eqs. 23-27) ([#5](https://github.com/prjemian/ad_hoc_diffractometer/issues/5))
 
-- [ ] Implement in `orientation.py`
-- [ ] Inputs: two `Reflection` objects + known lattice (B matrix)
-- [ ] Algorithm: Gram-Schmidt orthonormal triples Tc (crystal) and Tφ (phi
+- [x] Implement in `orientation.py`
+- [x] Inputs: two `Reflection` objects + known lattice (B matrix)
+- [x] Algorithm: Gram-Schmidt orthonormal triples Tc (crystal) and Tφ (phi
       frame); U = Tφ @ Tc.T; UB = U @ B
-- [ ] Sets `sample.U` and `sample.UB` in-place; returns UB
+- [x] Sets `sample.U` and `sample.UB` in-place; returns UB
 
 ### 2.2 `ub_from_three_reflections_bl1967` (BL1967 eqs. 29-31) ([#6](https://github.com/prjemian/ad_hoc_diffractometer/issues/6))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -36,6 +36,7 @@ from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
 from .orientation import angles_to_phi_vector
 from .orientation import ub_from_one_reflection
+from .orientation import ub_from_two_reflections_bl1967
 from .orientation import ub_identity
 from .reflection import Reflection
 from .reflection import ReflectionList
@@ -74,6 +75,7 @@ __all__ = [
     "angles_to_phi_vector",
     "ub_identity",
     "ub_from_one_reflection",
+    "ub_from_two_reflections_bl1967",
     # factories
     "list_geometries",
     "get_geometry",

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -14,11 +14,15 @@ ub_from_one_reflection(sample, reflection, reference_hkl, reference_stage)
     lab direction given by ``reference_stage``.  Sets ``sample.U`` and
     ``sample.UB`` in-place; returns UB.
 
+ub_from_two_reflections_bl1967(sample, r1, r2)
+    Compute U and UB from two orienting reflections using the Busing & Levy
+    (1967) algorithm (eqs. 23-27).  Sets ``sample.U`` and ``sample.UB``
+    in-place; returns UB.
+
 ub_identity(sample)
     Set U = I, UB = B; return UB.  The crudest assumption.
 
 Future functions (separate issues):
-    ub_from_two_reflections_bl1967   — Busing & Levy 1967, eqs. 23-27  (#5)
     ub_from_three_reflections_bl1967 — Busing & Levy 1967, eqs. 29-31  (#6)
 
 References
@@ -334,6 +338,248 @@ def ub_from_one_reflection(
         U = rotation_matrix(ax, np.degrees(angle_rad))
 
     UB = U @ B
+    sample.U = U
+    sample.UB = UB
+    return UB
+
+
+def _gram_schmidt_triple(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
+    """
+    Build a right-handed orthonormal 3×3 matrix from two linearly independent
+    vectors using Gram-Schmidt orthogonalisation.
+
+    The columns of the returned matrix ``T`` are::
+
+        t1 = v1 / |v1|
+        t3 = t1 × v2 / |t1 × v2|
+        t2 = t3 × t1
+
+    so that ``t1 ∥ v1``, ``t2`` lies in the plane of ``v1`` and ``v2``, and
+    ``t3`` is perpendicular to that plane.  The triple ``(t1, t2, t3)`` is
+    right-handed and orthonormal.
+
+    Parameters
+    ----------
+    v1 : numpy.ndarray, shape (3,)
+        Primary vector (must be non-zero).
+    v2 : numpy.ndarray, shape (3,)
+        Secondary vector (must not be parallel to ``v1``).
+
+    Returns
+    -------
+    T : numpy.ndarray, shape (3, 3)
+        Columns are ``[t1, t2, t3]``, forming a right-handed orthonormal basis.
+
+    Raises
+    ------
+    ValueError
+        If ``v1`` is the zero vector or ``v1`` and ``v2`` are parallel
+        (cross product is zero).
+
+    Notes
+    -----
+    This is the Gram-Schmidt construction used in Busing & Levy (1967) to
+    build the orthonormal triples ``Tc`` (crystal frame) and ``Tφ`` (phi
+    frame) for the two-reflection orientation algorithm (eqs. 23-27).
+    """
+    v1 = np.asarray(v1, dtype=float)
+    v2 = np.asarray(v2, dtype=float)
+
+    n1 = np.linalg.norm(v1)
+    if n1 < 1e-14:
+        raise ValueError(
+            "_gram_schmidt_triple: v1 is the zero vector; cannot build an "
+            "orthonormal basis."
+        )
+    t1 = v1 / n1
+
+    cross = np.cross(t1, v2)
+    n_cross = np.linalg.norm(cross)
+    if n_cross < 1e-14:
+        raise ValueError(
+            "_gram_schmidt_triple: v1 and v2 are parallel (or v2 is zero); "
+            "cannot build an orthonormal basis."
+        )
+    t3 = cross / n_cross
+    t2 = np.cross(t3, t1)
+
+    return np.column_stack([t1, t2, t3])
+
+
+def ub_from_two_reflections_bl1967(
+    sample,
+    r1=None,
+    r2=None,
+) -> np.ndarray:
+    """
+    Compute U and UB from two orienting reflections (Busing & Levy 1967, eqs. 23-27).
+
+    Given two reflections with known hkl and measured motor angles, and a
+    known lattice (B matrix), this function computes the orientation matrix U
+    and then UB = U @ B, storing both on the sample.
+
+    Algorithm (BL1967 eqs. 23-27):
+
+    1. For each reflection, call ``angles_to_phi_vector()`` to get the
+       scattering vector in the phi frame: ``u1φ``, ``u2φ``.
+    2. From hkl and the lattice B matrix: ``h1c = B @ h1``, ``h2c = B @ h2``.
+    3. Build orthonormal triple ``Tc`` in the crystal frame via Gram-Schmidt:
+       ``t1c ∥ h1c``, ``t2c`` in the plane of ``h1c`` and ``h2c``,
+       ``t3c = t1c × t2c``.
+    4. Build the matching triple ``Tφ`` in the phi frame from ``u1φ``, ``u2φ``.
+    5. Compute ``U = Tφ @ Tc.T``  (eq. 27; Tc is orthogonal so Tc⁻¹ = Tc.T).
+    6. Compute ``UB = U @ B``.
+    7. Store ``sample.U = U``, ``sample.UB = UB``; return ``UB``.
+
+    Parameters
+    ----------
+    sample : Sample
+        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+        ``sample.lattice`` must be set.  ``sample.parent`` must be a geometry
+        with ``wavelength`` set (it is used to call ``angles_to_phi_vector``).
+    r1 : Reflection, str, or None
+        Primary orienting reflection.  If ``None``, defaults to
+        ``sample.reflections.orienting_reflections[0]``.
+    r2 : Reflection, str, or None
+        Secondary orienting reflection.  If ``None``, defaults to
+        ``sample.reflections.orienting_reflections[1]``.
+
+    Returns
+    -------
+    UB : numpy.ndarray, shape (3, 3)
+        Sets ``sample.U`` (first) and ``sample.UB = sample.U @ B`` in-place
+        before returning.
+
+    Raises
+    ------
+    KeyError
+        If ``r1`` or ``r2`` is a string not found in ``sample.reflections``.
+    ValueError
+        If ``r1`` or ``r2`` is ``None`` and the required orienting reflection
+        has not been designated (``setor1``/``setor2`` not called).
+    ValueError
+        If ``sample.parent`` is ``None`` (needed to call
+        ``angles_to_phi_vector``).
+    ValueError
+        If ``sample.parent.wavelength`` is ``None``.
+    ValueError
+        If the two reflections are parallel in the crystal frame (h1c and
+        h2c collinear) or in the phi frame (u1φ and u2φ collinear).
+    TypeError
+        If ``r1`` or ``r2`` is not a ``Reflection``, string, or ``None``.
+
+    Notes
+    -----
+    U is computed first (``sample.U = Tφ @ Tc.T``), then UB is derived from
+    it (``sample.UB = sample.U @ B``).
+
+    The wavelength used for ``angles_to_phi_vector`` is taken from
+    ``sample.parent.wavelength``.  If a reflection carries its own
+    ``wavelength`` attribute, that is *not* used here; the geometry's
+    wavelength governs the conversion from motor angles to Q_phi.
+
+    References
+    ----------
+    Busing & Levy, Acta Cryst. 22, 457-464 (1967), eqs. 23-27.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.psic()
+    >>> g.wavelength = 1.5406
+    >>> g.add_sample("sapphire", ahd.Lattice(a=4.758, c=12.991))
+    >>> g.sample = "sapphire"
+    >>> g.add_reflection("r1", hkl=(0, 0, 6),
+    ...     angles={"mu": 0, "eta": 20.97, "chi": 90, "phi": 0,
+    ...             "nu": 0, "delta": 41.94})
+    >>> g.add_reflection("r2", hkl=(1, 0, 4),
+    ...     angles={"mu": 0, "eta": 23.72, "chi": 57.04, "phi": 0,
+    ...             "nu": 0, "delta": 48.13})
+    >>> g.sample.reflections.setor1("r1")
+    >>> g.sample.reflections.setor2("r2")
+    >>> UB = ahd.ub_from_two_reflections_bl1967(g.sample)
+    """
+    from .reflection import Reflection
+
+    # --- Require a parent geometry (needed for angles_to_phi_vector) ----------
+    if sample.parent is None:
+        raise ValueError(
+            "ub_from_two_reflections_bl1967 requires sample.parent to be set "
+            "(an AdHocDiffractometer with wavelength).  Attach the sample to a "
+            "geometry before calling this function."
+        )
+    geometry = sample.parent
+
+    # --- Resolve r1 -----------------------------------------------------------
+    if r1 is None:
+        ors = sample.reflections.orienting_reflections
+        if len(ors) < 1 or ors[0] is None:
+            raise ValueError(
+                "r1 is None and no primary orienting reflection (or1) has been "
+                "designated.  Call sample.reflections.setor1() first, or pass "
+                "r1 explicitly."
+            )
+        r1 = ors[0]
+    elif isinstance(r1, str):
+        r1 = sample.reflections[r1]
+    if not isinstance(r1, Reflection):
+        raise TypeError(
+            f"r1 must be a Reflection, a name string, or None; "
+            f"got {type(r1).__name__!r}."
+        )
+
+    # --- Resolve r2 -----------------------------------------------------------
+    if r2 is None:
+        ors = sample.reflections.orienting_reflections
+        if len(ors) < 2:
+            raise ValueError(
+                "r2 is None and no secondary orienting reflection (or2) has been "
+                "designated.  Call sample.reflections.setor2() first, or pass "
+                "r2 explicitly."
+            )
+        r2 = ors[1]
+    elif isinstance(r2, str):
+        r2 = sample.reflections[r2]
+    if not isinstance(r2, Reflection):
+        raise TypeError(
+            f"r2 must be a Reflection, a name string, or None; "
+            f"got {type(r2).__name__!r}."
+        )
+
+    # --- Phi-frame scattering vectors from motor angles -----------------------
+    u1_phi = angles_to_phi_vector(geometry, **r1.angles)
+    u2_phi = angles_to_phi_vector(geometry, **r2.angles)
+
+    # --- Crystal-frame vectors from hkl and B ---------------------------------
+    B = sample.lattice.B
+    h1c = B @ np.asarray(r1.hkl, dtype=float)
+    h2c = B @ np.asarray(r2.hkl, dtype=float)
+
+    # --- Build orthonormal triples via Gram-Schmidt ---------------------------
+    # Tc: crystal frame.  t1c ∥ h1c, t2c in plane(h1c, h2c), t3c = t1c × t2c.
+    try:
+        Tc = _gram_schmidt_triple(h1c, h2c)
+    except ValueError as exc:
+        raise ValueError(
+            "The two reflections are parallel in the crystal frame "
+            f"(h1c = B @ {r1.hkl} and h2c = B @ {r2.hkl} are collinear). "
+            "Choose two reflections that are not parallel."
+        ) from exc
+
+    # Tphi: phi frame.  t1φ ∥ u1φ, t2φ in plane(u1φ, u2φ), t3φ = t1φ × t2φ.
+    try:
+        Tphi = _gram_schmidt_triple(u1_phi, u2_phi)
+    except ValueError as exc:
+        raise ValueError(
+            "The two reflections are parallel in the phi frame "
+            f"(Q_phi vectors for {r1.name!r} and {r2.name!r} are collinear). "
+            "Choose two reflections that are not parallel."
+        ) from exc
+
+    # --- BL1967 eq. 27: U = Tφ @ Tc.T  (Tc orthogonal → Tc⁻¹ = Tc.T) ------
+    U = Tphi @ Tc.T
+    UB = U @ B
+
     sample.U = U
     sample.UB = UB
     return UB

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -11,6 +11,8 @@ Covers:
   - reference_stage type handling (Stage, str, ndarray)
   - angles_to_phi_vector(): zero angles, magnitude (Bragg law), geometry independence
     of |Q| from sample rotations, angle restoration, error cases
+  - ub_from_two_reflections_bl1967(): orthonormal U, UB=U@B, direction checks,
+    default or1/or2 resolution, string/object reflection args, error cases
 """
 
 import math
@@ -24,6 +26,7 @@ from ad_hoc_diffractometer import angles_to_phi_vector
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import psic
 from ad_hoc_diffractometer import ub_from_one_reflection
+from ad_hoc_diffractometer import ub_from_two_reflections_bl1967
 from ad_hoc_diffractometer import ub_identity
 from ad_hoc_diffractometer.reflection import ReflectionList
 from ad_hoc_diffractometer.sample import Sample
@@ -537,3 +540,246 @@ def test_angles_to_phi_vector_unknown_stage_raises(psic_geom):
     psic_geom.wavelength = _LAMBDA_CU_KA
     with pytest.raises(KeyError):
         angles_to_phi_vector(psic_geom, no_such_stage=0.0)
+
+
+# ---------------------------------------------------------------------------
+# ub_from_two_reflections_bl1967()
+# ---------------------------------------------------------------------------
+#
+# "Clean" test case: psic geometry, cubic lattice with a = 2π so B = I.
+# With U = I (identity orientation), UB = B = I.
+#
+# Motor angles chosen so that each reflection gives Q_phi along an
+# orthogonal axis:
+#   r1: hkl = (1,0,0), mu=0 eta=30 chi=0 phi=0   nu=0 delta=60 → Q_phi ‖ XHAT
+#   r2: hkl = (0,1,0), mu=0 eta=30 chi=0 phi=90  nu=0 delta=60 → Q_phi ‖ YHAT
+#
+# BL1967 must then recover U = I exactly (both reflections are fully
+# consistent with U = I, B = I).
+
+_TWO_PI = 2.0 * math.pi
+_LAT_2PI = Lattice(a=_TWO_PI)  # cubic a = 2π → B = identity
+_R1_HKL_2PI = (1, 0, 0)
+_R1_ANG_2PI = {"mu": 0.0, "eta": 30.0, "chi": 0.0, "phi": 0.0, "nu": 0.0, "delta": 60.0}
+_R2_HKL_2PI = (0, 1, 0)
+_R2_ANG_2PI = {
+    "mu": 0.0,
+    "eta": 30.0,
+    "chi": 0.0,
+    "phi": 90.0,
+    "nu": 0.0,
+    "delta": 60.0,
+}
+
+
+@pytest.fixture
+def two_refl_geom():
+    """
+    psic geometry with cubic a=2π lattice and two orthogonal reflections.
+
+    The motor angles are constructed so that U = I is the exact solution.
+    """
+    g = psic()
+    g.wavelength = _TWO_PI
+    g.sample.lattice = _LAT_2PI
+    g.add_reflection("r1", hkl=_R1_HKL_2PI, angles=_R1_ANG_2PI)
+    g.add_reflection("r2", hkl=_R2_HKL_2PI, angles=_R2_ANG_2PI)
+    g.sample.reflections.setor1("r1")
+    g.sample.reflections.setor2("r2")
+    return g
+
+
+# --- mathematical correctness -----------------------------------------------
+
+
+def test_two_refl_U_is_orthonormal(two_refl_geom):
+    """U returned by BL1967 must satisfy U.T @ U = I and det(U) = 1."""
+    ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    U = two_refl_geom.sample.U
+    np.testing.assert_allclose(U.T @ U, np.eye(3), atol=1e-10)
+    assert abs(np.linalg.det(U) - 1.0) < 1e-10
+
+
+def test_two_refl_UB_equals_U_at_B(two_refl_geom):
+    """UB must equal U @ B (U is computed first, then UB derived)."""
+    ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    B = two_refl_geom.sample.lattice.B
+    np.testing.assert_allclose(
+        two_refl_geom.sample.UB,
+        two_refl_geom.sample.U @ B,
+        atol=1e-12,
+    )
+
+
+def test_two_refl_U_identity_for_aligned_crystal(two_refl_geom):
+    """When motor angles are consistent with U=I, BL1967 must recover U=I."""
+    ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    np.testing.assert_allclose(two_refl_geom.sample.U, np.eye(3), atol=1e-10)
+
+
+def test_two_refl_returns_UB_array(two_refl_geom):
+    """Return value is a (3,3) ndarray equal to sample.UB."""
+    UB = ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    assert isinstance(UB, np.ndarray)
+    assert UB.shape == (3, 3)
+    np.testing.assert_array_equal(UB, two_refl_geom.sample.UB)
+
+
+def test_two_refl_updates_sample_in_place(two_refl_geom):
+    """sample.U and sample.UB are set in-place (None before the call)."""
+    assert two_refl_geom.sample.U is None
+    assert two_refl_geom.sample.UB is None
+    UB = ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    assert two_refl_geom.sample.U is not None
+    assert two_refl_geom.sample.UB is UB
+
+
+def test_two_refl_r1_direction_exactly_reproduced(two_refl_geom):
+    """UB @ h1 must be parallel to Q_phi of r1 (primary reflection is exact)."""
+    g = two_refl_geom
+    UB = ub_from_two_reflections_bl1967(g.sample)
+    u1_phi = angles_to_phi_vector(g, **_R1_ANG_2PI)
+    q1 = UB @ np.array(_R1_HKL_2PI, dtype=float)
+    q1_hat = q1 / np.linalg.norm(q1)
+    u1_hat = u1_phi / np.linalg.norm(u1_phi)
+    np.testing.assert_allclose(q1_hat, u1_hat, atol=1e-10)
+
+
+def test_two_refl_r2_direction_exactly_reproduced_when_consistent(two_refl_geom):
+    """UB @ h2 must be parallel to Q_phi of r2 when angles are fully consistent."""
+    g = two_refl_geom
+    UB = ub_from_two_reflections_bl1967(g.sample)
+    u2_phi = angles_to_phi_vector(g, **_R2_ANG_2PI)
+    q2 = UB @ np.array(_R2_HKL_2PI, dtype=float)
+    q2_hat = q2 / np.linalg.norm(q2)
+    u2_hat = u2_phi / np.linalg.norm(u2_phi)
+    np.testing.assert_allclose(q2_hat, u2_hat, atol=1e-10)
+
+
+# --- reflection argument variants -------------------------------------------
+
+
+def test_two_refl_string_args(two_refl_geom):
+    """r1 and r2 may be supplied as name strings."""
+    UB = ub_from_two_reflections_bl1967(two_refl_geom.sample, r1="r1", r2="r2")
+    assert UB.shape == (3, 3)
+    np.testing.assert_allclose(two_refl_geom.sample.U, np.eye(3), atol=1e-10)
+
+
+def test_two_refl_reflection_objects(two_refl_geom):
+    """r1 and r2 may be supplied as Reflection objects."""
+    g = two_refl_geom
+    r1_obj = g.sample.reflections["r1"]
+    r2_obj = g.sample.reflections["r2"]
+    UB = ub_from_two_reflections_bl1967(g.sample, r1=r1_obj, r2=r2_obj)
+    assert UB.shape == (3, 3)
+
+
+def test_two_refl_none_uses_setor1_setor2(two_refl_geom):
+    """Passing r1=None, r2=None uses the designated or1 and or2."""
+    UB_default = ub_from_two_reflections_bl1967(two_refl_geom.sample)
+    two_refl_geom.sample.U = None
+    two_refl_geom.sample.UB = None
+    UB_explicit = ub_from_two_reflections_bl1967(two_refl_geom.sample, r1="r1", r2="r2")
+    np.testing.assert_allclose(UB_default, UB_explicit, atol=1e-12)
+
+
+def test_two_refl_mixed_string_and_object(two_refl_geom):
+    """r1 as string, r2 as Reflection object (and vice-versa) both work."""
+    g = two_refl_geom
+    r2_obj = g.sample.reflections["r2"]
+    UB = ub_from_two_reflections_bl1967(g.sample, r1="r1", r2=r2_obj)
+    assert UB.shape == (3, 3)
+
+
+# --- error cases ------------------------------------------------------------
+
+
+def test_two_refl_no_parent_raises():
+    """Raises ValueError when sample has no parent geometry."""
+    rl = ReflectionList(
+        geometry_name="psic",
+        valid_stages={"mu", "eta", "chi", "phi", "nu", "delta"},
+    )
+    rl.add("r1", hkl=(0, 0, 6), angles={"mu": 0.0})
+    rl.add("r2", hkl=(1, 0, 0), angles={"mu": 0.0})
+    rl.setor1("r1")
+    rl.setor2("r2")
+    sample = Sample(name="orphan", lattice=Lattice(a=1.0), reflections=rl)
+    with pytest.raises(ValueError, match=re.escape("sample.parent")):
+        ub_from_two_reflections_bl1967(sample)
+
+
+def test_two_refl_r1_none_no_setor1_raises(psic_geom):
+    """r1=None raises when no or1 has been designated."""
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_2PI
+    psic_geom.add_reflection("r1", hkl=_R1_HKL_2PI, angles=_R1_ANG_2PI)
+    # deliberately do NOT call setor1
+    with pytest.raises(ValueError, match=re.escape("no primary orienting reflection")):
+        ub_from_two_reflections_bl1967(psic_geom.sample, r1=None, r2=None)
+
+
+def test_two_refl_r2_none_no_setor2_raises(psic_geom):
+    """r2=None raises when no or2 has been designated."""
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_2PI
+    psic_geom.add_reflection("r1", hkl=_R1_HKL_2PI, angles=_R1_ANG_2PI)
+    psic_geom.sample.reflections.setor1("r1")
+    # deliberately do NOT call setor2
+    with pytest.raises(
+        ValueError, match=re.escape("no secondary orienting reflection")
+    ):
+        ub_from_two_reflections_bl1967(psic_geom.sample, r2=None)
+
+
+def test_two_refl_r1_unknown_string_raises(two_refl_geom):
+    """Raises KeyError when r1 is a string not in the reflection list."""
+    with pytest.raises(KeyError):
+        ub_from_two_reflections_bl1967(two_refl_geom.sample, r1="no_such")
+
+
+def test_two_refl_r2_unknown_string_raises(two_refl_geom):
+    """Raises KeyError when r2 is a string not in the reflection list."""
+    with pytest.raises(KeyError):
+        ub_from_two_reflections_bl1967(two_refl_geom.sample, r2="no_such")
+
+
+def test_two_refl_r1_bad_type_raises(two_refl_geom):
+    """Raises TypeError when r1 is not Reflection, str, or None."""
+    with pytest.raises(TypeError, match=re.escape("r1 must be a Reflection")):
+        ub_from_two_reflections_bl1967(two_refl_geom.sample, r1=42)
+
+
+def test_two_refl_r2_bad_type_raises(two_refl_geom):
+    """Raises TypeError when r2 is not Reflection, str, or None."""
+    with pytest.raises(TypeError, match=re.escape("r2 must be a Reflection")):
+        ub_from_two_reflections_bl1967(two_refl_geom.sample, r2=3.14)
+
+
+def test_two_refl_collinear_crystal_frame_raises(psic_geom):
+    """Raises ValueError when h1c and h2c are collinear (parallel hkl in crystal frame)."""
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_2PI
+    # (1,0,0) and (2,0,0) are parallel
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_R1_ANG_2PI)
+    psic_geom.add_reflection("r2", hkl=(2, 0, 0), angles=_R2_ANG_2PI)
+    psic_geom.sample.reflections.setor1("r1")
+    psic_geom.sample.reflections.setor2("r2")
+    with pytest.raises(ValueError, match=re.escape("parallel in the crystal frame")):
+        ub_from_two_reflections_bl1967(psic_geom.sample)
+
+
+def test_two_refl_collinear_phi_frame_raises(psic_geom):
+    """Raises ValueError when Q_phi vectors for r1 and r2 are collinear."""
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_2PI
+    # Different hkl but identical angles → same Q_phi
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_R1_ANG_2PI)
+    psic_geom.add_reflection(
+        "r2", hkl=(0, 1, 0), angles=_R1_ANG_2PI
+    )  # same angles as r1
+    psic_geom.sample.reflections.setor1("r1")
+    psic_geom.sample.reflections.setor2("r2")
+    with pytest.raises(ValueError, match=re.escape("parallel in the phi frame")):
+        ub_from_two_reflections_bl1967(psic_geom.sample)


### PR DESCRIPTION
## Summary

- Implements `ub_from_two_reflections_bl1967()` in `orientation.py` using the Busing & Levy (1967) Gram-Schmidt algorithm (eqs. 23-27)
- Adds private helper `_gram_schmidt_triple()` for building right-handed orthonormal triples
- Exports the new function from `__init__.py`; 20 new tests added (520 total, all pass)
- Checks all roadmap section 2.1 boxes in `docs/roadmap.md`

- closes #5

### Algorithm

1. For each reflection, `angles_to_phi_vector()` gives `u1φ`, `u2φ`.
2. Crystal-frame vectors: `h1c = B @ h1`, `h2c = B @ h2`.
3. Gram-Schmidt → orthonormal triple `Tc` in crystal frame (t1c ∥ h1c).
4. Gram-Schmidt → matching triple `Tφ` in phi frame (t1φ ∥ u1φ).
5. `U = Tφ @ Tc.T` (BL1967 eq. 27); `UB = U @ B`.
6. `sample.U` set first, then `sample.UB = sample.U @ B`; returns `UB`.

Contributed by: OpenCode (argo/claudesonnet46)