### PR TITLE
feat: logging support across all source modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@ for the full issue tracker.
 
 ### Added
 
+- Logging support (#61): ``logging.getLogger(__name__)`` added to all
+  source modules; root logger ``"ad_hoc_diffractometer"`` lets users
+  configure all package output at once; silent by default (WARNING level);
+  ``logger.debug()`` at broken-plugin skip, Nelder-Mead non-convergence,
+  and wh/to_dict exception catches; ``logger.warning()`` alongside
+  ``warnings.warn`` for left-handed H in ``ub_from_three_reflections_bl1967``.
+
 - 100% test coverage enforced (#60): ``pytest-cov`` configured with
   ``fail_under = 100`` and branch coverage; missing tests distributed
   into their proper test modules (all parametrized where appropriate);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -485,15 +485,18 @@ Current coverage: 93% (119 uncovered lines).  ``pytest-cov`` is installed.
 
 ### 3.8d Add logging support ([#61](https://github.com/prjemian/ad_hoc_diffractometer/issues/61))
 
-- [ ] ``logging.getLogger(__name__)`` in each source module; root logger
+- [x] ``logging.getLogger(__name__)`` in every source module; root logger
       ``"ad_hoc_diffractometer"`` lets users configure all output at once
-- [ ] Default level ``WARNING`` (Python's default) — silent unless user
-      configures a handler
-- [ ] ``logger.debug()`` in ``factories`` broken-plugin skip,
-      ``refinement._nelder_mead_numpy`` non-convergence, ``geometry.wh/pa``
-      silent exception catches
-- [ ] ``logger.warning()`` alongside ``warnings.warn`` in ``orientation.py``
-- [ ] Tests via ``caplog`` fixture; contribute to 100% coverage goal (#60)
+- [x] Default level ``WARNING`` (Python's default) — silent unless user
+      configures a handler; ``warnings.warn`` retained for library-facing alerts
+- [x] ``logger.debug()`` in ``factories`` broken-plugin skip and
+      outer ``entry_points()`` failure; ``refinement._nelder_mead_numpy``
+      non-convergence; ``geometry.wh`` silent HKL and psi exception catches;
+      ``geometry.to_dict`` version-lookup failure
+- [x] ``logger.warning()`` alongside ``warnings.warn`` in
+      ``orientation.ub_from_three_reflections_bl1967`` for left-handed H
+- [x] 5 tests via ``caplog`` fixture in ``test_factories``,
+      ``test_orientation``, ``test_refinement``, and ``test_geometry``
 
 ### 3.8e Sphinx documentation ([#57](https://github.com/prjemian/ad_hoc_diffractometer/issues/57))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -2,6 +2,8 @@
 ad_hoc_diffractometer — Multi-circle diffractometer geometry and related calculations.
 """
 
+import logging
+
 from ._version import __version__
 from .axes import axis_from_physical
 from .axes import axis_label
@@ -54,6 +56,10 @@ from .spec import g1_to_sample
 from .spec import parse_fourc_g1
 from .spec import sample_to_g1
 from .stage import Stage
+
+logger = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     # version

--- a/src/ad_hoc_diffractometer/axes.py
+++ b/src/ad_hoc_diffractometer/axes.py
@@ -28,11 +28,15 @@ International Tables for Crystallography, Vol. C, Section 2.2.6 (2006).
     Confirms kappa axis tilted 50° from the omega (vertical) axis.
 """
 
+import logging
+
 import numpy as np
 
 from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Canonical signed-axis string notation
@@ -193,6 +197,7 @@ def kappa_axis(alpha_deg: float, basis: dict | None = None) -> np.ndarray:
 
     The kappa axis lies in the vertical-lateral plane, tilted at angle alpha
     from the vertical axis toward the lateral axis:
+
 
         kappa_axis = vertical * cos(alpha) + lateral * sin(alpha)
 

--- a/src/ad_hoc_diffractometer/constants.py
+++ b/src/ad_hoc_diffractometer/constants.py
@@ -10,7 +10,13 @@ Convention follows You (1999):
     ZHAT = lateral (to our left)
 """
 
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
 
 XHAT = np.array([1.0, 0.0, 0.0])
 YHAT = np.array([0.0, 1.0, 0.0])

--- a/src/ad_hoc_diffractometer/display.py
+++ b/src/ad_hoc_diffractometer/display.py
@@ -27,7 +27,11 @@ considered equal when they agree to within half a unit in the last
 explicit tolerance can be supplied to override this default.
 """
 
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Package-level default
@@ -146,6 +150,7 @@ def fmt(value: float, digits: int | None = None) -> str:
     digits : int or None
         Number of decimal places.  If None, uses the package-level default
         from get_precision().
+
 
     Returns
     -------

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -69,6 +69,7 @@ References (chronological):
 
 from __future__ import annotations
 
+import logging
 from importlib.metadata import entry_points
 
 import numpy as np
@@ -79,6 +80,8 @@ from .constants import YHAT
 from .constants import ZHAT
 from .geometry import AdHocDiffractometer
 from .stage import Stage
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -157,10 +160,10 @@ def _load_entry_point_geometries() -> None:
                 try:
                     factory = ep.load()
                     _GEOMETRY_REGISTRY[ep.name] = factory
-                except Exception:  # noqa: BLE001
-                    pass  # broken plugin — skip silently
-    except Exception:  # noqa: BLE001
-        pass  # importlib.metadata unavailable — no-op
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Skipping broken entry point %r: %s", ep.name, exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("entry_points() failed; no plugins loaded: %s", exc)
 
 
 def list_geometries() -> dict[str, type]:
@@ -496,6 +499,7 @@ def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     The chi circle of a standard Eulerian fourcv is replaced by a kappa arm.
     The kappa axis lies in the vertical-lateral plane, tilted alpha degrees
     from the vertical toward the lateral axis.
+
 
     Basis (Busing & Levy convention): x=lateral, y=longitudinal, z=vertical.
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -6,6 +6,7 @@ The stacking order is encoded via the parent attribute of each Stage.
 """
 
 import builtins
+import logging
 
 import numpy as np
 
@@ -19,6 +20,8 @@ from .sample import _DEFAULT_SAMPLE_NAME
 from .sample import Sample
 from .sample import SampleDict
 from .stage import Stage
+
+logger = logging.getLogger(__name__)
 
 
 class AdHocDiffractometer:
@@ -775,16 +778,16 @@ class AdHocDiffractometer:
             current_angles = {s.name: s.angle for s in self._stages.values()}
             hkl = self.inverse(current_angles)
             hkl_str = "  {:g}  {:g}  {:g}".format(*[self._clean_zero(v) for v in hkl])
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("wh: could not compute HKL: %s", exc)
         lines.append(f"H K L = {hkl_str}")
 
         # Azimuthal angle ψ
         psi_str = "not available"
         try:
             psi_str = f"{self.psi():.4g}"
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("wh: could not compute psi: %s", exc)
         lines.append(f"Psi = {psi_str}")
 
         # Wavelength
@@ -1087,7 +1090,8 @@ class AdHocDiffractometer:
             from importlib.metadata import version as _version
 
             _pkg_version = _version("ad_hoc_diffractometer")
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not read package version: %s", exc)
             _pkg_version = "unknown"
 
         stages = [s.to_dict() for s in self._stages.values()]

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -16,9 +16,13 @@ Based on:
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from .display import fmt
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Crystal system definitions

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -39,10 +39,14 @@ You, J. Appl. Cryst. 32, 614-623 (1999)
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from .rotation import rotation_matrix
 from .stage import Stage
+
+logger = logging.getLogger(__name__)
 
 
 def angles_to_phi_vector(geometry, **motor_angles: float) -> np.ndarray:
@@ -745,13 +749,13 @@ def ub_from_three_reflections_bl1967(
         )
 
     if det_H < 0:
-        warnings.warn(
+        msg = (
             f"det(H) = {det_H:.6g} < 0: the three hkl triples form a "
             "left-handed system.  U may have det(U) = -1.  Consider "
-            "swapping r1 and r2 to restore a right-handed system.",
-            UserWarning,
-            stacklevel=2,
+            "swapping r1 and r2 to restore a right-handed system."
         )
+        logger.warning(msg)
+        warnings.warn(msg, UserWarning, stacklevel=2)
 
     # --- BL1967 eq. 31: UB = Hφ @ H⁻¹ -------------------------------------
     try:

--- a/src/ad_hoc_diffractometer/refinement.py
+++ b/src/ad_hoc_diffractometer/refinement.py
@@ -43,6 +43,7 @@ Nelder & Mead, The Computer Journal 7(4), 308-313 (1965).
 
 from __future__ import annotations
 
+import logging
 import math
 
 import numpy as np
@@ -50,6 +51,8 @@ import numpy as np
 from .lattice import _SYSTEM_FREE_PARAMS
 from .lattice import Lattice
 from .orientation import angles_to_phi_vector
+
+logger = logging.getLogger(__name__)
 
 # All six cell parameters, in the order stored internally.
 _ALL_CELL_PARAMS = ("a", "b", "c", "alpha", "beta", "gamma")
@@ -955,4 +958,10 @@ def _nelder_mead_numpy(
                 simplex[1:] = simplex[0] + sigma * (simplex[1:] - simplex[0])
                 fvals[1:] = np.array([f(simplex[i]) for i in range(1, n + 1)])
 
+    if not converged:
+        logger.debug(
+            "Nelder-Mead did not converge after %d iterations (tol=%.2g).",
+            n_iter,
+            tol,
+        )
     return simplex[0], n_iter, converged

--- a/src/ad_hoc_diffractometer/reflection.py
+++ b/src/ad_hoc_diffractometer/reflection.py
@@ -27,8 +27,11 @@ Typical usage::
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from dataclasses import field
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/src/ad_hoc_diffractometer/rotation.py
+++ b/src/ad_hoc_diffractometer/rotation.py
@@ -5,7 +5,13 @@ Provides the Rodrigues rotation formula for computing 3x3 rotation matrices
 from a unit axis vector and an angle.
 """
 
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
 
 
 def rotation_matrix(axis: np.ndarray, angle_deg: float) -> np.ndarray:

--- a/src/ad_hoc_diffractometer/sample.py
+++ b/src/ad_hoc_diffractometer/sample.py
@@ -30,10 +30,14 @@ Typical usage::
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from .lattice import Lattice
 from .reflection import ReflectionList
+
+logger = logging.getLogger(__name__)
 
 # Default sample name and lattice used when a new geometry is constructed.
 _DEFAULT_SAMPLE_NAME = "test"

--- a/src/ad_hoc_diffractometer/spec.py
+++ b/src/ad_hoc_diffractometer/spec.py
@@ -38,10 +38,13 @@ Busing & Levy, Acta Cryst. 22, 457-464 (1967).
 
 from __future__ import annotations
 
+import logging
 from typing import NamedTuple
 
 from .lattice import Lattice
 from .reflection import Reflection
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Data container

--- a/src/ad_hoc_diffractometer/stage.py
+++ b/src/ad_hoc_diffractometer/stage.py
@@ -6,9 +6,13 @@ is stored internally as a signed numpy array (the internal representation).
 The caller-facing +x/-z string notation is handled in axes.py.
 """
 
+import logging
+
 import numpy as np
 
 from .rotation import rotation_matrix
+
+logger = logging.getLogger(__name__)
 
 
 class Stage:

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -669,6 +669,38 @@ class TestEntryPointExtensibility:
             fac._GEOMETRY_REGISTRY.clear()
             fac._GEOMETRY_REGISTRY.update(original_registry)
 
+    def test_broken_plugin_logs_debug(self, caplog):
+        """A broken entry point emits a DEBUG message to the package logger."""
+        import logging
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        import ad_hoc_diffractometer.factories as _fac
+
+        broken_ep = MagicMock()
+        broken_ep.name = "broken_log_test"
+        broken_ep.load.side_effect = ImportError("oops")
+
+        original_ep_loaded = _fac._EP_LOADED
+        original_registry = dict(_fac._GEOMETRY_REGISTRY)
+        _fac._EP_LOADED = False
+        try:
+            with patch(
+                "ad_hoc_diffractometer.factories.entry_points",
+                return_value=[broken_ep],
+            ):
+                with caplog.at_level(
+                    logging.DEBUG,
+                    logger="ad_hoc_diffractometer.factories",
+                ):
+                    _fac._load_entry_point_geometries()
+            assert any("broken_log_test" in r.message for r in caplog.records)
+            assert any(r.levelno == logging.DEBUG for r in caplog.records)
+        finally:
+            _fac._EP_LOADED = original_ep_loaded
+            _fac._GEOMETRY_REGISTRY.clear()
+            _fac._GEOMETRY_REGISTRY.update(original_registry)
+
     def test_outer_importlib_exception_silently_ignored(self):
         """_load_entry_point_geometries swallows errors from entry_points() itself."""
         from unittest.mock import patch

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1288,3 +1288,40 @@ def test_geometry_summary_no_wavelength(capsys):
     g = fourcv()
     g.summary()
     assert "not set" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Logging — wh() emits DEBUG when HKL / psi cannot be computed
+# ---------------------------------------------------------------------------
+
+
+def test_wh_logs_debug_when_hkl_unavailable(caplog):
+    """wh() emits a DEBUG log when HKL cannot be computed (no UB set)."""
+    import logging
+
+    from ad_hoc_diffractometer import fourcv
+
+    g = fourcv()
+    g.wavelength = 1.5406
+    with caplog.at_level(logging.DEBUG, logger="ad_hoc_diffractometer.geometry"):
+        g.wh(print=False)
+
+    assert any("wh" in r.message.lower() for r in caplog.records)
+    assert any(r.levelno == logging.DEBUG for r in caplog.records)
+
+
+def test_wh_logs_debug_when_psi_unavailable(caplog):
+    """wh() emits a DEBUG log when psi cannot be computed (no azimuthal reference)."""
+    import logging
+
+    from ad_hoc_diffractometer import fourcv
+    from ad_hoc_diffractometer import ub_identity
+
+    g = fourcv()
+    g.wavelength = 1.5406
+    ub_identity(g.sample)
+    # No azimuthal_reference → psi() raises → logger.debug fires
+    with caplog.at_level(logging.DEBUG, logger="ad_hoc_diffractometer.geometry"):
+        g.wh(print=False)
+
+    assert any("psi" in r.message.lower() for r in caplog.records)

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1232,3 +1232,35 @@ def test_ub_from_three_singular_B_inv_sets_U_none():
 
     assert g.sample.U is None
     assert UB is not None
+
+
+def test_ub_from_three_left_handed_H_logs_warning(caplog):
+    """ub_from_three emits a WARNING log alongside warnings.warn for left-handed H."""
+    import logging
+    import math
+
+    from ad_hoc_diffractometer import Lattice
+    from ad_hoc_diffractometer import fourcv
+    from ad_hoc_diffractometer import ub_identity
+    from ad_hoc_diffractometer.orientation import ub_from_three_reflections_bl1967
+
+    TWO_PI = 2 * math.pi
+    g = fourcv()
+    g.wavelength = TWO_PI
+    g.sample.lattice = Lattice(a=1.0)
+    ub_identity(g.sample)
+    # Swap r2 and r3 → det(H) < 0 → left-handed
+    for name, hkl, ang in [
+        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}),
+        ("r2", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "two_theta": 60.0}),
+        ("r3", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "two_theta": 60.0}),
+    ]:
+        g.add_reflection(name, hkl=hkl, angles=ang)
+
+    with caplog.at_level(logging.WARNING, logger="ad_hoc_diffractometer.orientation"):
+        ub_from_three_reflections_bl1967(g.sample, "r1", "r2", "r3")
+
+    assert any(
+        "left-handed" in r.message.lower() or "det(H)" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -679,6 +679,24 @@ def test_simplex_branches(refine_cell, refine_orientation, refine_all, perturbed
     assert "rms" in result
 
 
+def test_nelder_mead_non_convergence_logs_debug(caplog):
+    """_nelder_mead_numpy emits a DEBUG message when it does not converge."""
+    import logging
+
+    from ad_hoc_diffractometer.refinement import _nelder_mead_numpy
+
+    with caplog.at_level(logging.DEBUG, logger="ad_hoc_diffractometer.refinement"):
+        _nelder_mead_numpy(
+            lambda x: float(np.sum(x**2)),
+            np.array([100.0, 100.0]),
+            max_iter=2,
+            tol=1e-20,
+        )
+
+    assert any("did not converge" in r.message.lower() for r in caplog.records)
+    assert any(r.levelno == logging.DEBUG for r in caplog.records)
+
+
 def test_bl1967_explicit_tol_skips_default(perturbed_geom):
     """refine_lattice_bl1967 with explicit tol= skips the 'if tol is None' branch."""
     from ad_hoc_diffractometer.refinement import refine_lattice_bl1967


### PR DESCRIPTION
## Summary

- `logging.getLogger(__name__)` added to every source module; root logger `"ad_hoc_diffractometer"` lets users configure all package output at once
- Silent by default (WARNING level); `warnings.warn` retained for library-facing alerts
- 5 new `caplog` tests; 860 tests total, 100% coverage maintained

- closes #61

### Usage

```python
import logging
logging.getLogger("ad_hoc_diffractometer").setLevel(logging.DEBUG)
# Now debug messages appear from all submodules
```

### Callsites

| Module | Level | Trigger |
|--------|-------|---------|
| `factories` | DEBUG | Broken entry-point plugin skip; `entry_points()` failure |
| `orientation` | WARNING | `ub_from_three`: left-handed H (alongside `warnings.warn`) |
| `refinement` | DEBUG | `_nelder_mead_numpy` non-convergence |
| `geometry` | DEBUG | `wh()` HKL/psi computation failure; `to_dict()` version lookup |

Contributed by: OpenCode (argo/claudesonnet46)