### PR TITLE
feat: dynamic versioning via hatch-vcs; expose __version__

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history so hatch-vcs can read git tags
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 references/
+src/ad_hoc_diffractometer/_version.py
 .pytest_cache/
 __pycache__/
 *.py[cod]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,14 @@ for the full issue tracker.
 
 ### Added
 
+- Dynamic versioning via ``hatch-vcs`` (#59): version is now derived from
+  git tags; ``pyproject.toml`` no longer contains a hardcoded version string.
+  Tags follow SemVer (``vMAJOR.minor.patch``); existing ``v0.1`` and ``v0.2``
+  retagged as ``v0.1.0`` and ``v0.2.0``; current development line starts at
+  ``v0.3.0.dev0``.  CI workflow updated with ``fetch-depth: 0`` so tags are
+  available during builds.  ``hatch-vcs`` and ``pytest-cov`` added to the
+  ``dev`` optional-dependency group.
+
 - Export/restore full diffractometer settings (#52): ``to_dict()`` /
   ``from_dict()`` on ``Lattice``, ``Reflection``, ``ReflectionList``,
   ``Sample``, and ``AdHocDiffractometer``; JSON-serialisable; top-level

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -456,13 +456,14 @@ angle calculations.  Depends on #1 (wavelength on `AdHocDiffractometer`).
 
 ### 3.8b Dynamic versioning with hatch-vcs ([#59](https://github.com/prjemian/ad_hoc_diffractometer/issues/59))
 
-- [ ] Add ``hatch-vcs`` to ``[build-system] requires``; remove hardcoded
+- [x] Add ``hatch-vcs`` to ``[build-system] requires``; remove hardcoded
       ``version``; add ``dynamic = ["version"]``
-- [ ] ``[tool.hatch.version] source = "vcs"`` with ``tag-pattern`` requiring
+- [x] ``[tool.hatch.version] source = "vcs"`` with ``tag-pattern`` requiring
       three-component SemVer (``v0.3.0``, etc.); ignores old ``v0.1`` / ``v0.2``
-- [ ] ``[tool.hatch.build.hooks.vcs] version-file`` bakes version into wheel
-- [ ] CI: add ``fetch-depth: 0`` to ``actions/checkout``
-- [ ] Existing tags ``v0.1`` and ``v0.2`` retagged as ``v0.1.0`` and ``v0.2.0``;
+- [x] ``[tool.hatch.build.hooks.vcs] version-file`` bakes version into wheel
+- [x] ``ad_hoc_diffractometer.__version__`` exposed in ``__init__.py``
+- [x] CI: add ``fetch-depth: 0`` to ``actions/checkout``
+- [x] Existing tags ``v0.1`` and ``v0.2`` retagged as ``v0.1.0`` and ``v0.2.0``;
       ``v0.3.0.dev0`` marks start of current development line
 
 ### 3.8c 100% test coverage ([#60](https://github.com/prjemian/ad_hoc_diffractometer/issues/60))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "ad_hoc_diffractometer"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Multi-circle diffractometer geometry and related calculations"
 authors = [{ name = "Pete Jemian", email = "prjemian+chewacla@gmail.com" }]
 maintainers = [{ name = "Pete Jemian", email = "prjemian+chewacla@gmail.com" }]
@@ -18,7 +18,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "hatch-vcs",
     "pytest",
+    "pytest-cov",
 ]
 
 [project.entry-points."ad_hoc_diffractometer.geometries"]
@@ -32,6 +34,15 @@ kappa6c  = "ad_hoc_diffractometer.factories:kappa6c"
 zaxis    = "ad_hoc_diffractometer.factories:zaxis"
 s2d2     = "ad_hoc_diffractometer.factories:s2d2"
 fivec    = "ad_hoc_diffractometer.factories:fivec"
+
+[tool.hatch.version]
+source = "vcs"
+# Require three-component SemVer tags (v0.3.0, v0.4.0, ...);
+# this intentionally ignores the legacy two-component tags v0.1 and v0.2.
+tag-pattern = "v(?P<version>[0-9]+\\.[0-9]+\\.[0-9].*)"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/ad_hoc_diffractometer/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ad_hoc_diffractometer"]

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -2,6 +2,7 @@
 ad_hoc_diffractometer — Multi-circle diffractometer geometry and related calculations.
 """
 
+from ._version import __version__
 from .axes import axis_from_physical
 from .axes import axis_label
 from .axes import kappa_axis
@@ -55,6 +56,8 @@ from .spec import sample_to_g1
 from .stage import Stage
 
 __all__ = [
+    # version
+    "__version__",
     # constants
     "XHAT",
     "YHAT",


### PR DESCRIPTION
## Summary

- Replaces hardcoded `version = "0.2.0"` with `hatch-vcs` dynamic versioning
- `ahd.__version__` now works out of the box
- CI updated with `fetch-depth: 0`; `hatch-vcs` and `pytest-cov` added to dev deps

- closes #59

### Version scheme

| Tag | Produces |
|-----|---------|
| `v0.3.0.dev0` (current HEAD) | `0.3.0.dev1+g...` |
| `v0.3.0` (next release) | `0.3.0` |
| commit after `v0.3.0` | `0.3.0.post1+g...` |

`tag-pattern` requires three-component SemVer — legacy `v0.1` and `v0.2` tags are ignored (retagged as `v0.1.0` and `v0.2.0`).

### Usage

```python
import ad_hoc_diffractometer as ahd
print(ahd.__version__)   # e.g. '0.3.0.dev1+g75c31f3bf'
```

Contributed by: OpenCode (argo/claudesonnet46)