### PR TITLE
feat: wh and pa as @property on AdHocDiffractometer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ for the full issue tracker.
 
 ### Added
 
+- `AdHocDiffractometer.wh` and `AdHocDiffractometer.pa` properties (#51):
+  access the terse/verbose status strings as ``g.wh`` / ``g.pa`` without
+  needing to import the module-level functions; module-level ``wh(g)`` and
+  ``pa(g)`` remain as thin wrappers for backward compatibility
 - Azimuthal reference vector and ψ angle (#11):
   - ``AdHocDiffractometer.azimuthal_reference``: stores the reference
     direction as Miller indices (h, k, l); default ``None``; validated as

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -401,6 +401,17 @@ to a chosen reference direction.  Two important classes:
 - [ ] Raised by users; priority to be determined once Priority 1 and 2
       items are complete
 
+### 3.7a Refactor `wh` and `pa` as methods ([#51](https://github.com/prjemian/ad_hoc_diffractometer/issues/51))
+
+Move `wh()` and `pa()` from standalone functions in `status.py` to methods
+on `AdHocDiffractometer`, while keeping the module-level functions as
+thin wrappers for backward compatibility.
+
+- [x] Add `AdHocDiffractometer.wh` property (delegates to `status.wh(self)`)
+- [x] Add `AdHocDiffractometer.pa` property (delegates to `status.pa(self)`)
+- [x] Module-level `wh(geometry)` and `pa(geometry)` remain as thin wrappers
+- [x] Tests: `g.wh` and `g.pa` return the same string as `wh(g)` / `pa(g)`
+
 ### 3.7b `wh()` and `pa()` status commands ([#38](https://github.com/prjemian/ad_hoc_diffractometer/issues/38))
 
 - [x] `wh(geometry)` — terse one-screen status: current HKL (via `inverse()`),
@@ -411,6 +422,25 @@ to a chosen reference direction.  Two important classes:
 - [x] Both functions return a `str`; graceful fallback when UB or wavelength
       not set; modelled on Align4Pete.log SPEC output
 - [x] Exported from `__init__.py`; 35 tests in `test_status.py`
+
+### 3.7c Export and restore full diffractometer settings ([#52](https://github.com/prjemian/ad_hoc_diffractometer/issues/52))
+
+Serialize the complete diffractometer configuration — geometry, samples,
+lattice, reflections, UB matrices, wavelength, azimuthal reference — to
+and from a JSON-compatible dictionary.  Supports documentation, archival,
+diagnostics, and programmatic reconstruction.
+
+- [ ] Each class (`AdHocDiffractometer`, `Sample`, `Lattice`,
+      `ReflectionList`, `Reflection`, `Stage`) exposes a `to_dict()`
+      method returning a JSON-serialisable ``dict``
+- [ ] Matching `from_dict()` class methods reconstruct each object from
+      such a dict
+- [ ] Top-level dict includes metadata: creation timestamp, software name
+      (``"ad_hoc_diffractometer"``), and package version
+- [ ] Round-trip: ``from_dict(obj.to_dict())`` reproduces the object
+      (verified by ``__eq__``)
+- [ ] Tests covering each class, full geometry round-trip, and JSON
+      serialisability
 
 ### 3.8 Energy / wave-number conversions and named radiation lines ([#21](https://github.com/prjemian/ad_hoc_diffractometer/issues/21))
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -722,6 +722,79 @@ class AdHocDiffractometer:
         sin_psi = float(np.dot(Q_hat, np.cross(y_perp_hat, n_perp_hat)))
         return math.degrees(math.atan2(sin_psi, cos_psi))
 
+    @property
+    def wh(self) -> str:
+        """
+        Terse one-screen status string (the SPEC ``wh`` command).
+
+        Returns the same string as ``status.wh(self)``: current H K L
+        position, azimuthal angle ψ, wavelength, and a motor-angle table
+        with SPEC-style column names.
+
+        Read as a property so the call site reads naturally::
+
+            print(g.wh)
+
+        Returns
+        -------
+        str
+            Multi-line status string, ready to ``print()``.
+
+        See Also
+        --------
+        ad_hoc_diffractometer.status.wh : Module-level function (thin wrapper).
+
+        Examples
+        --------
+        >>> import ad_hoc_diffractometer as ahd
+        >>> g = ahd.fourcv()
+        >>> g.wavelength = 1.5406
+        >>> print(g.wh)
+        H K L = not available
+        Psi = not available
+        Lambda = 1.5406
+        <BLANKLINE>
+          TwoTheta     Theta       Chi       Phi
+             0.000     0.000     0.000     0.000
+        """
+        from .status import wh as _wh
+
+        return _wh(self)
+
+    @property
+    def pa(self) -> str:
+        """
+        Verbose parameter listing (the SPEC ``pa`` command).
+
+        Returns the same string as ``status.pa(self)``: geometry name,
+        primary and secondary orienting reflections, lattice constants
+        in real and reciprocal space, azimuthal reference, and wavelength.
+
+        Read as a property so the call site reads naturally::
+
+            print(g.pa)
+
+        Returns
+        -------
+        str
+            Multi-line parameter string, ready to ``print()``.
+
+        See Also
+        --------
+        ad_hoc_diffractometer.status.pa : Module-level function (thin wrapper).
+
+        Examples
+        --------
+        >>> import ad_hoc_diffractometer as ahd
+        >>> g = ahd.fourcv()
+        >>> print(g.pa)                     # doctest: +ELLIPSIS
+        Geometry: fourcv
+        ...
+        """
+        from .status import pa as _pa
+
+        return _pa(self)
+
     def sample_rotation_matrix(self) -> np.ndarray:
         """
         Compute the total sample rotation matrix Z = R_floor * ... * R_top.

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -10,6 +10,8 @@ Covers:
   - Both functions work with no UB set (graceful fallback)
   - Both functions work with no wavelength set (graceful fallback)
   - Regression against Align4Pete.log output values
+  - g.wh and g.pa properties (#51): property access returns the same
+    string as the module-level functions; both are @property descriptors
 """
 
 import pytest
@@ -246,3 +248,70 @@ class TestPa:
                 break
         else:
             pytest.fail("No 'reciprocal space' line found in pa() output")
+
+
+# ---------------------------------------------------------------------------
+# g.wh and g.pa properties (#51)
+# ---------------------------------------------------------------------------
+
+
+class TestWhPaProperties:
+    """g.wh and g.pa are @property descriptors on AdHocDiffractometer."""
+
+    def test_wh_is_property(self):
+        """AdHocDiffractometer.wh must be a property descriptor."""
+        from ad_hoc_diffractometer import AdHocDiffractometer
+
+        assert isinstance(AdHocDiffractometer.wh, property)
+
+    def test_pa_is_property(self):
+        """AdHocDiffractometer.pa must be a property descriptor."""
+        from ad_hoc_diffractometer import AdHocDiffractometer
+
+        assert isinstance(AdHocDiffractometer.pa, property)
+
+    def test_wh_property_equals_function(self, sapphire_geom):
+        """g.wh returns the same string as wh(g)."""
+        assert sapphire_geom.wh == wh(sapphire_geom)
+
+    def test_pa_property_equals_function(self, sapphire_geom):
+        """g.pa returns the same string as pa(g)."""
+        assert sapphire_geom.pa == pa(sapphire_geom)
+
+    def test_wh_property_returns_str(self, bare_geom):
+        """g.wh returns a str even when nothing is configured."""
+        bare_geom.wavelength = 1.5406
+        assert isinstance(bare_geom.wh, str)
+
+    def test_pa_property_returns_str(self, bare_geom):
+        """g.pa returns a str even when nothing is configured."""
+        bare_geom.wavelength = 1.5406
+        assert isinstance(bare_geom.pa, str)
+
+    def test_wh_property_contains_hkl(self, sapphire_geom):
+        """g.wh contains the 'H K L' line."""
+        assert "H K L" in sapphire_geom.wh
+
+    def test_pa_property_contains_geometry_name(self, sapphire_geom):
+        """g.pa contains the geometry name."""
+        assert "fourcv" in sapphire_geom.pa
+
+    def test_wh_property_not_callable(self, sapphire_geom):
+        """g.wh is a str, not callable — consistent with property semantics."""
+        assert not callable(sapphire_geom.wh)
+
+    def test_pa_property_not_callable(self, sapphire_geom):
+        """g.pa is a str, not callable — consistent with property semantics."""
+        assert not callable(sapphire_geom.pa)
+
+    def test_wh_property_same_result_psic(self):
+        """g.wh works for psic geometry too."""
+        g = psic()
+        g.wavelength = 1.5406
+        assert g.wh == wh(g)
+
+    def test_pa_property_same_result_psic(self):
+        """g.pa works for psic geometry too."""
+        g = psic()
+        g.wavelength = 1.5406
+        assert g.pa == pa(g)


### PR DESCRIPTION
## Summary

- Adds `AdHocDiffractometer.wh` and `AdHocDiffractometer.pa` as read-only `@property` descriptors
- Both delegate to the existing module-level `status.wh(g)` / `status.pa(g)` functions
- Module-level functions unchanged (backward compatible)
- 12 new tests; 727 total pass; roadmap section 3.7a checked

- closes #51

### Usage

```python
g = ahd.fourcv()
g.wavelength = 1.5406
print(g.wh)   # terse: HKL, Psi, Lambda, motor table
print(g.pa)   # verbose: geometry, reflections, lattice, reference, lambda
```

Contributed by: OpenCode (argo/claudesonnet46)