### PR TITLE
fix: correct fourcv/fourch stage axes; clarify v/h suffix; rename two_theta→ttheta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,8 +219,8 @@ in `list_geometries()`.  Naming convention:
 
 | Suffix | Meaning |
 |---|---|
-| `v` | vertical detector axis (laboratory, horizontal scattering plane) |
-| `h` | lateral detector axis (synchrotron, vertical scattering plane) |
+| `v` | vertical scattering plane (synchrotron) — ttheta rotates about the lateral axis |
+| `h` | horizontal scattering plane (laboratory) — ttheta rotates about the vertical axis |
 | no suffix | detector convention unambiguous (psic, sixc) or compound (zaxis, s2d2) |
 
 Current factories: `psic`, `fourcv`, `fourch`, `sixc`, `kappa4cv`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,20 @@ for the full issue tracker.
 
 ## Unreleased
 
+### Fixed
+
+- ``fourcv`` / ``fourch`` / ``kappa4cv`` / ``kappa4ch`` stage axes corrected
+  (#66): the ``v``/``h`` suffix describes the **scattering plane** (not the
+  detector axis); ``fourcv`` (vertical scattering plane) now has omega, chi,
+  phi, and ttheta on the lateral/longitudinal axes; ``fourch`` (horizontal
+  scattering plane, matching BL1967 Fig. 1b) has omega, chi, phi, and ttheta
+  on the vertical/lateral axes; same corrections applied to ``kappa4cv`` /
+  ``kappa4ch``.  Stage axis assignments now use ``_BASIS_BL["lateral"]`` etc.
+  for self-documenting physical-direction notation.
+- ``two_theta`` stage name renamed to ``ttheta`` throughout all factories,
+  tests, and supporting modules.
+- AGENTS.md suffix table corrected.
+
 ### Added
 
 - Logging support (#61): ``logging.getLogger(__name__)`` added to all

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -498,6 +498,30 @@ Current coverage: 93% (119 uncovered lines).  ``pytest-cov`` is installed.
 - [x] 5 tests via ``caplog`` fixture in ``test_factories``,
       ``test_orientation``, ``test_refinement``, and ``test_geometry``
 
+### 3.8f Clarify v/h suffix and fix fourcv/fourch stage axes ([#66](https://github.com/prjemian/ad_hoc_diffractometer/issues/66))
+
+- [x] The ``v``/``h`` suffix describes the **scattering plane**, not the
+      detector axis: ``v`` = vertical scattering plane (synchrotron, ttheta on
+      lateral axis); ``h`` = horizontal scattering plane (laboratory, ttheta on
+      vertical axis)
+- [x] ``fourcv``: corrected — omega, chi (longitudinal), phi, ttheta all on
+      lateral axis giving vertical scattering plane (BL1967 Fig. 1b is ``fourch``)
+- [x] ``fourch``: corrected — omega, chi (lateral), phi, ttheta all on vertical
+      axis giving horizontal scattering plane, matching BL1967 Fig. 1b
+- [x] ``kappa4cv`` / ``kappa4ch``: same corrections applied
+- [x] Stage axis expressions use ``_BASIS_BL["lateral"]`` / ``["vertical"]`` /
+      ``["longitudinal"]`` for self-documenting physical-direction assignments
+- [x] ``two_theta`` stage name renamed to ``ttheta`` throughout
+- [x] AGENTS.md suffix table corrected; 860 tests pass, 100% coverage
+
+### 3.8g Refactor factory functions to accept basis as argument ([#67](https://github.com/prjemian/ad_hoc_diffractometer/issues/67))
+
+- [ ] Pass basis dict as optional argument to each factory; resolve
+      ``_LATERAL``/``_VERTICAL``/``_LONGITUDINAL`` locally
+- [ ] Unify ``_BASIS_BL`` and ``_BASIS_YOU`` stage axis expressions into a
+      single physical-direction notation
+- [ ] Backward-compatible (basis defaults to current value per factory)
+
 ### 3.8e Sphinx documentation ([#57](https://github.com/prjemian/ad_hoc_diffractometer/issues/57))
 
 - [ ] Allow either reST or Markdown source
@@ -527,9 +551,10 @@ this issue is independent of the X-ray energy conversion issue (#21).
 - Walko (2016) designation system: S = sample axes, D = detector axes,
   number = count, parentheses = shared base.  All implemented geometries
   are catalogued in factories.py.
-- The distinction between laboratory (horizontal scattering plane, vertical
-  detector) and synchrotron (vertical scattering plane, lateral detector)
-  is encoded in the _v / _h suffix convention.
+- The ``v``/``h`` suffix describes the scattering plane: ``v`` = vertical
+  scattering plane (synchrotron, ttheta on lateral axis); ``h`` = horizontal
+  scattering plane (laboratory, ttheta on vertical axis).  This matches
+  Busing & Levy (1967) Fig. 1b for ``fourch`` (horizontal scattering plane).
 - The SPEC #G line format is documented in
   references/2020-12-13-fourcc-alignment-7-id-c/spec_G_lines.md.
 - Threading and RunEngine diagnostics are in threading_diagnostics.md.

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -30,9 +30,9 @@ Naming convention:
     Kappa geometries:        kappa4cv, kappa4ch, kappa6c
     Inclined geometries:     zaxis, s2d2, fivec
 
-Detector axis suffix convention (v / h):
-    v  ->  vertical detector axis   (laboratory / horizontal scattering plane)
-    h  ->  lateral   detector axis  (synchrotron / vertical scattering plane)
+Scattering-plane suffix convention (v / h):
+    v  ->  vertical   scattering plane  (synchrotron) — ttheta rotates about the lateral axis
+    h  ->  horizontal scattering plane  (laboratory)  — ttheta rotates about the vertical axis
 
     Walko (2016): "at synchrotron sources the scattering plane is usually
     vertical, to take advantage of the (typically) s-polarization of the
@@ -41,8 +41,9 @@ Detector axis suffix convention (v / h):
     Where no suffix is given, the geometry has no single-axis 2theta detector
     (inclined geometries) or the detector convention is unambiguous (psic, sixc).
 
-    fourcv (vertical detector) is the default/laboratory convention.
-    kappa4cv (vertical detector) is the default/laboratory convention.
+    fourch  (horizontal scattering plane) matches Busing & Levy (1967) Fig. 1b.
+    fourcv  (vertical   scattering plane) is the synchrotron convention.
+    kappa4ch and kappa4cv follow the same convention as fourch and fourcv.
 
 Kappa angle (alpha) convention (Walko 2016; Enraf-Nonius; ITC Vol. C Sec. 2.2.6):
     The kappa axis lies in the vertical-lateral plane, tilted alpha degrees
@@ -353,38 +354,36 @@ def psic() -> AdHocDiffractometer:
 @register_geometry
 def fourcv() -> AdHocDiffractometer:
     """
-    Busing & Levy (1967) four-circle Eulerian diffractometer, vertical detector.
+    Four-circle Eulerian diffractometer, vertical scattering plane (synchrotron).
 
     Walko (2016) designation: S3D1.
 
-    This is the default / laboratory configuration: the detector arm swings
-    in a vertical plane (horizontal scattering plane), which minimises
-    gravitational distortions.  This is the geometry described in Busing &
-    Levy (1967).
+    Synchrotron configuration: omega and ttheta both rotate about the
+    lateral axis, so the scattering plane is vertical.  This exploits the
+    s-polarisation and tighter vertical collimation of synchrotron radiation
+    (Walko 2016).
 
     Basis (Busing & Levy convention):
-        x = lateral  (scattering vector at zero angles)
-        y = longitudinal (along the beam)
-        z = vertical
-    Right-handed: lateral x longitudinal = vertical.
+        x = lateral, y = longitudinal, z = vertical.
 
     Sample stack (floor first):
-        omega     : vertical, -z, left-handed
-        chi       : lateral,  +x, right-handed
-        phi       : vertical, -z, left-handed
+        omega     : lateral,       -x, left-handed
+        chi       : longitudinal,  +y, right-handed
+        phi       : lateral,       -x, left-handed
 
     Detector (floor, mechanically independent of sample stack):
-        two_theta : vertical, -z, left-handed
+        ttheta : lateral,       -x, left-handed
 
-    omega and two_theta share the same vertical axis; mechanically independent.
+    omega and ttheta share the same lateral axis; mechanically independent.
 
-    Reference: W.R. Busing & H.A. Levy, Acta Cryst. 22, 457-464 (1967).
+    References: W.R. Busing & H.A. Levy, Acta Cryst. 22, 457-464 (1967).
+                D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016).
     """
     stages = [
-        Stage("omega", -_ZHAT_BL, parent=None, role="sample"),
-        Stage("chi", +_XHAT_BL, parent="omega", role="sample"),
-        Stage("phi", -_ZHAT_BL, parent="chi", role="sample"),
-        Stage("two_theta", -_ZHAT_BL, parent=None, role="detector"),
+        Stage("omega", -_BASIS_BL["lateral"], parent=None, role="sample"),
+        Stage("chi", +_BASIS_BL["longitudinal"], parent="omega", role="sample"),
+        Stage("phi", -_BASIS_BL["lateral"], parent="chi", role="sample"),
+        Stage("ttheta", -_BASIS_BL["lateral"], parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
@@ -392,7 +391,7 @@ def fourcv() -> AdHocDiffractometer:
         basis=_BASIS_BL,
         description=(
             "Busing & Levy (1967) four-circle Eulerian diffractometer "
-            "(vertical detector, horizontal scattering plane, laboratory)"
+            "(vertical scattering plane, lateral ttheta, synchrotron)"
         ),
     )
 
@@ -400,13 +399,13 @@ def fourcv() -> AdHocDiffractometer:
 @register_geometry
 def fourch() -> AdHocDiffractometer:
     """
-    Busing & Levy (1967) four-circle Eulerian diffractometer, lateral detector.
+    Four-circle Eulerian diffractometer, horizontal scattering plane (laboratory).
 
     Walko (2016) designation: S3D1.
 
-    Synchrotron configuration: the scattering plane is vertical (horizontal
-    detector axis), exploiting the s-polarisation and tighter vertical
-    collimation of synchrotron radiation (Walko 2016).
+    Laboratory / default configuration: omega and ttheta both rotate about
+    the vertical axis, so the scattering plane is horizontal.  This is the
+    geometry described in Busing & Levy (1967), Fig. 1b.
 
     Basis (Busing & Levy convention):
         x = lateral, y = longitudinal, z = vertical.
@@ -417,18 +416,18 @@ def fourch() -> AdHocDiffractometer:
         phi       : vertical, -z, left-handed
 
     Detector (floor, mechanically independent):
-        two_theta : lateral,  -x, left-handed
+        ttheta : vertical, -z, left-handed
 
-    omega and two_theta share the same vertical axis; mechanically independent.
+    omega and ttheta share the same vertical axis; mechanically independent.
 
     Reference: W.R. Busing & H.A. Levy, Acta Cryst. 22, 457-464 (1967).
                D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016).
     """
     stages = [
-        Stage("omega", -_ZHAT_BL, parent=None, role="sample"),
-        Stage("chi", +_XHAT_BL, parent="omega", role="sample"),
-        Stage("phi", -_ZHAT_BL, parent="chi", role="sample"),
-        Stage("two_theta", -_XHAT_BL, parent=None, role="detector"),
+        Stage("omega", -_BASIS_BL["vertical"], parent=None, role="sample"),
+        Stage("chi", +_BASIS_BL["lateral"], parent="omega", role="sample"),
+        Stage("phi", -_BASIS_BL["vertical"], parent="chi", role="sample"),
+        Stage("ttheta", -_BASIS_BL["vertical"], parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
@@ -436,7 +435,7 @@ def fourch() -> AdHocDiffractometer:
         basis=_BASIS_BL,
         description=(
             "Busing & Levy (1967) four-circle Eulerian diffractometer "
-            "(lateral detector, vertical scattering plane, synchrotron)"
+            "(horizontal scattering plane, vertical ttheta, laboratory)"
         ),
     )
 
@@ -493,7 +492,7 @@ KAPPA_ALPHA_DEFAULT = 50.0
 @register_geometry
 def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
-    Four-circle kappa diffractometer, vertical detector (laboratory default).
+    Four-circle kappa diffractometer, vertical scattering plane (synchrotron).
 
     Walko (2016) designation: S3D1.
 
@@ -501,16 +500,20 @@ def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     The kappa axis lies in the vertical-lateral plane, tilted alpha degrees
     from the vertical toward the lateral axis.
 
+    komega and ttheta both rotate about the lateral axis; the scattering
+    plane is vertical (synchrotron convention).
 
     Basis (Busing & Levy convention): x=lateral, y=longitudinal, z=vertical.
 
     Sample stack (floor first):
-        komega    : vertical, -z, left-handed
+        komega    : lateral,  -x, left-handed
         kappa     : tilted,   kappa_axis(alpha), right-handed
-        kphi      : vertical, -z, left-handed
+        kphi      : lateral,  -x, left-handed
 
     Detector (floor, mechanically independent):
-        two_theta : vertical, -z, left-handed
+        ttheta : lateral,  -x, left-handed
+
+    komega and ttheta share the same lateral axis; mechanically independent.
 
     Parameters
     ----------
@@ -523,18 +526,18 @@ def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
     kax = kappa_axis(alpha_deg, basis=_BASIS_BL)
     stages = [
-        Stage("komega", -_ZHAT_BL, parent=None, role="sample"),
+        Stage("komega", -_BASIS_BL["lateral"], parent=None, role="sample"),
         Stage("kappa", kax, parent="komega", role="sample"),
-        Stage("kphi", -_ZHAT_BL, parent="kappa", role="sample"),
-        Stage("two_theta", -_ZHAT_BL, parent=None, role="detector"),
+        Stage("kphi", -_BASIS_BL["lateral"], parent="kappa", role="sample"),
+        Stage("ttheta", -_BASIS_BL["lateral"], parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
         basis=_BASIS_BL,
         description=(
-            f"Four-circle kappa diffractometer, vertical detector (laboratory). "
-            f"Kappa alpha = {alpha_deg} deg."
+            f"Four-circle kappa diffractometer, vertical scattering plane "
+            f"(synchrotron). Kappa alpha = {alpha_deg} deg."
         ),
         kappa_alpha_deg=alpha_deg,
     )
@@ -543,13 +546,12 @@ def kappa4cv(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
 @register_geometry
 def kappa4ch(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
-    Four-circle kappa diffractometer, lateral detector (synchrotron).
+    Four-circle kappa diffractometer, horizontal scattering plane (laboratory).
 
     Walko (2016) designation: S3D1.
 
-    Identical to kappa4cv() but the two_theta (detector) axis is lateral,
-    corresponding to the synchrotron configuration with a vertical
-    scattering plane.
+    Identical to kappa4cv() but komega and ttheta rotate about the vertical
+    axis, giving a horizontal scattering plane (laboratory convention).
 
     Basis (Busing & Levy convention): x=lateral, y=longitudinal, z=vertical.
 
@@ -559,7 +561,9 @@ def kappa4ch(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
         kphi      : vertical, -z, left-handed
 
     Detector (floor, mechanically independent):
-        two_theta : lateral,  -x, left-handed
+        ttheta : vertical, -z, left-handed
+
+    komega and ttheta share the same vertical axis; mechanically independent.
 
     Parameters
     ----------
@@ -572,18 +576,18 @@ def kappa4ch(alpha_deg: float = KAPPA_ALPHA_DEFAULT) -> AdHocDiffractometer:
     """
     kax = kappa_axis(alpha_deg, basis=_BASIS_BL)
     stages = [
-        Stage("komega", -_ZHAT_BL, parent=None, role="sample"),
+        Stage("komega", -_BASIS_BL["vertical"], parent=None, role="sample"),
         Stage("kappa", kax, parent="komega", role="sample"),
-        Stage("kphi", -_ZHAT_BL, parent="kappa", role="sample"),
-        Stage("two_theta", -_XHAT_BL, parent=None, role="detector"),
+        Stage("kphi", -_BASIS_BL["vertical"], parent="kappa", role="sample"),
+        Stage("ttheta", -_BASIS_BL["vertical"], parent=None, role="detector"),
     ]
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
         basis=_BASIS_BL,
         description=(
-            f"Four-circle kappa diffractometer, lateral detector (synchrotron). "
-            f"Kappa alpha = {alpha_deg} deg."
+            f"Four-circle kappa diffractometer, horizontal scattering plane "
+            f"(laboratory). Kappa alpha = {alpha_deg} deg."
         ),
         kappa_alpha_deg=alpha_deg,
     )
@@ -758,7 +762,7 @@ def fivec() -> AdHocDiffractometer:
           --> omega (sample): lateral,  -z, left-handed
                 --> chi:      lateral,  -z, left-handed (chi axis)
                       --> phi: lateral, -z, left-handed
-          --> two_theta (detector): lateral, -z, left-handed
+          --> ttheta (detector): lateral, -z, left-handed
 
     Note: the inner fourc uses the You (1999) basis (xHat=vertical) rather
     than the Busing & Levy basis, since mu is the outermost vertical axis.
@@ -774,7 +778,7 @@ def fivec() -> AdHocDiffractometer:
         Stage("chi", +YHAT, parent="omega", role="sample"),
         Stage("phi", -ZHAT, parent="chi", role="sample"),
         # Detector stack on mu
-        Stage("two_theta", -ZHAT, parent="mu", role="detector"),
+        Stage("ttheta", -ZHAT, parent="mu", role="detector"),
     ]
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -948,7 +948,7 @@ class AdHocDiffractometer:
         Unknown names pass through unchanged.
         """
         _MAP = {
-            "two_theta": "TwoTheta",
+            "ttheta": "TwoTheta",
             "omega": "Theta",
             "chi": "Chi",
             "phi": "Phi",

--- a/src/ad_hoc_diffractometer/spec.py
+++ b/src/ad_hoc_diffractometer/spec.py
@@ -4,7 +4,7 @@ spec.py — SPEC #G1 line parser and emitter for fourc geometry.
 The SPEC diffractometer control software stores the complete geometry state
 in ``#G`` header lines at the start of every scan.  This module handles the
 ``#G1`` line for the **fourc** geometry only (Busing & Levy convention,
-Eulerian four-circle: omega, chi, phi, two_theta).
+Eulerian four-circle: omega, chi, phi, ttheta).
 
 .. warning::
    The ``#G1`` field layout is **geometry-specific**.  The implementation
@@ -74,7 +74,7 @@ class FourcG1(NamedTuple):
         Secondary orienting reflection Miller indices.
     or1_two_theta, or1_omega, or1_chi, or1_phi : float
         Primary reflection motor angles (degrees).
-        Note: SPEC fourc uses ``2θ, θ(=omega), χ, φ`` — **not** ``two_theta``.
+        Note: SPEC fourc uses ``2θ, θ(=omega), χ, φ`` — mapped to our stage name ``ttheta``.
     unused1 : tuple of float
         Two unused zeros following the primary angles (indices 22–23).
     or2_two_theta, or2_omega, or2_chi, or2_phi : float
@@ -336,7 +336,7 @@ def g1_to_sample(g1: FourcG1, geometry) -> None:
 
     Sets the active sample's lattice from the direct-lattice parameters in
     ``g1``, adds the two orienting reflections (using fourc motor-angle names
-    ``omega``, ``chi``, ``phi``, ``two_theta``), designates them as or1 and
+    ``omega``, ``chi``, ``phi``, ``ttheta``), designates them as or1 and
     or2, and sets the geometry wavelength to ``g1.lambda1``.
 
     Parameters
@@ -355,7 +355,7 @@ def g1_to_sample(g1: FourcG1, geometry) -> None:
       the secondary reflection object but is not set on the geometry (SPEC
       always uses the same wavelength for both in fourc).
     - The fourc motor-angle keys are ``omega``, ``chi``, ``phi``,
-      ``two_theta``.  SPEC's ``#G1`` stores ``2θ, θ, χ, φ`` for each
+      ``ttheta``.  SPEC's ``#G1`` stores ``2θ, θ, χ, φ`` for each
       reflection; ``θ`` is mapped to ``omega``.
 
     Examples
@@ -398,13 +398,13 @@ def g1_to_sample(g1: FourcG1, geometry) -> None:
 
     # fourc angle mapping: SPEC stores (2θ, θ, χ, φ); θ maps to omega
     or1_angles = {
-        "two_theta": g1.or1_two_theta,
+        "ttheta": g1.or1_two_theta,
         "omega": g1.or1_omega,
         "chi": g1.or1_chi,
         "phi": g1.or1_phi,
     }
     or2_angles = {
-        "two_theta": g1.or2_two_theta,
+        "ttheta": g1.or2_two_theta,
         "omega": g1.or2_omega,
         "chi": g1.or2_chi,
         "phi": g1.or2_phi,
@@ -462,7 +462,7 @@ def sample_to_g1(geometry) -> FourcG1:
       using the package's standard computation.
     - If only one orienting reflection is designated (or2 not set), the
       secondary reflection fields are filled with zeros.
-    - The fourc motor-angle keys ``omega``, ``chi``, ``phi``, ``two_theta``
+    - The fourc motor-angle keys ``omega``, ``chi``, ``phi``, ``ttheta``
       are mapped back to SPEC's ``θ, χ, φ, 2θ`` field order.
 
     Examples
@@ -526,7 +526,7 @@ def sample_to_g1(geometry) -> FourcG1:
     # Primary orienting reflection
     or1: Reflection = ors[0]
     or1_h, or1_k, or1_l = or1.hkl
-    or1_two_theta = or1.angles.get("two_theta", 0.0)
+    or1_two_theta = or1.angles.get("ttheta", 0.0)
     or1_omega = or1.angles.get("omega", 0.0)
     or1_chi = or1.angles.get("chi", 0.0)
     or1_phi = or1.angles.get("phi", 0.0)
@@ -536,7 +536,7 @@ def sample_to_g1(geometry) -> FourcG1:
     if len(ors) >= 2:
         or2: Reflection = ors[1]
         or2_h, or2_k, or2_l = or2.hkl
-        or2_two_theta = or2.angles.get("two_theta", 0.0)
+        or2_two_theta = or2.angles.get("ttheta", 0.0)
         or2_omega = or2.angles.get("omega", 0.0)
         or2_chi = or2.angles.get("chi", 0.0)
         or2_phi = or2.angles.get("phi", 0.0)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -51,12 +51,12 @@ def _sapphire_fourcv():
     g.add_reflection(
         "or1",
         hkl=(0, 0, 6),
-        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94188},
+        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94188},
     )
     g.add_reflection(
         "or2",
         hkl=(1, 0, 0),
-        angles={"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0},
+        angles={"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0},
     )
     g.sample.reflections.setor1("or1")
     g.sample.reflections.setor2("or2")
@@ -226,7 +226,7 @@ class TestReflectionSerialization:
         return Reflection(
             name="r1",
             hkl=(0.0, 0.0, 6.0),
-            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94},
+            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94},
             wavelength=1.5498,
             geometry_name="fourcv",
         )
@@ -272,17 +272,17 @@ class TestReflectionListSerialization:
     def rl(self):
         r = ReflectionList(
             geometry_name="fourcv",
-            valid_stages={"omega", "chi", "phi", "two_theta"},
+            valid_stages={"omega", "chi", "phi", "ttheta"},
         )
         r.add(
             "r1",
             hkl=(0, 0, 6),
-            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94},
+            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94},
         )
         r.add(
             "r2",
             hkl=(1, 0, 0),
-            angles={"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0},
+            angles={"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0},
         )
         r.setor1("r1")
         r.setor2("r2")
@@ -329,12 +329,12 @@ class TestSampleSerialization:
     def sample(self):
         rl = ReflectionList(
             geometry_name="fourcv",
-            valid_stages={"omega", "chi", "phi", "two_theta"},
+            valid_stages={"omega", "chi", "phi", "ttheta"},
         )
         rl.add(
             "r1",
             hkl=(0, 0, 6),
-            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94},
+            angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94},
         )
         s = Sample(
             name="sapphire",
@@ -422,7 +422,7 @@ class TestGeometryToDict:
     def test_stages_list(self, geom):
         stages = geom.to_dict()["stages"]
         assert isinstance(stages, list)
-        assert {s["name"] for s in stages} == {"omega", "chi", "phi", "two_theta"}
+        assert {s["name"] for s in stages} == {"omega", "chi", "phi", "ttheta"}
 
     def test_stage_has_required_keys(self, geom):
         for sd in geom.to_dict()["stages"]:

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -202,7 +202,7 @@ def test_make_geometry_kappa_alpha_forwarded():
             fourcv,
             "fourcv",
             ["omega", "chi", "phi"],
-            ["two_theta"],
+            ["ttheta"],
             does_not_raise(),
             id="fourcv-stage-lists",
         ),
@@ -210,7 +210,7 @@ def test_make_geometry_kappa_alpha_forwarded():
             fourch,
             "fourch",
             ["omega", "chi", "phi"],
-            ["two_theta"],
+            ["ttheta"],
             does_not_raise(),
             id="fourch-stage-lists",
         ),
@@ -226,7 +226,7 @@ def test_make_geometry_kappa_alpha_forwarded():
             kappa4cv,
             "kappa4cv",
             ["komega", "kappa", "kphi"],
-            ["two_theta"],
+            ["ttheta"],
             does_not_raise(),
             id="kappa4cv-stage-lists",
         ),
@@ -234,7 +234,7 @@ def test_make_geometry_kappa_alpha_forwarded():
             kappa4ch,
             "kappa4ch",
             ["komega", "kappa", "kphi"],
-            ["two_theta"],
+            ["ttheta"],
             does_not_raise(),
             id="kappa4ch-stage-lists",
         ),
@@ -266,7 +266,7 @@ def test_make_geometry_kappa_alpha_forwarded():
             fivec,
             "fivec",
             ["mu", "omega", "chi", "phi"],
-            ["two_theta"],
+            ["ttheta"],
             does_not_raise(),
             id="fivec-stage-lists",
         ),
@@ -303,10 +303,10 @@ def test_geometry_factories(
         ),
         pytest.param(
             fourcv,
-            "two_theta",
+            "ttheta",
             None,
             does_not_raise(),
-            id="fourcv-two_theta-decoupled",
+            id="fourcv-ttheta-decoupled",
         ),
         pytest.param(
             fourcv, "chi", "omega", does_not_raise(), id="fourcv-chi-on-omega"
@@ -315,10 +315,10 @@ def test_geometry_factories(
         # fourch
         pytest.param(
             fourch,
-            "two_theta",
+            "ttheta",
             None,
             does_not_raise(),
-            id="fourch-two_theta-decoupled",
+            id="fourch-ttheta-decoupled",
         ),
         # sixc
         pytest.param(sixc, "alpha", None, does_not_raise(), id="sixc-alpha-on-floor"),
@@ -337,10 +337,10 @@ def test_geometry_factories(
         ),
         pytest.param(
             kappa4cv,
-            "two_theta",
+            "ttheta",
             None,
             does_not_raise(),
-            id="kappa4cv-two_theta-decoupled",
+            id="kappa4cv-ttheta-decoupled",
         ),
         pytest.param(
             kappa4cv, "kappa", "komega", does_not_raise(), id="kappa4cv-kappa-on-komega"
@@ -377,9 +377,7 @@ def test_geometry_factories(
         # fivec
         pytest.param(fivec, "mu", None, does_not_raise(), id="fivec-mu-on-floor"),
         pytest.param(fivec, "omega", "mu", does_not_raise(), id="fivec-omega-on-mu"),
-        pytest.param(
-            fivec, "two_theta", "mu", does_not_raise(), id="fivec-two_theta-on-mu"
-        ),
+        pytest.param(fivec, "ttheta", "mu", does_not_raise(), id="fivec-ttheta-on-mu"),
         pytest.param(fivec, "chi", "omega", does_not_raise(), id="fivec-chi-on-omega"),
         pytest.param(fivec, "phi", "chi", does_not_raise(), id="fivec-phi-on-chi"),
     ],

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -826,7 +826,13 @@ def test_azimuthal_reference_wrong_length_raises():
 
 
 def _fourcv_identity():
-    """fourcv with B=I (a=1), lambda=2pi, UB=I, azimuthal_reference=(0,0,1)."""
+    """fourcv with B=I (a=1), lambda=2pi, UB=I, azimuthal_reference=(1,0,0).
+
+    With the corrected fourcv (vertical scattering plane), omega and ttheta
+    rotate about the lateral (-x) axis.  At chi=0, phi=0, omega=30, ttheta=60
+    Q points along -z (vertical).  XHAT_BL = (1,0,0) = lateral is perpendicular
+    to Q and to the scattering plane.
+    """
     from ad_hoc_diffractometer import Lattice
     from ad_hoc_diffractometer import fourcv
     from ad_hoc_diffractometer import ub_identity
@@ -835,7 +841,7 @@ def _fourcv_identity():
     g.wavelength = 2 * _math.pi
     g.sample.lattice = Lattice(a=1.0)
     ub_identity(g.sample)
-    g.azimuthal_reference = (0, 0, 1)  # ZHAT_BL = vertical ⊥ scattering plane at chi=0
+    g.azimuthal_reference = (1, 0, 0)  # XHAT_BL = lateral ⊥ scattering plane at chi=0
     return g
 
 
@@ -843,25 +849,29 @@ def test_psi_returns_float():
     """psi() returns a float."""
     g = _fourcv_identity()
     g.set_angle("omega", 30)
-    g.set_angle("two_theta", 60)
+    g.set_angle("ttheta", 60)
     result = g.psi()
     assert isinstance(result, float)
 
 
 def test_psi_n_perpendicular_to_scattering_plane_is_90():
-    """n=(0,0,1) ⊥ scattering plane at chi=0 → psi=90."""
+    """n=(1,0,0) = XHAT_BL (lateral) ⊥ vertical scattering plane at chi=0 → psi=90."""
     g = _fourcv_identity()
-    g.azimuthal_reference = (0, 0, 1)  # ZHAT_BL ⊥ lateral-longitudinal plane
-    angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}
+    g.azimuthal_reference = (1, 0, 0)  # XHAT_BL = lateral ⊥ vertical scattering plane
+    angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}
     psi = g.psi(angles)
     assert abs(psi - 90.0) < 1e-8
 
 
 def test_psi_n_in_scattering_plane_is_0():
-    """n=(0,1,0) = YHAT_BL lies in scattering plane at chi=0 → psi=0."""
+    """n=(0,1,0) = YHAT_BL (longitudinal) lies in vertical scattering plane at chi=0 → psi=0."""
     g = _fourcv_identity()
-    g.azimuthal_reference = (0, 1, 0)  # YHAT_BL = longitudinal = in scattering plane
-    angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}
+    g.azimuthal_reference = (
+        0,
+        1,
+        0,
+    )  # YHAT_BL = longitudinal = in vertical scattering plane
+    angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}
     psi = g.psi(angles)
     assert abs(psi - 0.0) < 1e-8
 
@@ -872,10 +882,10 @@ def test_psi_uses_current_angles_when_none_passed():
     g.set_angle("omega", 30.0)
     g.set_angle("chi", 0.0)
     g.set_angle("phi", 0.0)
-    g.set_angle("two_theta", 60.0)
-    g.azimuthal_reference = (0, 0, 1)
+    g.set_angle("ttheta", 60.0)
+    g.azimuthal_reference = (1, 0, 0)  # lateral — perpendicular to Q at these angles
     psi_implicit = g.psi()
-    psi_explicit = g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+    psi_explicit = g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
     assert abs(psi_implicit - psi_explicit) < 1e-10
 
 
@@ -888,7 +898,7 @@ def test_psi_range_within_180():
                 "omega": 30.0,
                 "chi": float(chi),
                 "phi": float(phi),
-                "two_theta": 60.0,
+                "ttheta": 60.0,
             }
             try:
                 psi = g.psi(angles)
@@ -902,7 +912,7 @@ def test_psi_no_reference_raises():
     g = _fourcv_identity()
     g.azimuthal_reference = None
     with pytest.raises(ValueError, match=re.escape("azimuthal_reference")):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
 
 
 def test_psi_no_wavelength_raises():
@@ -910,7 +920,7 @@ def test_psi_no_wavelength_raises():
     g = _fourcv_identity()
     g.wavelength = None
     with pytest.raises(ValueError, match=re.escape("wavelength")):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
 
 
 def test_psi_no_ub_raises():
@@ -918,16 +928,17 @@ def test_psi_no_ub_raises():
     g = _fourcv_identity()
     g.sample.UB = None
     with pytest.raises(ValueError, match=re.escape("UB matrix")):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
 
 
 def test_psi_n_parallel_to_q_raises():
     """psi() raises ValueError when the reference is parallel to Q."""
     g = _fourcv_identity()
-    # At chi=0 Q is along XHAT_BL=(1,0,0). Set n=(1,0,0) → parallel to Q.
-    g.azimuthal_reference = (1, 0, 0)
+    # With corrected fourcv at chi=0, Q is along -ZHAT_BL=(0,0,-1).
+    # Set n=(0,0,1) → parallel to Q → raises.
+    g.azimuthal_reference = (0, 0, 1)
     with pytest.raises(ValueError, match=re.escape("parallel to Q")):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
 
 
 def test_psi_pa_shows_azimuthal_reference():
@@ -956,7 +967,7 @@ def test_psi_wh_shows_psi_when_available():
     g.set_angle("omega", 30.0)
     g.set_angle("chi", 0.0)
     g.set_angle("phi", 0.0)
-    g.set_angle("two_theta", 60.0)
+    g.set_angle("ttheta", 60.0)
     assert "Psi" in g.wh(print=False)
 
 
@@ -983,7 +994,7 @@ def test_psi_wh_shows_not_available_when_no_reference():
 @pytest.mark.parametrize(
     "internal,expected",
     [
-        pytest.param("two_theta", "TwoTheta", id="two_theta"),
+        pytest.param("ttheta", "TwoTheta", id="ttheta"),
         pytest.param("omega", "Theta", id="omega"),
         pytest.param("chi", "Chi", id="chi"),
         pytest.param("phi", "Phi", id="phi"),
@@ -1217,7 +1228,7 @@ def test_geometry_samples_property_is_read_only():
     "angles, match",
     [
         pytest.param(
-            {"omega": 0.0, "chi": 0.0, "phi": 0.0, "two_theta": 0.0},
+            {"omega": 0.0, "chi": 0.0, "phi": 0.0, "ttheta": 0.0},
             "Q = 0",
             id="psi-q-zero",
         ),
@@ -1248,7 +1259,7 @@ def test_psi_n_maps_to_zero_raises():
     g.sample.U = np.zeros((3, 3))
     g.azimuthal_reference = (0, 0, 1)
     with pytest.raises(ValueError, match="zero in the phi frame"):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0})
+        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
 
 
 def test_pa_reflection_wavelength_none_falls_back_to_geometry_wavelength():
@@ -1261,7 +1272,7 @@ def test_pa_reflection_wavelength_none_falls_back_to_geometry_wavelength():
     r = Reflection(
         "r1",
         hkl=(0, 0, 6),
-        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94},
+        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94},
         wavelength=None,
     )
     g.sample.reflections._data["r1"] = r

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -456,7 +456,7 @@ def test_angles_to_phi_vector_fourcv_all_zero_gives_zero():
     """fourcv: all-zero angles → Q_phi = 0."""
     g = fourcv()
     g.wavelength = 1.0
-    Q = angles_to_phi_vector(g, omega=0, chi=0, phi=0, two_theta=0)
+    Q = angles_to_phi_vector(g, omega=0, chi=0, phi=0, ttheta=0)
     np.testing.assert_allclose(Q, np.zeros(3), atol=1e-12)
 
 
@@ -469,12 +469,12 @@ def test_angles_to_phi_vector_fourcv_bisecting_magnitude():
     """
     g = fourcv()
     g.wavelength = _LAMBDA_CU_KA
-    two_theta = 28.4474  # Si (111) at Cu Kα
+    ttheta_deg = 28.4474  # Si (111) at Cu Kα
     Q = angles_to_phi_vector(
-        g, omega=two_theta / 2.0, chi=0.0, phi=0.0, two_theta=two_theta
+        g, omega=ttheta_deg / 2.0, chi=0.0, phi=0.0, ttheta=ttheta_deg
     )
     expected_mag = (
-        4.0 * math.pi / _LAMBDA_CU_KA * math.sin(math.radians(two_theta / 2.0))
+        4.0 * math.pi / _LAMBDA_CU_KA * math.sin(math.radians(ttheta_deg / 2.0))
     )
     np.testing.assert_allclose(np.linalg.norm(Q), expected_mag, rtol=1e-6)
 
@@ -1080,7 +1080,7 @@ def test_ub_from_one_reflection_error_branches(reference_stage, reference_hkl, m
     g.add_reflection(
         "r1",
         hkl=(0, 0, 1),
-        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "two_theta": 40.0},
+        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "ttheta": 40.0},
     )
     with pytest.raises(ValueError, match=match):
         ub_from_one_reflection(
@@ -1125,7 +1125,7 @@ def test_ub_from_one_reflection_antiparallel_Bh_and_r(hkl, reference_stage, desc
     g.add_reflection(
         "r1",
         hkl=hkl,
-        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "two_theta": 40.0},
+        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "ttheta": 40.0},
     )
     UB = ub_from_one_reflection(
         g.sample,
@@ -1149,7 +1149,7 @@ def test_ub_from_one_reflection_normal_rotation():
     g.add_reflection(
         "r1",
         hkl=(0, 0, 1),
-        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "two_theta": 40.0},
+        angles={"omega": 20.0, "chi": 0.0, "phi": 0.0, "ttheta": 40.0},
     )
     # B @ (0,0,1) is along z-axis; chi axis is along x-axis → angle ≈ 90°
     # This is neither parallel (0°) nor anti-parallel (180°), so the else branch fires.
@@ -1187,9 +1187,9 @@ def test_ub_from_three_linalg_error_on_H_inv_raises():
     g.sample.lattice = Lattice(a=1.0)
     ub_identity(g.sample)
     for name, hkl, ang in [
-        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}),
-        ("r2", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "two_theta": 60.0}),
-        ("r3", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "two_theta": 60.0}),
+        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}),
+        ("r2", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "ttheta": 60.0}),
+        ("r3", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "ttheta": 60.0}),
     ]:
         g.add_reflection(name, hkl=hkl, angles=ang)
 
@@ -1212,9 +1212,9 @@ def test_ub_from_three_singular_B_inv_sets_U_none():
     g.wavelength = TWO_PI
     g.sample.lattice = Lattice(a=1.0)
     for name, hkl, ang in [
-        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}),
-        ("r2", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "two_theta": 60.0}),
-        ("r3", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "two_theta": 60.0}),
+        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}),
+        ("r2", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "ttheta": 60.0}),
+        ("r3", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "ttheta": 60.0}),
     ]:
         g.add_reflection(name, hkl=hkl, angles=ang)
 
@@ -1251,9 +1251,9 @@ def test_ub_from_three_left_handed_H_logs_warning(caplog):
     ub_identity(g.sample)
     # Swap r2 and r3 → det(H) < 0 → left-handed
     for name, hkl, ang in [
-        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "two_theta": 60.0}),
-        ("r2", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "two_theta": 60.0}),
-        ("r3", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "two_theta": 60.0}),
+        ("r1", (1, 0, 0), {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}),
+        ("r2", (0, 0, 1), {"omega": 30.0, "chi": 90.0, "phi": 30.0, "ttheta": 60.0}),
+        ("r3", (0, 1, 0), {"omega": 30.0, "chi": 0.0, "phi": 90.0, "ttheta": 60.0}),
     ]:
         g.add_reflection(name, hkl=hkl, angles=ang)
 

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -109,7 +109,7 @@ def sapphire_geom():
             "omega": 17.6428,
             "chi": 50.8925,
             "phi": 29.95,
-            "two_theta": 35.392375,
+            "ttheta": 35.392375,
         },
         wavelength=1.549802558,
     )

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -233,7 +233,7 @@ class TestG1ToSample:
 
     def test_or1_angles(self, geom_a):
         ang = geom_a.sample.reflections["or1"].angles
-        assert ang["two_theta"] == pytest.approx(41.94188)
+        assert ang["ttheta"] == pytest.approx(41.94188)
         assert ang["omega"] == pytest.approx(20.97)
         assert ang["chi"] == pytest.approx(90.0)
         assert ang["phi"] == pytest.approx(0.0)
@@ -253,7 +253,7 @@ class TestG1ToSample:
         g = fourcv()
         g1_to_sample(parse_fourc_g1(_G1_LINE_C), g)
         ang = g.sample.reflections["or2"].angles
-        assert ang["two_theta"] == pytest.approx(35.392375)
+        assert ang["ttheta"] == pytest.approx(35.392375)
         assert ang["chi"] == pytest.approx(50.8925)
         assert ang["phi"] == pytest.approx(29.95)
 
@@ -419,7 +419,7 @@ def test_sample_to_g1_only_or1_set():
     g.add_reflection(
         "r1",
         hkl=(0, 0, 6),
-        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "two_theta": 41.94},
+        angles={"omega": 20.97, "chi": 90.0, "phi": 0.0, "ttheta": 41.94},
     )
     g.sample.reflections.setor1("r1")
     g1 = sample_to_g1(g)


### PR DESCRIPTION
## Summary

- Corrects the stage axes of `fourcv`, `fourch`, `kappa4cv`, `kappa4ch` — the `v`/`h` suffix describes the **scattering plane**, not the detector axis
- Renames stage `two_theta` → `ttheta` throughout
- 860 tests pass, 100% coverage

- closes #66

### Root cause

The `v`/`h` suffix was being described as referring to the detector axis, but the correct meaning is the **scattering plane**. Comparing with Busing & Levy (1967) Fig. 1b confirmed `fourch` (horizontal scattering plane) is the laboratory/BL1967 geometry.

### Corrections

| Factory | Before (ttheta axis) | After (ttheta axis) | Scattering plane |
|---------|---------------------|---------------------|-----------------|
| `fourcv` | vertical (-z) | **lateral (-x)** | vertical (synchrotron) ✓ |
| `fourch` | lateral (-x) | **vertical (-z)** | horizontal (BL1967) ✓ |
| `kappa4cv` | vertical (-z) | **lateral (-x)** | vertical ✓ |
| `kappa4ch` | lateral (-x) | **vertical (-z)** | horizontal ✓ |

Also: `fourcv` chi corrected from lateral to **longitudinal** (+y).

### Stage axis notation

Stage axes in the four BL factories now use `_BASIS_BL["lateral"]` etc. instead of `_XHAT_BL`/`_ZHAT_BL`, making the physical direction self-documenting.

Contributed by: OpenCode (argo/claudesonnet46)