### PR TITLE
feat: implement ub_from_three_reflections_bl1967 (BL1967 eqs. 29-31)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -103,10 +103,10 @@ be implemented first.
 
 ### 2.2 `ub_from_three_reflections_bl1967` (BL1967 eqs. 29-31) ([#6](https://github.com/prjemian/ad_hoc_diffractometer/issues/6))
 
-- [ ] Implement in `orientation.py`
-- [ ] Inputs: three `Reflection` objects; no prior lattice needed
-- [ ] Algorithm: UB = Hφ @ H⁻¹ (direct matrix inversion); U = UB @ B⁻¹
-- [ ] Sets `sample.U` and `sample.UB` in-place; returns UB
+- [x] Implement in `orientation.py`
+- [x] Inputs: three `Reflection` objects; no prior lattice needed
+- [x] Algorithm: UB = Hφ @ H⁻¹ (direct matrix inversion); U = UB @ B⁻¹
+- [x] Sets `sample.U` and `sample.UB` in-place; returns UB
 
 ### 2.3 Orienting reflections data structure ([#7](https://github.com/prjemian/ad_hoc_diffractometer/issues/7))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -36,6 +36,7 @@ from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
 from .orientation import angles_to_phi_vector
 from .orientation import ub_from_one_reflection
+from .orientation import ub_from_three_reflections_bl1967
 from .orientation import ub_from_two_reflections_bl1967
 from .orientation import ub_identity
 from .reflection import Reflection
@@ -76,6 +77,7 @@ __all__ = [
     "ub_identity",
     "ub_from_one_reflection",
     "ub_from_two_reflections_bl1967",
+    "ub_from_three_reflections_bl1967",
     # factories
     "list_geometries",
     "get_geometry",

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -19,6 +19,12 @@ ub_from_two_reflections_bl1967(sample, r1, r2)
     (1967) algorithm (eqs. 23-27).  Sets ``sample.U`` and ``sample.UB``
     in-place; returns UB.
 
+ub_from_three_reflections_bl1967(sample, r1, r2, r3)
+    Compute UB directly from three reflections using the Busing & Levy (1967)
+    direct method (eqs. 29-31), without prior knowledge of the lattice.
+    Sets ``sample.UB`` in-place; also sets ``sample.U`` if a lattice B is
+    available.  Returns UB.
+
 ub_identity(sample)
     Set U = I, UB = B; return UB.  The crudest assumption.
 
@@ -582,6 +588,192 @@ def ub_from_two_reflections_bl1967(
 
     sample.U = U
     sample.UB = UB
+    return UB
+
+
+def ub_from_three_reflections_bl1967(
+    sample,
+    r1,
+    r2,
+    r3,
+) -> np.ndarray:
+    """
+    Compute UB directly from three reflections (Busing & Levy 1967, eqs. 29-31).
+
+    This method requires no prior knowledge of the lattice: it computes UB
+    directly by matrix inversion from three measured reflections.  If a
+    lattice B matrix is available on the sample, U is also derived.
+
+    Algorithm (BL1967 eqs. 28-31):
+
+    1. For each reflection i compute the phi-frame scattering vector
+       ``hiφ = angles_to_phi_vector(geometry, **ri.angles)`` (eq. 28 gives
+       the magnitude; ``angles_to_phi_vector`` already carries the full
+       vector in Å⁻¹).
+    2. Stack as column matrices::
+
+           Hφ = [h1φ | h2φ | h3φ]    (3×3, columns are phi-frame vectors)
+           H  = [h1  | h2  | h3 ]    (3×3, columns are Miller-index triples)
+
+    3. ``UB = Hφ @ inv(H)``  (eq. 31).
+    4. If ``sample.lattice`` is set: ``U = UB @ inv(B)`` (derived from UB).
+    5. Store ``sample.UB = UB`` (first) and ``sample.U = U``; return ``UB``.
+
+    Parameters
+    ----------
+    sample : Sample
+        The sample whose ``UB`` (and ``U``) attributes are updated in-place.
+        ``sample.parent`` must be a geometry with ``wavelength`` set.
+    r1, r2, r3 : Reflection or str
+        Three orienting reflections.  Each may be a ``Reflection`` object or
+        the name of a reflection in ``sample.reflections``.
+
+    Returns
+    -------
+    UB : numpy.ndarray, shape (3, 3)
+        ``sample.UB`` is set first (directly, via eq. 31), then
+        ``sample.U = UB @ inv(B)`` is derived.  Both are set in-place.
+
+    Raises
+    ------
+    KeyError
+        If any of ``r1``, ``r2``, ``r3`` is a string not found in
+        ``sample.reflections``.
+    TypeError
+        If any argument is not a ``Reflection`` or a string.
+    ValueError
+        If ``sample.parent`` is ``None``.
+    ValueError
+        If the three Miller-index column matrix ``H`` is singular
+        (``|det(H)| < tol``), i.e. the three hkl vectors are coplanar.
+    ValueError
+        If ``sample.parent.wavelength`` is ``None``.
+
+    Warns
+    -----
+    UserWarning
+        If ``det(H) < 0``, the hkl triples form a left-handed system.
+        The computation proceeds but the sign convention may give U with
+        ``det(U) = -1``; consider swapping r1 and r2 to make det(H) > 0.
+
+    Notes
+    -----
+    UB is computed first (``sample.UB = Hφ @ H⁻¹``).  U is then derived
+    as ``sample.U = UB @ B⁻¹``.  This is the opposite order from
+    ``ub_from_two_reflections_bl1967``, where U is computed first.
+
+    The method does not require a known lattice: ``H`` is formed from the
+    raw hkl indices, not from ``B @ hkl``.  However, if ``sample.lattice``
+    is the package default (cubic, a = 1 Å) rather than a measured lattice,
+    the derived U will not be physically meaningful.
+
+    If ``det(H)`` is exactly zero (degenerate reflections), ``numpy.linalg.inv``
+    will raise ``LinAlgError``, which is caught and re-raised as ``ValueError``.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> import math
+    >>> g = ahd.psic()
+    >>> g.wavelength = 2 * math.pi
+    >>> g.sample.lattice = ahd.Lattice(a=2 * math.pi)
+    >>> g.add_reflection("r1", hkl=(1, 0, 0),
+    ...     angles={"mu": 0, "eta": 30, "chi": 0, "phi": 0, "nu": 0, "delta": 60})
+    >>> g.add_reflection("r2", hkl=(0, 1, 0),
+    ...     angles={"mu": 0, "eta": 30, "chi": 0, "phi": 90, "nu": 0, "delta": 60})
+    >>> g.add_reflection("r3", hkl=(0, 0, 1),
+    ...     angles={"mu": 0, "eta": 30, "chi": 90, "phi": 30, "nu": 0, "delta": 60})
+    >>> UB = ahd.ub_from_three_reflections_bl1967(g.sample, "r1", "r2", "r3")
+
+    References
+    ----------
+    Busing & Levy, Acta Cryst. 22, 457-464 (1967), eqs. 28-31.
+    """
+    import warnings
+
+    from .reflection import Reflection
+
+    # --- Require a parent geometry -------------------------------------------
+    if sample.parent is None:
+        raise ValueError(
+            "ub_from_three_reflections_bl1967 requires sample.parent to be set "
+            "(an AdHocDiffractometer with wavelength).  Attach the sample to a "
+            "geometry before calling this function."
+        )
+    geometry = sample.parent
+
+    # --- Resolve reflections -------------------------------------------------
+    def _resolve(r, label: str) -> Reflection:
+        if isinstance(r, str):
+            r = sample.reflections[r]
+        if not isinstance(r, Reflection):
+            raise TypeError(
+                f"{label} must be a Reflection or a name string; "
+                f"got {type(r).__name__!r}."
+            )
+        return r
+
+    r1 = _resolve(r1, "r1")
+    r2 = _resolve(r2, "r2")
+    r3 = _resolve(r3, "r3")
+
+    # --- Phi-frame scattering vectors ----------------------------------------
+    h1_phi = angles_to_phi_vector(geometry, **r1.angles)
+    h2_phi = angles_to_phi_vector(geometry, **r2.angles)
+    h3_phi = angles_to_phi_vector(geometry, **r3.angles)
+
+    # --- Column matrices Hφ and H -------------------------------------------
+    H_phi = np.column_stack([h1_phi, h2_phi, h3_phi])  # 3×3
+    H = np.column_stack(
+        [
+            np.asarray(r1.hkl, dtype=float),
+            np.asarray(r2.hkl, dtype=float),
+            np.asarray(r3.hkl, dtype=float),
+        ]
+    )  # 3×3
+
+    # --- Check H is non-singular --------------------------------------------
+    det_H = float(np.linalg.det(H))
+    tol = 1e-10
+    if abs(det_H) < tol:
+        raise ValueError(
+            "The three reflections are coplanar in reciprocal space: "
+            f"det(H) = {det_H:.3g} ≈ 0.  Choose three reflections whose "
+            "Miller-index vectors are linearly independent."
+        )
+
+    if det_H < 0:
+        warnings.warn(
+            f"det(H) = {det_H:.6g} < 0: the three hkl triples form a "
+            "left-handed system.  U may have det(U) = -1.  Consider "
+            "swapping r1 and r2 to restore a right-handed system.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # --- BL1967 eq. 31: UB = Hφ @ H⁻¹ -------------------------------------
+    try:
+        H_inv = np.linalg.inv(H)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(
+            "Cannot invert the Miller-index matrix H; the three reflections "
+            "are linearly dependent (coplanar in reciprocal space)."
+        ) from exc
+
+    UB = H_phi @ H_inv
+
+    # --- Derive U = UB @ B⁻¹ -----------------------------------------------
+    B = sample.lattice.B
+    try:
+        B_inv = np.linalg.inv(B)
+    except np.linalg.LinAlgError:
+        U = None
+    else:
+        U = UB @ B_inv
+
+    # --- Store in-place (UB first, then U) ----------------------------------
+    sample.UB = UB
+    sample.U = U
     return UB
 
 

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -13,6 +13,9 @@ Covers:
     of |Q| from sample rotations, angle restoration, error cases
   - ub_from_two_reflections_bl1967(): orthonormal U, UB=U@B, direction checks,
     default or1/or2 resolution, string/object reflection args, error cases
+  - ub_from_three_reflections_bl1967(): UB@hi==h_phi_i for all three, orthonormal U,
+    U=I recovery for aligned crystal, string/object args, error cases (singular H,
+    no parent, bad types), warning for left-handed H
 """
 
 import math
@@ -26,6 +29,7 @@ from ad_hoc_diffractometer import angles_to_phi_vector
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import psic
 from ad_hoc_diffractometer import ub_from_one_reflection
+from ad_hoc_diffractometer import ub_from_three_reflections_bl1967
 from ad_hoc_diffractometer import ub_from_two_reflections_bl1967
 from ad_hoc_diffractometer import ub_identity
 from ad_hoc_diffractometer.reflection import ReflectionList
@@ -783,3 +787,220 @@ def test_two_refl_collinear_phi_frame_raises(psic_geom):
     psic_geom.sample.reflections.setor2("r2")
     with pytest.raises(ValueError, match=re.escape("parallel in the phi frame")):
         ub_from_two_reflections_bl1967(psic_geom.sample)
+
+
+# ---------------------------------------------------------------------------
+# ub_from_three_reflections_bl1967()
+# ---------------------------------------------------------------------------
+#
+# "Clean" test case: psic geometry, cubic a = 1 Å (B = I), λ = 2π Å.
+# With U = I (identity orientation), UB = B = I.
+#
+# Motor angles chosen so each reflection gives Q_phi along a principal axis:
+#   r1: hkl=(1,0,0), eta=30, chi=0,  phi=0  → Q_phi ‖ XHAT = (1,0,0)
+#   r2: hkl=(0,1,0), eta=30, chi=0,  phi=90 → Q_phi ‖ YHAT = (0,1,0)
+#   r3: hkl=(0,0,1), eta=30, chi=90, phi=30 → Q_phi ‖ ZHAT = (0,0,1)
+#
+# For this geometry λ=2π, a=1 → B=I, so BL1967 must recover U=I exactly.
+
+_LAT_A1 = Lattice(a=1.0)  # cubic a=1 → B = identity
+_R3_HKL = (0, 0, 1)
+_R3_ANG = {"mu": 0.0, "eta": 30.0, "chi": 90.0, "phi": 30.0, "nu": 0.0, "delta": 60.0}
+
+
+@pytest.fixture
+def three_refl_geom():
+    """
+    psic geometry with cubic a=1 lattice (B=I) and three orthogonal reflections.
+
+    Motor angles are constructed so that U = I is the exact solution
+    (Q_phi_i = B @ h_i = h_i for each reflection).
+    """
+    g = psic()
+    g.wavelength = _TWO_PI
+    g.sample.lattice = _LAT_A1
+    g.add_reflection("r1", hkl=_R1_HKL_2PI, angles=_R1_ANG_2PI)
+    g.add_reflection("r2", hkl=_R2_HKL_2PI, angles=_R2_ANG_2PI)
+    g.add_reflection("r3", hkl=_R3_HKL, angles=_R3_ANG)
+    return g
+
+
+# --- mathematical correctness -----------------------------------------------
+
+
+def test_three_refl_UB_times_h_equals_h_phi_r1(three_refl_geom):
+    """UB @ h1 must equal Q_phi of r1 exactly (fundamental BL1967 guarantee)."""
+    g = three_refl_geom
+    UB = ub_from_three_reflections_bl1967(g.sample, "r1", "r2", "r3")
+    h_phi = angles_to_phi_vector(g, **_R1_ANG_2PI)
+    np.testing.assert_allclose(
+        UB @ np.array(_R1_HKL_2PI, dtype=float), h_phi, atol=1e-10
+    )
+
+
+def test_three_refl_UB_times_h_equals_h_phi_r2(three_refl_geom):
+    """UB @ h2 must equal Q_phi of r2 exactly."""
+    g = three_refl_geom
+    UB = ub_from_three_reflections_bl1967(g.sample, "r1", "r2", "r3")
+    h_phi = angles_to_phi_vector(g, **_R2_ANG_2PI)
+    np.testing.assert_allclose(
+        UB @ np.array(_R2_HKL_2PI, dtype=float), h_phi, atol=1e-10
+    )
+
+
+def test_three_refl_UB_times_h_equals_h_phi_r3(three_refl_geom):
+    """UB @ h3 must equal Q_phi of r3 exactly."""
+    g = three_refl_geom
+    UB = ub_from_three_reflections_bl1967(g.sample, "r1", "r2", "r3")
+    h_phi = angles_to_phi_vector(g, **_R3_ANG)
+    np.testing.assert_allclose(UB @ np.array(_R3_HKL, dtype=float), h_phi, atol=1e-10)
+
+
+def test_three_refl_U_is_orthonormal(three_refl_geom):
+    """U returned by BL1967 must satisfy U.T @ U = I and det(U) = 1."""
+    ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    U = three_refl_geom.sample.U
+    np.testing.assert_allclose(U.T @ U, np.eye(3), atol=1e-10)
+    assert abs(np.linalg.det(U) - 1.0) < 1e-10
+
+
+def test_three_refl_U_identity_for_aligned_crystal(three_refl_geom):
+    """When angles are consistent with U=I and B=I, BL1967 must recover U=I."""
+    ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    np.testing.assert_allclose(three_refl_geom.sample.U, np.eye(3), atol=1e-10)
+
+
+def test_three_refl_UB_equals_B_for_identity_crystal(three_refl_geom):
+    """When U=I and B=I, UB must equal B = I."""
+    UB = ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    np.testing.assert_allclose(UB, three_refl_geom.sample.lattice.B, atol=1e-10)
+
+
+def test_three_refl_UB_is_computed_first(three_refl_geom):
+    """sample.UB is set before sample.U (UB computed first, U derived from it)."""
+    # We cannot observe the order directly; verify both are set and UB = H_phi @ H^-1
+    UB = ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    assert three_refl_geom.sample.UB is UB
+    assert three_refl_geom.sample.U is not None
+
+
+def test_three_refl_returns_UB_array(three_refl_geom):
+    """Return value is a (3,3) ndarray equal to sample.UB."""
+    UB = ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    assert isinstance(UB, np.ndarray)
+    assert UB.shape == (3, 3)
+    np.testing.assert_array_equal(UB, three_refl_geom.sample.UB)
+
+
+def test_three_refl_updates_sample_in_place(three_refl_geom):
+    """sample.UB and sample.U are set in-place (both None before the call)."""
+    assert three_refl_geom.sample.UB is None
+    assert three_refl_geom.sample.U is None
+    ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    assert three_refl_geom.sample.UB is not None
+    assert three_refl_geom.sample.U is not None
+
+
+# --- reflection argument variants -------------------------------------------
+
+
+def test_three_refl_string_args(three_refl_geom):
+    """r1, r2, r3 may be supplied as name strings."""
+    UB = ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "r3")
+    assert UB.shape == (3, 3)
+
+
+def test_three_refl_reflection_objects(three_refl_geom):
+    """r1, r2, r3 may be supplied as Reflection objects."""
+    g = three_refl_geom
+    r1_obj = g.sample.reflections["r1"]
+    r2_obj = g.sample.reflections["r2"]
+    r3_obj = g.sample.reflections["r3"]
+    UB = ub_from_three_reflections_bl1967(g.sample, r1_obj, r2_obj, r3_obj)
+    assert UB.shape == (3, 3)
+
+
+def test_three_refl_mixed_string_and_object(three_refl_geom):
+    """r1 as string, r2 as Reflection, r3 as string — all combinations work."""
+    g = three_refl_geom
+    r2_obj = g.sample.reflections["r2"]
+    UB = ub_from_three_reflections_bl1967(g.sample, "r1", r2_obj, "r3")
+    assert UB.shape == (3, 3)
+
+
+# --- error cases ------------------------------------------------------------
+
+
+def test_three_refl_no_parent_raises():
+    """Raises ValueError when sample has no parent geometry."""
+    rl = ReflectionList(
+        geometry_name="psic",
+        valid_stages={"mu", "eta", "chi", "phi", "nu", "delta"},
+    )
+    rl.add("r1", hkl=(1, 0, 0), angles={"mu": 0.0})
+    rl.add("r2", hkl=(0, 1, 0), angles={"mu": 0.0})
+    rl.add("r3", hkl=(0, 0, 1), angles={"mu": 0.0})
+    sample = Sample(name="orphan", lattice=Lattice(a=1.0), reflections=rl)
+    with pytest.raises(ValueError, match=re.escape("sample.parent")):
+        ub_from_three_reflections_bl1967(sample, "r1", "r2", "r3")
+
+
+def test_three_refl_r1_unknown_string_raises(three_refl_geom):
+    """Raises KeyError when r1 is a string not in the reflection list."""
+    with pytest.raises(KeyError):
+        ub_from_three_reflections_bl1967(three_refl_geom.sample, "no_such", "r2", "r3")
+
+
+def test_three_refl_r2_unknown_string_raises(three_refl_geom):
+    """Raises KeyError when r2 is a string not in the reflection list."""
+    with pytest.raises(KeyError):
+        ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "no_such", "r3")
+
+
+def test_three_refl_r3_unknown_string_raises(three_refl_geom):
+    """Raises KeyError when r3 is a string not in the reflection list."""
+    with pytest.raises(KeyError):
+        ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", "no_such")
+
+
+def test_three_refl_r1_bad_type_raises(three_refl_geom):
+    """Raises TypeError when r1 is not a Reflection or string."""
+    with pytest.raises(TypeError, match=re.escape("r1 must be a Reflection")):
+        ub_from_three_reflections_bl1967(three_refl_geom.sample, 42, "r2", "r3")
+
+
+def test_three_refl_r3_bad_type_raises(three_refl_geom):
+    """Raises TypeError when r3 is not a Reflection or string."""
+    with pytest.raises(TypeError, match=re.escape("r3 must be a Reflection")):
+        ub_from_three_reflections_bl1967(three_refl_geom.sample, "r1", "r2", 3.14)
+
+
+def test_three_refl_coplanar_hkl_raises(psic_geom):
+    """Raises ValueError when the three hkl vectors are coplanar (singular H)."""
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_A1
+    # (1,0,0), (2,0,0), (3,0,0) are all on the same line → coplanar
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_R1_ANG_2PI)
+    psic_geom.add_reflection("r2", hkl=(2, 0, 0), angles=_R2_ANG_2PI)
+    psic_geom.add_reflection("r3", hkl=(3, 0, 0), angles=_R3_ANG)
+    with pytest.raises(ValueError, match=re.escape("coplanar")):
+        ub_from_three_reflections_bl1967(psic_geom.sample, "r1", "r2", "r3")
+
+
+def test_three_refl_left_handed_H_warns(psic_geom):
+    """Issues UserWarning when det(H) < 0 (left-handed hkl triple)."""
+    import warnings
+
+    psic_geom.wavelength = _TWO_PI
+    psic_geom.sample.lattice = _LAT_A1
+    # Swap r2 and r3 so det([[1,0,0],[0,0,1],[0,1,0]]) = -1
+    psic_geom.add_reflection("r1", hkl=(1, 0, 0), angles=_R1_ANG_2PI)
+    psic_geom.add_reflection("r2", hkl=(0, 0, 1), angles=_R3_ANG)
+    psic_geom.add_reflection("r3", hkl=(0, 1, 0), angles=_R2_ANG_2PI)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ub_from_three_reflections_bl1967(psic_geom.sample, "r1", "r2", "r3")
+    assert any(
+        "left-handed" in str(w.message).lower() or "det(H)" in str(w.message)
+        for w in caught
+    ), f"Expected left-handed warning; got: {[str(w.message) for w in caught]}"


### PR DESCRIPTION
## Summary

- Implements `ub_from_three_reflections_bl1967()` in `orientation.py` using the BL1967 direct method (eqs. 28-31)
- No prior lattice needed: `UB = Hφ @ H⁻¹` directly; `U = UB @ B⁻¹` derived afterward
- Raises `ValueError` for coplanar reflections; warns if `det(H) < 0`
- 20 new tests (540 total, all pass); roadmap section 2.2 checked

- closes #6

### Algorithm

1. For each reflection, `angles_to_phi_vector()` gives `hiφ`.
2. Stack column matrices: `Hφ = [h1φ|h2φ|h3φ]`, `H = [h1|h2|h3]`.
3. `UB = Hφ @ H⁻¹` (BL1967 eq. 31) — computed first.
4. `U = UB @ B⁻¹` derived from UB — stored second.

Contributed by: OpenCode (argo/claudesonnet46)