### PR TITLE
refactor: wh() and pa() as methods with print=True kwarg

### DIFF
--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -5,6 +5,8 @@ Describes a diffractometer as an ordered collection of rotary stages.
 The stacking order is encoded via the parent attribute of each Stage.
 """
 
+import builtins
+
 import numpy as np
 
 from .constants import XHAT
@@ -722,8 +724,7 @@ class AdHocDiffractometer:
         sin_psi = float(np.dot(Q_hat, np.cross(y_perp_hat, n_perp_hat)))
         return math.degrees(math.atan2(sin_psi, cos_psi))
 
-    @property
-    def wh(self) -> str:
+    def wh(self, print: bool = True) -> str:
         """
         Terse one-screen status string (the SPEC ``wh`` command).
 
@@ -732,33 +733,40 @@ class AdHocDiffractometer:
         column names.  Graceful fallback text is shown for any field
         that cannot be computed (e.g. no UB matrix or no wavelength).
 
-        Read as a property so the call site reads naturally::
-
-            print(g.wh)
+        Parameters
+        ----------
+        print : bool, optional
+            If ``True`` (default), the string is printed to stdout before
+            being returned.  Pass ``print=False`` to suppress output and
+            capture the string instead (useful in tests and logging).
 
         Returns
         -------
         str
-            Multi-line status string, ready to ``print()``.
+            Multi-line status string.
 
         Examples
         --------
         >>> import ad_hoc_diffractometer as ahd
         >>> g = ahd.fourcv()
         >>> g.wavelength = 1.5406
-        >>> print(g.wh)
+        >>> g.wh()                          # prints and returns
         H K L = not available
         Psi = not available
         Lambda = 1.5406
         <BLANKLINE>
           TwoTheta     Theta       Chi       Phi
              0.000     0.000     0.000     0.000
+        >>> out = g.wh(print=False)         # capture without printing
+        >>> "Lambda" in out
+        True
 
         References
         ----------
         Align4Pete.log — ``wh`` command outputs, 7-ID-C fourc session,
         Dec 2020.
         """
+        _print = builtins.print
         lines: list[str] = []
 
         # HKL position
@@ -789,10 +797,12 @@ class AdHocDiffractometer:
         lines.append("".join(f"{self._spec_motor_name(n):>10s}" for n in stage_names))
         lines.append("".join(f"{self._stages[n].angle:>10.3f}" for n in stage_names))
 
-        return "\n".join(lines)
+        result = "\n".join(lines)
+        if print:
+            _print(result)
+        return result
 
-    @property
-    def pa(self) -> str:
+    def pa(self, print: bool = True) -> str:
         """
         Verbose parameter listing (the SPEC ``pa`` command).
 
@@ -800,28 +810,35 @@ class AdHocDiffractometer:
         (if set), lattice constants in real and reciprocal space, the
         azimuthal reference vector, and the wavelength.
 
-        Read as a property so the call site reads naturally::
-
-            print(g.pa)
+        Parameters
+        ----------
+        print : bool, optional
+            If ``True`` (default), the string is printed to stdout before
+            being returned.  Pass ``print=False`` to suppress output and
+            capture the string instead (useful in tests and logging).
 
         Returns
         -------
         str
-            Multi-line parameter string, ready to ``print()``.
+            Multi-line parameter string.
 
         Examples
         --------
         >>> import ad_hoc_diffractometer as ahd
         >>> g = ahd.fourcv()
-        >>> print(g.pa)                     # doctest: +ELLIPSIS
+        >>> g.pa()                          # prints and returns
         Geometry: fourcv
         ...
+        >>> out = g.pa(print=False)         # capture without printing
+        >>> "Geometry" in out
+        True
 
         References
         ----------
         Align4Pete.log — ``pa`` command outputs, 7-ID-C fourc session,
         Dec 2020.
         """
+        _print = builtins.print
         lines: list[str] = []
         lines.append(f"Geometry: {self.name}")
         lines.append("")
@@ -903,10 +920,13 @@ class AdHocDiffractometer:
         lam = self.wavelength
         lines.append(f"  Lambda = {lam:g}" if lam is not None else "  Lambda = not set")
 
-        return "\n".join(lines)
+        result = "\n".join(lines)
+        if print:
+            _print(result)
+        return result
 
     # ------------------------------------------------------------------
-    # Private status helpers (used by wh and pa properties)
+    # Private status helpers (used by wh and pa methods)
     # ------------------------------------------------------------------
 
     @staticmethod

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -11,8 +11,8 @@ Covers:
   - azimuthal_reference property: storage, validation, default None
   - psi() method: psi=0 when n in scattering plane, psi=90 when n perp,
     uses current angles when called with no args, error cases
-  - wh property: @property descriptor, str output, content, graceful fallbacks
-  - pa property: @property descriptor, str output, content, graceful fallbacks
+  - wh(print=False): str output, content, graceful fallbacks, stdout control
+  - pa(print=False): str output, content, graceful fallbacks, stdout control
   - _spec_motor_name static helper: SPEC column-name mapping
 """
 
@@ -937,31 +937,31 @@ def test_psi_pa_shows_azimuthal_reference():
     g = fourcv()
     g.wavelength = 1.5406
     g.azimuthal_reference = (0, 0, 1)
-    assert "Azimuthal Reference" in g.pa
-    assert "0  0  1" in g.pa
+    assert "Azimuthal Reference" in g.pa(print=False)
+    assert "0  0  1" in g.pa(print=False)
 
 
 def test_psi_pa_shows_not_set_when_none():
-    """pa property shows 'not set' for azimuthal reference when not configured."""
+    """pa method shows 'not set' for azimuthal reference when not configured."""
     from ad_hoc_diffractometer import fourcv
 
     g = fourcv()
     g.wavelength = 1.5406
-    assert "not set" in g.pa
+    assert "not set" in g.pa(print=False)
 
 
 def test_psi_wh_shows_psi_when_available():
-    """wh property includes a Psi line when psi can be computed."""
+    """wh method includes a Psi line when psi can be computed."""
     g = _fourcv_identity()
     g.set_angle("omega", 30.0)
     g.set_angle("chi", 0.0)
     g.set_angle("phi", 0.0)
     g.set_angle("two_theta", 60.0)
-    assert "Psi" in g.wh
+    assert "Psi" in g.wh(print=False)
 
 
 def test_psi_wh_shows_not_available_when_no_reference():
-    """wh property shows 'not available' for Psi when reference is not set."""
+    """wh method shows 'not available' for Psi when reference is not set."""
     from ad_hoc_diffractometer import Lattice
     from ad_hoc_diffractometer import fourcv
     from ad_hoc_diffractometer import ub_identity
@@ -970,9 +970,9 @@ def test_psi_wh_shows_not_available_when_no_reference():
     g.wavelength = 2 * _math.pi
     g.sample.lattice = Lattice(a=1.0)
     ub_identity(g.sample)
-    # No azimuthal_reference set
-    assert "Psi" in g.wh
-    assert "not available" in g.wh
+    out = g.wh(print=False)
+    assert "Psi" in out
+    assert "not available" in out
 
 
 # ---------------------------------------------------------------------------
@@ -1000,43 +1000,45 @@ def test_spec_motor_name(internal, expected):
 
 
 # ---------------------------------------------------------------------------
-# wh and pa properties
+# wh() and pa() methods
 # ---------------------------------------------------------------------------
 
 
-class TestWhProperty:
-    """Tests for AdHocDiffractometer.wh — all via the property, no imports."""
+class TestWhMethod:
+    """Tests for AdHocDiffractometer.wh(print=False) — capture mode."""
 
-    def test_wh_is_property_descriptor(self):
-        assert isinstance(AdHocDiffractometer.wh, property)
+    def test_wh_is_callable(self):
+        from ad_hoc_diffractometer import fourcv
+
+        assert callable(fourcv().wh)
 
     def test_wh_returns_str(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert isinstance(g.wh, str)
+        assert isinstance(g.wh(print=False), str)
 
     def test_wh_contains_hkl(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "H K L" in g.wh
+        assert "H K L" in g.wh(print=False)
 
     def test_wh_contains_lambda(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "1.5406" in g.wh
+        assert "1.5406" in g.wh(print=False)
 
     def test_wh_contains_motor_table(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        out = g.wh
+        out = g.wh(print=False)
         assert "TwoTheta" in out
         assert "Theta" in out
 
@@ -1045,90 +1047,120 @@ class TestWhProperty:
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "not available" in g.wh
+        assert "not available" in g.wh(print=False)
 
     def test_wh_graceful_no_wavelength(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
-        assert "H K L" in g.wh
-        assert "Lambda" in g.wh
+        out = g.wh(print=False)
+        assert "H K L" in out
+        assert "Lambda" in out
 
-    def test_wh_not_callable(self):
+    def test_wh_print_true_prints(self, capsys):
+        """Default print=True writes to stdout."""
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
-        assert not callable(g.wh)
+        g.wavelength = 1.5406
+        g.wh()
+        captured = capsys.readouterr()
+        assert "Lambda" in captured.out
+
+    def test_wh_print_false_no_stdout(self, capsys):
+        """print=False produces no stdout output."""
+        from ad_hoc_diffractometer import fourcv
+
+        g = fourcv()
+        g.wavelength = 1.5406
+        g.wh(print=False)
+        assert capsys.readouterr().out == ""
 
     def test_wh_psic_stage_names(self):
         from ad_hoc_diffractometer import psic
 
         g = psic()
         g.wavelength = 1.5406
-        out = g.wh
+        out = g.wh(print=False)
         assert "Mu" in out
         assert "Eta" in out
         assert "Nu" in out
         assert "Delta" in out
 
 
-class TestPaProperty:
-    """Tests for AdHocDiffractometer.pa — all via the property, no imports."""
+class TestPaMethod:
+    """Tests for AdHocDiffractometer.pa(print=False) — capture mode."""
 
-    def test_pa_is_property_descriptor(self):
-        assert isinstance(AdHocDiffractometer.pa, property)
+    def test_pa_is_callable(self):
+        from ad_hoc_diffractometer import fourcv
+
+        assert callable(fourcv().pa)
 
     def test_pa_returns_str(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert isinstance(g.pa, str)
+        assert isinstance(g.pa(print=False), str)
 
     def test_pa_contains_geometry_name(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "fourcv" in g.pa
+        assert "fourcv" in g.pa(print=False)
 
     def test_pa_contains_lattice_section(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "Lattice" in g.pa
+        assert "Lattice" in g.pa(print=False)
 
     def test_pa_contains_wavelength(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "1.5406" in g.pa
+        assert "1.5406" in g.pa(print=False)
 
     def test_pa_no_reflections_shows_not_set(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
         g.wavelength = 1.5406
-        assert "not set" in g.pa
+        assert "not set" in g.pa(print=False)
 
     def test_pa_graceful_no_wavelength(self):
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
-        assert "fourcv" in g.pa
-        assert "Lattice" in g.pa
+        out = g.pa(print=False)
+        assert "fourcv" in out
+        assert "Lattice" in out
 
-    def test_pa_not_callable(self):
+    def test_pa_print_true_prints(self, capsys):
+        """Default print=True writes to stdout."""
         from ad_hoc_diffractometer import fourcv
 
         g = fourcv()
-        assert not callable(g.pa)
+        g.wavelength = 1.5406
+        g.pa()
+        captured = capsys.readouterr()
+        assert "Geometry" in captured.out
+
+    def test_pa_print_false_no_stdout(self, capsys):
+        """print=False produces no stdout output."""
+        from ad_hoc_diffractometer import fourcv
+
+        g = fourcv()
+        g.wavelength = 1.5406
+        g.pa(print=False)
+        assert capsys.readouterr().out == ""
 
     def test_pa_psic_geometry_name(self):
         from ad_hoc_diffractometer import psic
 
         g = psic()
         g.wavelength = 1.5406
-        assert "psic" in g.pa
+        assert "psic" in g.pa(print=False)


### PR DESCRIPTION
## Summary

Converts `wh` and `pa` from `@property` to regular methods with `print=True` (default).

- closes #51

### API

```python
g.wh()              # prints to stdout — no print() wrapper needed
g.pa()              # prints to stdout — no print() wrapper needed

out = g.wh(print=False)   # capture string, no output (tests / logging)
out = g.pa(print=False)   # capture string, no output
```

### Design
- `print=True` default: common interactive use needs no wrapping
- `print=False`: clean for tests (`capsys`-verified) and logging
- `builtins.print` aliased before the parameter shadows it

### Tests added
- `test_wh_print_true_prints` / `test_pa_print_true_prints` — `capsys` confirms stdout output
- `test_wh_print_false_no_stdout` / `test_pa_print_false_no_stdout` — confirms silence

800 tests pass.

Contributed by: OpenCode (argo/claudesonnet46)