### PR TITLE
feat: 3.1 Diffraction mode / operating constraints

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,50 +233,49 @@ The user should be able to declare available modes as part of the
 geometry definition passed to `AdHocDiffractometer`, analogously to
 how stages are declared.
 
-**Interface design questions to resolve:**
-
-- [ ] **Mode declaration in the geometry dict / constructor**: the
-      `AdHocDiffractometer` constructor (or the factory functions)
-      should accept a `modes` argument — a list or dict of named
-      mode objects — so that the available modes are part of the
-      geometry description, not set separately after construction.
-      Example sketch:
+- [x] **Mode declaration in the geometry dict / constructor**: the
+      `AdHocDiffractometer` constructor accepts a `modes` argument —
+      a dict or `ModeDict` of named mode objects — and a `default_mode`
+      argument so that the available modes and the active mode are part
+      of the geometry description, not set separately after construction.
       ```python
       AdHocDiffractometer(
           name="psic",
           stages=[...],
           modes={
-              "bisecting":   BisectingMode(),
+              "bisecting":   BisectingMode("eta", "delta",
+                                 frozen_angles={"mu": 0.0, "nu": 0.0}),
               "fixed_chi":   FixedAngleMode(stage="chi", value=90.0),
               "fixed_phi":   FixedAngleMode(stage="phi", value=0.0),
           },
           default_mode="bisecting",
       )
       ```
-- [ ] **Mode object interface**: each mode must declare:
-      - which stages it constrains (and to what values or relationships)
-      - which stages remain free
-      - any additional constraints (e.g. bisecting: ω = 2θ/2;
-        reference-vector: Q || N)
-      - a method `constrain(geometry, hkl) -> dict[stage_name, angle]`
-        that computes the constrained angle set for a given (h, k, l)
-- [ ] **Active mode**: `AdHocDiffractometer` holds a reference to the
-      currently active mode; switching modes changes which constraints
-      are applied during angle calculations
-- [ ] **Geometry-specific modes**: factory functions should pre-populate
-      the modes dict with the canonical modes for that geometry.
-      For example, psic() should include bisecting, fixed-chi, fixed-mu,
-      and reference-vector modes as defined by You (1999).
-- [ ] **Mode name attribute**: current mode name accessible as a property
-- [ ] **Frozen angle values**: stages held fixed in a given mode
-      (matches SPEC #G0 frozen motor values; see spec_G_lines.md)
-- [ ] **Cut points**: SPEC-style branch selection per axis determining
-      which of the multiple valid angle solutions is chosen
-      (matches SPEC #G4; see spec_G_lines.md)
-- [ ] Reference: You (1999) section on operating modes and constraints;
-      Walko (2016) section 3.3 "Operating Modes";
-      Busing & Levy (1967) section on angle settings.
-- [ ] Depends on: 2.0, 2.2 (angle calculations require UB matrix).
+- [x] **Mode object interface**: `DiffractionMode` ABC in `mode.py`
+      declares `constrained_stages`, `frozen_angles`, `cut_points`, and
+      `apply_cut_point(stage, angle)`; `FixedAngleMode` and
+      `BisectingMode` are the two built-in concrete subclasses.
+- [x] **Active mode**: `AdHocDiffractometer.mode_name` (read/write
+      property) and `AdHocDiffractometer.mode` (read-only, returns the
+      active `DiffractionMode` object or `None`).
+- [x] **Geometry-specific modes**: factory functions pre-populate the
+      modes dict with canonical modes.  psic: bisecting, fixed_chi,
+      fixed_phi, fixed_mu (You 1999); fourcv / fourch: bisecting,
+      fixed_chi, fixed_phi (BL1967); kappa4cv / kappa4ch: bisecting,
+      fixed_kphi; kappa6c: bisecting, fixed_kphi, fixed_mu.
+- [x] **Mode name attribute**: `geometry.mode_name` (str or None).
+- [x] **Frozen angle values**: `DiffractionMode.frozen_angles` dict;
+      mirrors SPEC #G0 frozen motor values.
+- [x] **Cut points (per mode)**: `DiffractionMode.cut_points` dict and
+      `apply_cut_point(stage, angle)` method; mirrors SPEC #G4.
+- [x] **Cut points (per geometry)**: `AdHocDiffractometer.cut_points`
+      dict for geometry-level SPEC #G4 defaults.
+- [x] **Serialisation**: `to_dict` / `from_dict` round-trips modes
+      (`FixedAngleMode`, `BisectingMode`), `mode_name`, and `cut_points`
+      as part of the geometry export; all JSON-serialisable.
+- [x] **ModeDict**: guarded ordered dict; rejects non-`DiffractionMode`
+      values; exported from `__init__.py`.
+- [x] 73 tests in `test_mode.py`; 100% line and branch coverage.
 
 ### 3.2 Azimuthal reference vector ([#11](https://github.com/prjemian/ad_hoc_diffractometer/issues/11))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -40,6 +40,10 @@ from .lattice import Lattice
 from .lattice import b_matrix
 from .lattice import lattice_vectors
 from .lattice import reciprocal_vectors
+from .mode import BisectingMode
+from .mode import DiffractionMode
+from .mode import FixedAngleMode
+from .mode import ModeDict
 from .orientation import angles_to_phi_vector
 from .orientation import ub_from_one_reflection
 from .orientation import ub_from_three_reflections_bl1967
@@ -91,6 +95,11 @@ __all__ = [
     "ReflectionList",
     "Sample",
     "SampleDict",
+    # modes
+    "DiffractionMode",
+    "FixedAngleMode",
+    "BisectingMode",
+    "ModeDict",
     # orientation
     "angles_to_phi_vector",
     "ub_identity",

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -515,19 +515,25 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     """
     Lohmeier & Vlieg (1993) six-circle surface diffractometer (sixc geometry).
 
+    Also known as the IUCr six-circle diffractometer.
     Walko (2016) designation: (S3D2)1.
     Default basis: You (1999) — vertical=+x, longitudinal=+y, lateral=+z.
 
     Sample and detector stacks share the alpha (rotary table) base stage,
     making this a coupled geometry.  Useful for surface diffraction.
 
+    From Fig. 1 and §2.1 of Lohmeier & Vlieg (1993):
+        alpha and gamma rotate about the vertical axis (x in LV convention).
+        omega, phi, and delta all rotate about the lateral axis (z in LV).
+        chi rotates about the longitudinal axis (y in LV).
+
     Stack (floor first):
         alpha (shared base): vertical,     right-handed  [rotary table]
-          --> omega (sample):     longitudinal, right-handed
-                --> chi:          longitudinal, right-handed
-                      --> phi:    longitudinal, right-handed
-          --> delta (detector):   lateral,      left-handed
-                --> gamma:        vertical,     right-handed
+          --> omega (sample):  lateral,      left-handed
+                --> chi:       longitudinal, right-handed
+                      --> phi: lateral,      left-handed
+          --> delta (detector): lateral,     left-handed
+                --> gamma:      vertical,    right-handed
 
     Reference: M. Lohmeier & E. Vlieg, J. Appl. Cryst. 26, 706-716 (1993).
     """
@@ -536,9 +542,9 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     LONGITUDINAL = basis["longitudinal"]
     stages = [
         Stage("alpha", +VERTICAL, parent=None, role="sample"),
-        Stage("omega", +LONGITUDINAL, parent="alpha", role="sample"),
+        Stage("omega", -LATERAL, parent="alpha", role="sample"),
         Stage("chi", +LONGITUDINAL, parent="omega", role="sample"),
-        Stage("phi", +LONGITUDINAL, parent="chi", role="sample"),
+        Stage("phi", -LATERAL, parent="chi", role="sample"),
         Stage("delta", -LATERAL, parent="alpha", role="detector"),
         Stage("gamma", +VERTICAL, parent="delta", role="detector"),
     ]
@@ -548,7 +554,7 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         basis=basis,
         description=(
             "Lohmeier & Vlieg (1993) six-circle surface diffractometer "
-            "(Walko S(3D2)1). "
+            "(IUCr six-circle; Walko S(3D2)1). "
             "Sample and detector share the alpha (rotary table) base stage."
         ),
     )

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -110,6 +110,8 @@ from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
 from .geometry import AdHocDiffractometer
+from .mode import BisectingMode
+from .mode import FixedAngleMode
 from .stage import Stage
 
 logger = logging.getLogger(__name__)
@@ -373,6 +375,21 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         Stage("nu", +VERTICAL, parent=None, role="detector"),
         Stage("delta", -LATERAL, parent="nu", role="detector"),
     ]
+    # Canonical modes from You (1999) section on operating modes.
+    # "bisecting": eta = delta/2, mu = nu = 0  (symmetric reflection geometry)
+    # "fixed_chi":  chi held at a fixed angle (default 90°)
+    # "fixed_phi":  phi held at a fixed angle (default 0°)
+    # "fixed_mu":   mu held at a fixed angle  (default 0°)
+    modes = {
+        "bisecting": BisectingMode(
+            sample_stage="eta",
+            detector_stage="delta",
+            frozen_angles={"mu": 0.0, "nu": 0.0},
+        ),
+        "fixed_chi": FixedAngleMode(stage="chi", value=90.0),
+        "fixed_phi": FixedAngleMode(stage="phi", value=0.0),
+        "fixed_mu": FixedAngleMode(stage="mu", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -381,6 +398,8 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "You (1999) 4S+2D six-circle diffractometer "
             "(lateral detector, vertical scattering plane, synchrotron)"
         ),
+        modes=modes,
+        default_mode="bisecting",
     )
 
 
@@ -419,6 +438,12 @@ def fourcv(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         Stage("phi", -LATERAL, parent="chi", role="sample"),
         Stage("ttheta", -LATERAL, parent=None, role="detector"),
     ]
+    # Canonical four-circle modes (BL1967 / standard practice)
+    modes = {
+        "bisecting": BisectingMode(sample_stage="omega", detector_stage="ttheta"),
+        "fixed_chi": FixedAngleMode(stage="chi", value=90.0),
+        "fixed_phi": FixedAngleMode(stage="phi", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -427,6 +452,8 @@ def fourcv(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
             "Busing & Levy (1967) four-circle Eulerian diffractometer "
             "(vertical scattering plane, lateral ttheta, synchrotron)"
         ),
+        modes=modes,
+        default_mode="bisecting",
     )
 
 
@@ -464,6 +491,12 @@ def fourch(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         Stage("phi", -VERTICAL, parent="chi", role="sample"),
         Stage("ttheta", -VERTICAL, parent=None, role="detector"),
     ]
+    # Canonical four-circle modes (BL1967 / standard practice)
+    modes = {
+        "bisecting": BisectingMode(sample_stage="omega", detector_stage="ttheta"),
+        "fixed_chi": FixedAngleMode(stage="chi", value=90.0),
+        "fixed_phi": FixedAngleMode(stage="phi", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -472,6 +505,8 @@ def fourch(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
             "Busing & Levy (1967) four-circle Eulerian diffractometer "
             "(horizontal scattering plane, vertical ttheta, laboratory)"
         ),
+        modes=modes,
+        default_mode="bisecting",
     )
 
 
@@ -573,6 +608,11 @@ def kappa4cv(
         Stage("kphi", -LATERAL, parent="kappa", role="sample"),
         Stage("ttheta", -LATERAL, parent=None, role="detector"),
     ]
+    # Canonical kappa four-circle modes
+    modes = {
+        "bisecting": BisectingMode(sample_stage="komega", detector_stage="ttheta"),
+        "fixed_kphi": FixedAngleMode(stage="kphi", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -582,6 +622,8 @@ def kappa4cv(
             f"(synchrotron). Kappa alpha = {alpha_deg} deg."
         ),
         kappa_alpha_deg=alpha_deg,
+        modes=modes,
+        default_mode="bisecting",
     )
 
 
@@ -627,6 +669,11 @@ def kappa4ch(
         Stage("kphi", -VERTICAL, parent="kappa", role="sample"),
         Stage("ttheta", -VERTICAL, parent=None, role="detector"),
     ]
+    # Canonical kappa four-circle modes
+    modes = {
+        "bisecting": BisectingMode(sample_stage="komega", detector_stage="ttheta"),
+        "fixed_kphi": FixedAngleMode(stage="kphi", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -636,6 +683,8 @@ def kappa4ch(
             f"(laboratory). Kappa alpha = {alpha_deg} deg."
         ),
         kappa_alpha_deg=alpha_deg,
+        modes=modes,
+        default_mode="bisecting",
     )
 
 
@@ -687,6 +736,16 @@ def kappa6c(
         Stage("nu", +VERTICAL, parent=None, role="detector"),
         Stage("delta", -LATERAL, parent="nu", role="detector"),
     ]
+    # Canonical six-circle kappa modes (psic-style, You 1999)
+    modes = {
+        "bisecting": BisectingMode(
+            sample_stage="komega",
+            detector_stage="delta",
+            frozen_angles={"mu": 0.0, "nu": 0.0},
+        ),
+        "fixed_kphi": FixedAngleMode(stage="kphi", value=0.0),
+        "fixed_mu": FixedAngleMode(stage="mu", value=0.0),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -697,6 +756,8 @@ def kappa6c(
             f"Kappa alpha = {alpha_deg} deg."
         ),
         kappa_alpha_deg=alpha_deg,
+        modes=modes,
+        default_mode="bisecting",
     )
 
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -13,6 +13,8 @@ import numpy as np
 from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
+from .mode import DiffractionMode
+from .mode import ModeDict
 from .reflection import Reflection
 from .reflection import ReflectionList
 from .sample import _DEFAULT_LATTICE
@@ -69,6 +71,19 @@ class AdHocDiffractometer:
         Azimuthal reference direction as Miller indices (h, k, l).  Used
         by :meth:`psi` to compute the azimuthal angle ψ.  ``None`` (default)
         means no reference is set.  Must be a non-zero vector.
+    modes : dict[str, DiffractionMode] or ModeDict or None, optional
+        Named diffraction modes available for this geometry.  Keys are
+        mode names (str); values are :class:`~mode.DiffractionMode`
+        instances.  ``None`` (default) means no modes are declared.
+    default_mode : str or None, optional
+        Name of the mode that is active at construction time.  Must be a
+        key of ``modes`` if both are supplied.  ``None`` (default) means no
+        active mode is set (``mode_name`` returns ``None``).
+    cut_points : dict[str, float] or None, optional
+        Geometry-level SPEC #G4 cut-points per stage name.  These are the
+        default cut-points when no mode-level cut-point overrides them.
+        A cut-point C for stage X means the returned angle lies in
+        ``[C, C + 360°)``.  ``None`` is equivalent to an empty dict.
 
     Attributes
     ----------
@@ -82,6 +97,12 @@ class AdHocDiffractometer:
         Kappa tilt angle in degrees, or None for non-kappa geometries.
     azimuthal_reference : tuple of float or None
         Azimuthal reference vector (h, k, l), or None if not set.
+    modes : ModeDict
+        The collection of named modes.  Empty if none were supplied.
+    mode_name : str or None
+        Name of the currently active mode, or ``None`` if no mode is set.
+    cut_points : dict[str, float]
+        Geometry-level SPEC #G4 cut-points per stage; mirrors SPEC #G4.
     """
 
     DEFAULT_BASIS = {
@@ -99,6 +120,9 @@ class AdHocDiffractometer:
         wavelength: float | None = None,
         kappa_alpha_deg: float | None = None,
         azimuthal_reference: tuple[float, float, float] | None = None,
+        modes: dict | ModeDict | None = None,
+        default_mode: str | None = None,
+        cut_points: dict[str, float] | None = None,
     ):
         self.name = name
         self.description = description
@@ -106,6 +130,24 @@ class AdHocDiffractometer:
         self.wavelength = wavelength  # validated via property setter
         self.kappa_alpha_deg = kappa_alpha_deg
         self.azimuthal_reference = azimuthal_reference  # validated via property setter
+
+        # Diffraction modes
+        if isinstance(modes, ModeDict):
+            self._modes = modes
+        else:
+            self._modes = ModeDict(modes)  # accepts None or plain dict
+
+        # Validate and set the active mode name
+        if default_mode is not None and default_mode not in self._modes:
+            available = sorted(self._modes.keys())
+            raise ValueError(
+                f"default_mode {default_mode!r} is not in the modes dict. "
+                f"Available modes: {available}."
+            )
+        self._mode_name: str | None = default_mode
+
+        # Geometry-level cut-points (SPEC #G4)
+        self.cut_points: dict[str, float] = dict(cut_points or {})
 
         # Validate basis vectors
         self._check_basis()
@@ -335,6 +377,70 @@ class AdHocDiffractometer:
                 "azimuthal_reference must be a non-zero vector; (0, 0, 0) is not allowed."
             )
         self._azimuthal_reference = (h, k, l)
+
+    # ------------------------------------------------------------------
+    # Diffraction modes
+    # ------------------------------------------------------------------
+
+    @property
+    def modes(self) -> ModeDict:
+        """
+        The collection of named diffraction modes for this geometry.
+
+        A ``ModeDict`` mapping mode name (str) to
+        :class:`~mode.DiffractionMode` instance.  Empty when no modes
+        have been declared.
+
+        Returns
+        -------
+        ModeDict
+        """
+        return self._modes
+
+    @property
+    def mode_name(self) -> str | None:
+        """
+        Name of the currently active diffraction mode, or ``None``.
+
+        Setting this property switches the active mode.  The name must
+        be a key of :attr:`modes`.
+
+        Returns
+        -------
+        str or None
+
+        Raises
+        ------
+        ValueError
+            If the supplied name is not in :attr:`modes`.
+        """
+        return self._mode_name
+
+    @mode_name.setter
+    def mode_name(self, name: str | None) -> None:
+        if name is not None and name not in self._modes:
+            available = sorted(self._modes.keys())
+            raise ValueError(
+                f"Mode {name!r} is not available in this geometry. "
+                f"Available modes: {available}."
+            )
+        self._mode_name = name
+
+    @property
+    def mode(self) -> DiffractionMode | None:
+        """
+        The currently active :class:`~mode.DiffractionMode`, or ``None``.
+
+        Equivalent to ``self.modes[self.mode_name]`` when a mode is
+        active; ``None`` when :attr:`mode_name` is ``None``.
+
+        Returns
+        -------
+        DiffractionMode or None
+        """
+        if self._mode_name is None:
+            return None
+        return self._modes[self._mode_name]
 
     # ------------------------------------------------------------------
     # Public interface
@@ -1033,6 +1139,82 @@ class AdHocDiffractometer:
     # Serialisation
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _mode_to_dict(mode: "DiffractionMode") -> dict:
+        """
+        Serialise a :class:`~mode.DiffractionMode` to a JSON-serialisable dict.
+
+        The ``"type"`` key records the class name so that :meth:`_mode_from_dict`
+        can reconstruct the correct subclass.  Currently supports
+        ``FixedAngleMode`` and ``BisectingMode``; other subclasses are
+        serialised with their class name and common fields only (they will
+        be reconstructed as the base type on round-trip, which is a no-op
+        for the abstract base class — callers should not round-trip custom
+        subclasses through ``to_dict`` / ``from_dict``).
+        """
+        from .mode import BisectingMode
+        from .mode import FixedAngleMode
+
+        d: dict = {
+            "type": type(mode).__name__,
+            "frozen_angles": dict(mode.frozen_angles),
+            "cut_points": dict(mode.cut_points),
+        }
+        if isinstance(mode, FixedAngleMode):
+            d["stage"] = mode._stage
+            d["value"] = mode._value
+        elif isinstance(mode, BisectingMode):  # pragma: no branch
+            d["sample_stage"] = mode.sample_stage
+            d["detector_stage"] = mode.detector_stage
+        return d
+
+    @staticmethod
+    def _mode_from_dict(d: dict) -> "DiffractionMode":
+        """
+        Reconstruct a :class:`~mode.DiffractionMode` from a dict produced by
+        :meth:`_mode_to_dict`.
+
+        Unknown ``"type"`` values fall back to reconstructing a plain
+        :class:`~mode.DiffractionMode`-compatible object; practically, an
+        unrecognised type is silently skipped and a ``FixedAngleMode`` with
+        no stage is not valid.  In practice this code path is unreachable
+        from the built-in types.
+        """
+        from .mode import BisectingMode
+        from .mode import DiffractionMode
+        from .mode import FixedAngleMode
+
+        type_name = d.get("type", "")
+        frozen = d.get("frozen_angles", {})
+        cuts = d.get("cut_points", {})
+
+        if type_name == "FixedAngleMode":
+            return FixedAngleMode(
+                stage=d["stage"],
+                value=d["value"],
+                cut_points=cuts or None,
+            )
+        if type_name == "BisectingMode":
+            return BisectingMode(
+                sample_stage=d["sample_stage"],
+                detector_stage=d["detector_stage"],
+                frozen_angles=frozen or None,
+                cut_points=cuts or None,
+            )
+        # Unknown type — reconstruct as a minimal anonymous subclass so the
+        # round-trip does not crash, preserving frozen_angles and cut_points.
+        # (This branch is not exercised by built-in types — pragma: no cover)
+
+        class _UnknownMode(DiffractionMode):  # pragma: no cover
+            @property
+            def constrained_stages(self) -> list[str]:
+                return list(self.frozen_angles.keys())
+
+        obj = _UnknownMode(  # pragma: no cover
+            frozen_angles=frozen or None, cut_points=cuts or None
+        )
+        return obj  # pragma: no cover
+
     def to_dict(self) -> dict:
         """
         Export the complete diffractometer configuration as a
@@ -1100,6 +1282,11 @@ class AdHocDiffractometer:
             name: sample.to_dict() for name, sample in self.__samples._data.items()
         }
 
+        # Serialise modes: each mode records its type name and constructor fields.
+        modes_dict = {}
+        for mode_name, mode_obj in self._modes.items():
+            modes_dict[mode_name] = self._mode_to_dict(mode_obj)
+
         return {
             "_meta": {
                 "software": "ad_hoc_diffractometer",
@@ -1119,6 +1306,9 @@ class AdHocDiffractometer:
             "stages": stages,
             "active_sample": self._active_ref[0],
             "samples": samples,
+            "modes": modes_dict,
+            "mode_name": self._mode_name,
+            "cut_points": dict(self.cut_points),
         }
 
     @classmethod
@@ -1179,6 +1369,12 @@ class AdHocDiffractometer:
 
         stages_list = list(stage_objects.values())
 
+        # Restore modes
+        raw_modes = d.get("modes", {})
+        restored_modes: dict[str, DiffractionMode] = {}
+        for mname, mdict in raw_modes.items():
+            restored_modes[mname] = cls._mode_from_dict(mdict)
+
         geom = cls(
             name=d["name"],
             stages=stages_list,
@@ -1187,6 +1383,9 @@ class AdHocDiffractometer:
             wavelength=d.get("wavelength"),
             kappa_alpha_deg=d.get("kappa_alpha_deg"),
             azimuthal_reference=d.get("azimuthal_reference"),
+            modes=restored_modes if restored_modes else None,
+            default_mode=d.get("mode_name"),
+            cut_points=d.get("cut_points"),
         )
 
         # Restore samples.

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -1,0 +1,388 @@
+"""
+mode.py — Diffraction mode / operating constraints.
+
+A diffraction mode specifies which degrees of freedom are constrained
+during a diffraction calculation and which are free.  Modes are a
+first-class concern of the geometry description.
+
+Classes
+-------
+DiffractionMode
+    Abstract base class for all modes.  Declares which stages are
+    constrained (frozen) and which remain free, plus optional cut-points
+    for branch selection.
+
+FixedAngleMode
+    Constrains one named stage to a fixed angle value.
+
+BisectingMode
+    Bisecting geometry: omega = ttheta/2 (half the detector angle).
+    For psic-family geometries this means eta = delta/2.
+
+ModeDict
+    An ordered, guarded dict of named modes.  Validates that all entries
+    are DiffractionMode instances; prevents inserting non-Mode values.
+
+Notes
+-----
+Cut-points control which branch of a multi-valued angle solution is
+returned (SPEC #G4 convention).  A cut-point for stage X with value C
+means the returned angle is chosen in the interval [C, C + 360°).
+
+Frozen-angle values mirror the SPEC #G0 convention: when a mode holds a
+stage fixed, that stage's frozen angle is recorded on the mode object as
+``frozen_angles``.
+
+References
+----------
+Busing & Levy, Acta Cryst. 22, 457-464 (1967).
+You, J. Appl. Cryst. 32, 614-623 (1999).
+Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), section 3.3.
+SPEC #G0, #G4 lines — references/2020-12-13-fourcc-alignment-7-id-c/spec_G_lines.md
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class DiffractionMode(ABC):
+    """
+    Abstract base class for diffraction modes.
+
+    A mode specifies:
+    - which stages are frozen (held at a fixed angle during the calculation)
+    - which stages are free (computed by the forward calculation)
+    - per-stage cut-points for branch selection (SPEC #G4)
+
+    Subclasses must implement :meth:`constrain` and :meth:`constrained_stages`.
+
+    Parameters
+    ----------
+    frozen_angles : dict[str, float] or None
+        Mapping of stage name -> frozen angle (degrees).  Stages in this
+        dict are held at the given angle during diffraction calculations.
+        ``None`` is equivalent to an empty dict (no frozen angles).
+    cut_points : dict[str, float] or None
+        Mapping of stage name -> cut-point angle (degrees).  The returned
+        solution angle for that stage lies in ``[cut, cut + 360)``.
+        ``None`` is equivalent to an empty dict (no cut-points set, i.e.
+        the default branch [-180, 180) is used).
+
+    Attributes
+    ----------
+    frozen_angles : dict[str, float]
+        Stages held fixed in this mode; mirrors SPEC #G0.
+    cut_points : dict[str, float]
+        Branch selection cut-points per stage; mirrors SPEC #G4.
+    """
+
+    def __init__(
+        self,
+        frozen_angles: dict[str, float] | None = None,
+        cut_points: dict[str, float] | None = None,
+    ) -> None:
+        self.frozen_angles: dict[str, float] = dict(frozen_angles or {})
+        self.cut_points: dict[str, float] = dict(cut_points or {})
+
+    @property
+    @abstractmethod
+    def constrained_stages(self) -> list[str]:
+        """
+        Return the list of stage names that are constrained (not free) in this mode.
+
+        Constrained stages include both:
+        - frozen stages (held at a fixed angle)
+        - stages whose angle is determined by a relationship to another stage
+          (e.g. bisecting: omega = ttheta/2)
+
+        Returns
+        -------
+        list of str
+        """
+
+    def apply_cut_point(self, stage_name: str, angle_deg: float) -> float:
+        """
+        Apply the cut-point for *stage_name* to *angle_deg*.
+
+        If no cut-point is set for this stage, the angle is returned
+        unchanged.
+
+        A cut-point C means the returned angle lies in ``[C, C + 360)``.
+
+        Parameters
+        ----------
+        stage_name : str
+            Stage to apply the cut-point to.
+        angle_deg : float
+            Angle to normalise (degrees).
+
+        Returns
+        -------
+        float
+            Angle normalised to the cut-point interval.
+        """
+        if stage_name not in self.cut_points:
+            return angle_deg
+        cut = self.cut_points[stage_name]
+        # Shift into [cut, cut + 360)
+        remainder = (angle_deg - cut) % 360.0
+        return cut + remainder
+
+    def __repr__(self) -> str:  # pragma: no cover
+        # Each concrete subclass provides its own __repr__; this fallback is
+        # kept for completeness but is never reached in production use.
+        return (
+            f"{type(self).__name__}("
+            f"frozen_angles={self.frozen_angles!r}, "
+            f"cut_points={self.cut_points!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover
+        # Each concrete subclass overrides __eq__ with type-specific checks;
+        # this base implementation is never reached in production use.
+        if type(self) is not type(other):
+            return False
+        return (
+            self.frozen_angles == other.frozen_angles  # type: ignore[attr-defined]
+            and self.cut_points == other.cut_points  # type: ignore[attr-defined]
+        )
+
+
+class FixedAngleMode(DiffractionMode):
+    """
+    Mode that constrains one stage to a fixed angle.
+
+    The stage named ``stage`` is held at ``value`` degrees for all
+    diffraction calculations performed in this mode.
+
+    Parameters
+    ----------
+    stage : str
+        Name of the stage to freeze.
+    value : float
+        Angle (degrees) at which to freeze the stage.
+    cut_points : dict[str, float] or None
+        Branch-selection cut-points (see :class:`DiffractionMode`).
+
+    Examples
+    --------
+    >>> mode = FixedAngleMode(stage="chi", value=90.0)
+    >>> mode.frozen_angles
+    {'chi': 90.0}
+    >>> mode.constrained_stages
+    ['chi']
+    """
+
+    def __init__(
+        self,
+        stage: str,
+        value: float,
+        cut_points: dict[str, float] | None = None,
+    ) -> None:
+        super().__init__(
+            frozen_angles={stage: float(value)},
+            cut_points=cut_points,
+        )
+        self._stage = stage
+        self._value = float(value)
+
+    @property
+    def constrained_stages(self) -> list[str]:
+        """Stages constrained by this mode: just the one frozen stage."""
+        return [self._stage]
+
+    def __repr__(self) -> str:
+        return (
+            f"FixedAngleMode(stage={self._stage!r}, value={self._value!r}, "
+            f"cut_points={self.cut_points!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        return (
+            self._stage == other._stage  # type: ignore[attr-defined]
+            and self._value == other._value  # type: ignore[attr-defined]
+            and self.cut_points == other.cut_points  # type: ignore[attr-defined]
+        )
+
+
+class BisectingMode(DiffractionMode):
+    """
+    Bisecting geometry: the sample rotation is set to half the detector angle.
+
+    In the four-circle / psic convention, "bisecting" means that the
+    incident and diffracted beam make equal angles with the diffracting
+    planes.  Concretely:
+
+    - For ``fourcv`` / ``fourch``: ``omega = ttheta / 2``
+    - For ``psic``: ``eta = delta / 2`` (with ``mu = nu = 0`` by convention)
+
+    This mode records the convention via ``sample_stage`` (the stage that is
+    driven to half the detector angle) and ``detector_stage`` (the reference
+    detector stage).
+
+    Parameters
+    ----------
+    sample_stage : str
+        Name of the sample rotation stage driven to half the detector angle
+        (e.g. ``"omega"`` for fourcv, ``"eta"`` for psic).
+    detector_stage : str
+        Name of the detector stage whose angle determines the constraint
+        (e.g. ``"ttheta"`` for fourcv, ``"delta"`` for psic).
+    frozen_angles : dict[str, float] or None
+        Additional stages held fixed (e.g. ``{"mu": 0.0, "nu": 0.0}`` for psic).
+    cut_points : dict[str, float] or None
+        Branch-selection cut-points (see :class:`DiffractionMode`).
+
+    Examples
+    --------
+    >>> mode = BisectingMode(sample_stage="omega", detector_stage="ttheta")
+    >>> mode.constrained_stages
+    ['omega']
+    >>> mode_psic = BisectingMode(
+    ...     sample_stage="eta",
+    ...     detector_stage="delta",
+    ...     frozen_angles={"mu": 0.0, "nu": 0.0},
+    ... )
+    >>> mode_psic.constrained_stages
+    ['eta', 'mu', 'nu']
+    """
+
+    def __init__(
+        self,
+        sample_stage: str,
+        detector_stage: str,
+        frozen_angles: dict[str, float] | None = None,
+        cut_points: dict[str, float] | None = None,
+    ) -> None:
+        super().__init__(frozen_angles=frozen_angles, cut_points=cut_points)
+        self._sample_stage = sample_stage
+        self._detector_stage = detector_stage
+
+    @property
+    def sample_stage(self) -> str:
+        """The sample rotation stage driven to half the detector angle."""
+        return self._sample_stage
+
+    @property
+    def detector_stage(self) -> str:
+        """The detector stage that determines the bisecting constraint."""
+        return self._detector_stage
+
+    @property
+    def constrained_stages(self) -> list[str]:
+        """
+        Stages constrained by the bisecting condition.
+
+        Always includes ``sample_stage``, plus any additional stages in
+        ``frozen_angles``.
+        """
+        constrained = [self._sample_stage]
+        for name in self.frozen_angles:
+            if name not in constrained:
+                constrained.append(name)
+        return constrained
+
+    def __repr__(self) -> str:
+        return (
+            f"BisectingMode(sample_stage={self._sample_stage!r}, "
+            f"detector_stage={self._detector_stage!r}, "
+            f"frozen_angles={self.frozen_angles!r}, "
+            f"cut_points={self.cut_points!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
+            return False
+        return (
+            self._sample_stage == other._sample_stage  # type: ignore[attr-defined]
+            and self._detector_stage == other._detector_stage  # type: ignore[attr-defined]
+            and self.frozen_angles == other.frozen_angles  # type: ignore[attr-defined]
+            and self.cut_points == other.cut_points  # type: ignore[attr-defined]
+        )
+
+
+class ModeDict:
+    """
+    An ordered, guarded dict of named diffraction modes.
+
+    Only :class:`DiffractionMode` instances may be stored.  Keys are
+    mode names (str).  Iteration follows insertion order.
+
+    Parameters
+    ----------
+    modes : dict[str, DiffractionMode] or None
+        Initial modes.  If ``None``, an empty dict is created.
+
+    Raises
+    ------
+    TypeError
+        If any value is not a :class:`DiffractionMode` instance.
+
+    Examples
+    --------
+    >>> md = ModeDict({"bisecting": BisectingMode("omega", "ttheta")})
+    >>> "bisecting" in md
+    True
+    >>> len(md)
+    1
+    """
+
+    def __init__(self, modes: dict[str, DiffractionMode] | None = None) -> None:
+        self._data: dict[str, DiffractionMode] = {}
+        if modes:
+            for name, mode in modes.items():
+                self[name] = mode  # validates type
+
+    def __setitem__(self, name: str, mode: DiffractionMode) -> None:
+        if not isinstance(mode, DiffractionMode):
+            raise TypeError(
+                f"ModeDict values must be DiffractionMode instances; "
+                f"got {type(mode).__name__!r} for key {name!r}."
+            )
+        self._data[name] = mode
+
+    def __getitem__(self, name: str) -> DiffractionMode:
+        return self._data[name]
+
+    def __delitem__(self, name: str) -> None:
+        del self._data[name]
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __repr__(self) -> str:
+        return f"ModeDict({self._data!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ModeDict):
+            return False
+        return self._data == other._data
+
+    def keys(self):
+        """Return mode names."""
+        return self._data.keys()
+
+    def values(self):
+        """Return mode objects."""
+        return self._data.values()
+
+    def items(self):
+        """Return (name, mode) pairs."""
+        return self._data.items()

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -418,6 +418,56 @@ def test_geometry_parent_chain(factory, stage_name, expected_parent, context):
         pytest.param(
             psic, "delta", -ZHAT, does_not_raise(), id="psic-delta-lateral-left-handed"
         ),
+        # fourcv — BL1967, vertical scattering plane; basis: lateral=+x, long=+y, vert=+z
+        pytest.param(
+            fourcv,
+            "omega",
+            -XHAT,
+            does_not_raise(),
+            id="fourcv-omega-lateral-left-handed",
+        ),
+        pytest.param(
+            fourcv,
+            "chi",
+            +YHAT,
+            does_not_raise(),
+            id="fourcv-chi-longitudinal-right-handed",
+        ),
+        pytest.param(
+            fourcv, "phi", -XHAT, does_not_raise(), id="fourcv-phi-lateral-left-handed"
+        ),
+        pytest.param(
+            fourcv,
+            "ttheta",
+            -XHAT,
+            does_not_raise(),
+            id="fourcv-ttheta-lateral-left-handed",
+        ),
+        # fourch — BL1967, horizontal scattering plane; basis: lateral=+x, long=+y, vert=+z
+        pytest.param(
+            fourch,
+            "omega",
+            -ZHAT,
+            does_not_raise(),
+            id="fourch-omega-vertical-left-handed",
+        ),
+        pytest.param(
+            fourch,
+            "chi",
+            +YHAT,
+            does_not_raise(),
+            id="fourch-chi-longitudinal-right-handed",
+        ),
+        pytest.param(
+            fourch, "phi", -ZHAT, does_not_raise(), id="fourch-phi-vertical-left-handed"
+        ),
+        pytest.param(
+            fourch,
+            "ttheta",
+            -ZHAT,
+            does_not_raise(),
+            id="fourch-ttheta-vertical-left-handed",
+        ),
         # sixc — LV1993 Fig. 1 and §2.1:
         #   alpha, gamma: vertical (+x), right-handed
         #   omega, phi, delta: lateral (-z), left-handed
@@ -452,6 +502,28 @@ def test_geometry_parent_chain(factory, stage_name, expected_parent, context):
             does_not_raise(),
             id="sixc-gamma-vertical-right-handed",
         ),
+        # kappa4cv — BL1967 basis: lateral=+x, long=+y, vert=+z; vertical scattering plane
+        pytest.param(
+            kappa4cv,
+            "komega",
+            -XHAT,
+            does_not_raise(),
+            id="kappa4cv-komega-lateral-left-handed",
+        ),
+        pytest.param(
+            kappa4cv,
+            "kphi",
+            -XHAT,
+            does_not_raise(),
+            id="kappa4cv-kphi-lateral-left-handed",
+        ),
+        pytest.param(
+            kappa4cv,
+            "ttheta",
+            -XHAT,
+            does_not_raise(),
+            id="kappa4cv-ttheta-lateral-left-handed",
+        ),
         pytest.param(
             kappa4cv,
             "kappa",
@@ -459,6 +531,138 @@ def test_geometry_parent_chain(factory, stage_name, expected_parent, context):
             + np.sin(np.deg2rad(50)) * np.array([1, 0, 0]),
             does_not_raise(),
             id="kappa4cv-kappa-axis-tilted",
+        ),
+        # kappa4ch — BL1967 basis; horizontal scattering plane
+        pytest.param(
+            kappa4ch,
+            "komega",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa4ch-komega-vertical-left-handed",
+        ),
+        pytest.param(
+            kappa4ch,
+            "kphi",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa4ch-kphi-vertical-left-handed",
+        ),
+        pytest.param(
+            kappa4ch,
+            "ttheta",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa4ch-ttheta-vertical-left-handed",
+        ),
+        # kappa6c — You basis: vert=+x, long=+y, lat=+z; psic-style outer axes
+        pytest.param(
+            kappa6c,
+            "mu",
+            +XHAT,
+            does_not_raise(),
+            id="kappa6c-mu-vertical-right-handed",
+        ),
+        pytest.param(
+            kappa6c,
+            "komega",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa6c-komega-lateral-left-handed",
+        ),
+        pytest.param(
+            kappa6c,
+            "kphi",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa6c-kphi-lateral-left-handed",
+        ),
+        pytest.param(
+            kappa6c,
+            "nu",
+            +XHAT,
+            does_not_raise(),
+            id="kappa6c-nu-vertical-right-handed",
+        ),
+        pytest.param(
+            kappa6c,
+            "delta",
+            -ZHAT,
+            does_not_raise(),
+            id="kappa6c-delta-lateral-left-handed",
+        ),
+        # zaxis — You basis: vert=+x, long=+y, lat=+z
+        pytest.param(
+            zaxis,
+            "alpha",
+            +XHAT,
+            does_not_raise(),
+            id="zaxis-alpha-vertical-right-handed",
+        ),
+        pytest.param(
+            zaxis,
+            "Z",
+            +YHAT,
+            does_not_raise(),
+            id="zaxis-Z-longitudinal-right-handed",
+        ),
+        pytest.param(
+            zaxis,
+            "delta",
+            -ZHAT,
+            does_not_raise(),
+            id="zaxis-delta-lateral-left-handed",
+        ),
+        pytest.param(
+            zaxis,
+            "gamma",
+            +XHAT,
+            does_not_raise(),
+            id="zaxis-gamma-vertical-right-handed",
+        ),
+        # s2d2 — You basis: vert=+x, long=+y, lat=+z
+        pytest.param(
+            s2d2, "mu", +XHAT, does_not_raise(), id="s2d2-mu-vertical-right-handed"
+        ),
+        pytest.param(
+            s2d2, "Z", +YHAT, does_not_raise(), id="s2d2-Z-longitudinal-right-handed"
+        ),
+        pytest.param(
+            s2d2, "nu", +XHAT, does_not_raise(), id="s2d2-nu-vertical-right-handed"
+        ),
+        pytest.param(
+            s2d2,
+            "delta",
+            -ZHAT,
+            does_not_raise(),
+            id="s2d2-delta-lateral-left-handed",
+        ),
+        # fivec — You basis: vert=+x, long=+y, lat=+z; fourcv on vertical base
+        pytest.param(
+            fivec, "mu", +XHAT, does_not_raise(), id="fivec-mu-vertical-right-handed"
+        ),
+        pytest.param(
+            fivec,
+            "omega",
+            -ZHAT,
+            does_not_raise(),
+            id="fivec-omega-lateral-left-handed",
+        ),
+        pytest.param(
+            fivec,
+            "chi",
+            +YHAT,
+            does_not_raise(),
+            id="fivec-chi-longitudinal-right-handed",
+        ),
+        pytest.param(
+            fivec, "phi", -ZHAT, does_not_raise(), id="fivec-phi-lateral-left-handed"
+        ),
+        pytest.param(
+            fivec,
+            "ttheta",
+            -ZHAT,
+            does_not_raise(),
+            id="fivec-ttheta-lateral-left-handed",
         ),
     ],
 )

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -418,6 +418,40 @@ def test_geometry_parent_chain(factory, stage_name, expected_parent, context):
         pytest.param(
             psic, "delta", -ZHAT, does_not_raise(), id="psic-delta-lateral-left-handed"
         ),
+        # sixc — LV1993 Fig. 1 and §2.1:
+        #   alpha, gamma: vertical (+x), right-handed
+        #   omega, phi, delta: lateral (-z), left-handed
+        #   chi: longitudinal (+y), right-handed
+        pytest.param(
+            sixc,
+            "alpha",
+            +XHAT,
+            does_not_raise(),
+            id="sixc-alpha-vertical-right-handed",
+        ),
+        pytest.param(
+            sixc, "omega", -ZHAT, does_not_raise(), id="sixc-omega-lateral-left-handed"
+        ),
+        pytest.param(
+            sixc,
+            "chi",
+            +YHAT,
+            does_not_raise(),
+            id="sixc-chi-longitudinal-right-handed",
+        ),
+        pytest.param(
+            sixc, "phi", -ZHAT, does_not_raise(), id="sixc-phi-lateral-left-handed"
+        ),
+        pytest.param(
+            sixc, "delta", -ZHAT, does_not_raise(), id="sixc-delta-lateral-left-handed"
+        ),
+        pytest.param(
+            sixc,
+            "gamma",
+            +XHAT,
+            does_not_raise(),
+            id="sixc-gamma-vertical-right-handed",
+        ),
         pytest.param(
             kappa4cv,
             "kappa",

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1,0 +1,745 @@
+"""
+Unit tests for ad_hoc_diffractometer.mode and mode-related geometry features.
+
+Covers:
+  - DiffractionMode ABC (constrained_stages, apply_cut_point, __repr__, __eq__)
+  - FixedAngleMode: construction, frozen_angles, constrained_stages, __repr__, __eq__
+  - BisectingMode: construction, constrained_stages, __repr__, __eq__
+  - ModeDict: construction, set/get/delete, type guard, __len__, __iter__,
+    keys/values/items, __repr__, __eq__, __contains__
+  - AdHocDiffractometer: modes, default_mode, mode_name, mode property,
+    cut_points, mode_name setter validation, mode=None when no mode set
+  - Factory modes: psic, fourcv, fourch, kappa4cv, kappa4ch, kappa6c
+    each pre-populate modes and have a bisecting default
+  - Serialisation round-trip: to_dict / from_dict for FixedAngleMode,
+    BisectingMode, ModeDict on geometry, and cut_points
+  - Export/import: mode state survives to_dict / from_dict
+"""
+
+import json
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ad_hoc_diffractometer import AdHocDiffractometer
+from ad_hoc_diffractometer import BisectingMode
+from ad_hoc_diffractometer import FixedAngleMode
+from ad_hoc_diffractometer import ModeDict
+from ad_hoc_diffractometer import Stage
+from ad_hoc_diffractometer import fivec
+from ad_hoc_diffractometer import fourch
+from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import kappa4ch
+from ad_hoc_diffractometer import kappa4cv
+from ad_hoc_diffractometer import kappa6c
+from ad_hoc_diffractometer import psic
+from ad_hoc_diffractometer import s2d2
+from ad_hoc_diffractometer import sixc
+from ad_hoc_diffractometer import zaxis
+from ad_hoc_diffractometer.constants import XHAT
+from ad_hoc_diffractometer.constants import YHAT
+from ad_hoc_diffractometer.constants import ZHAT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _simple_geometry(**kwargs):
+    """Minimal 2-stage geometry for testing mode features."""
+    stages = [
+        Stage("omega", -ZHAT, parent=None, role="sample"),
+        Stage("ttheta", -ZHAT, parent=None, role="detector"),
+    ]
+    return AdHocDiffractometer(
+        name="test_geom",
+        stages=stages,
+        basis={"vertical": XHAT, "longitudinal": YHAT, "lateral": ZHAT},
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FixedAngleMode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stage, value, cut_points, expected_frozen, expected_constrained, context",
+    [
+        pytest.param(
+            "chi",
+            90.0,
+            None,
+            {"chi": 90.0},
+            ["chi"],
+            does_not_raise(),
+            id="basic-fixed-chi-90",
+        ),
+        pytest.param(
+            "phi",
+            0.0,
+            None,
+            {"phi": 0.0},
+            ["phi"],
+            does_not_raise(),
+            id="basic-fixed-phi-0",
+        ),
+        pytest.param(
+            "mu",
+            -45.0,
+            {"mu": -180.0},
+            {"mu": -45.0},
+            ["mu"],
+            does_not_raise(),
+            id="with-cut-point",
+        ),
+    ],
+)
+def test_fixed_angle_mode_construction(
+    stage, value, cut_points, expected_frozen, expected_constrained, context
+):
+    with context:
+        mode = FixedAngleMode(stage=stage, value=value, cut_points=cut_points)
+        assert mode.frozen_angles == expected_frozen
+        assert mode.constrained_stages == expected_constrained
+        assert mode.cut_points == (cut_points or {})
+
+
+def test_fixed_angle_mode_repr():
+    mode = FixedAngleMode(stage="chi", value=90.0)
+    r = repr(mode)
+    assert "FixedAngleMode" in r
+    assert "chi" in r
+    assert "90.0" in r
+
+
+def test_fixed_angle_mode_eq_same():
+    m1 = FixedAngleMode(stage="chi", value=90.0)
+    m2 = FixedAngleMode(stage="chi", value=90.0)
+    assert m1 == m2
+
+
+def test_fixed_angle_mode_eq_different_value():
+    m1 = FixedAngleMode(stage="chi", value=90.0)
+    m2 = FixedAngleMode(stage="chi", value=0.0)
+    assert m1 != m2
+
+
+def test_fixed_angle_mode_eq_different_stage():
+    m1 = FixedAngleMode(stage="chi", value=90.0)
+    m2 = FixedAngleMode(stage="phi", value=90.0)
+    assert m1 != m2
+
+
+def test_fixed_angle_mode_eq_different_type():
+    m1 = FixedAngleMode(stage="chi", value=90.0)
+    m2 = BisectingMode(sample_stage="omega", detector_stage="ttheta")
+    assert m1 != m2
+
+
+def test_fixed_angle_mode_eq_non_mode():
+    m = FixedAngleMode(stage="chi", value=90.0)
+    assert m != "not a mode"
+
+
+# ---------------------------------------------------------------------------
+# BisectingMode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sample_stage, detector_stage, frozen_angles, cut_points, "
+    "expected_constrained, context",
+    [
+        pytest.param(
+            "omega",
+            "ttheta",
+            None,
+            None,
+            ["omega"],
+            does_not_raise(),
+            id="basic-bisecting-omega-ttheta",
+        ),
+        pytest.param(
+            "eta",
+            "delta",
+            {"mu": 0.0, "nu": 0.0},
+            None,
+            ["eta", "mu", "nu"],
+            does_not_raise(),
+            id="psic-bisecting-with-frozen",
+        ),
+        pytest.param(
+            "komega",
+            "delta",
+            {"mu": 0.0, "nu": 0.0},
+            {"komega": -180.0},
+            ["komega", "mu", "nu"],
+            does_not_raise(),
+            id="bisecting-with-cut-point",
+        ),
+    ],
+)
+def test_bisecting_mode_construction(
+    sample_stage,
+    detector_stage,
+    frozen_angles,
+    cut_points,
+    expected_constrained,
+    context,
+):
+    with context:
+        mode = BisectingMode(
+            sample_stage=sample_stage,
+            detector_stage=detector_stage,
+            frozen_angles=frozen_angles,
+            cut_points=cut_points,
+        )
+        assert mode.sample_stage == sample_stage
+        assert mode.detector_stage == detector_stage
+        assert mode.frozen_angles == (frozen_angles or {})
+        assert mode.cut_points == (cut_points or {})
+        # constrained_stages preserves insertion order
+        assert mode.constrained_stages == expected_constrained
+
+
+def test_bisecting_mode_repr():
+    mode = BisectingMode(sample_stage="omega", detector_stage="ttheta")
+    r = repr(mode)
+    assert "BisectingMode" in r
+    assert "omega" in r
+    assert "ttheta" in r
+
+
+def test_bisecting_mode_eq_same():
+    m1 = BisectingMode(
+        sample_stage="eta",
+        detector_stage="delta",
+        frozen_angles={"mu": 0.0, "nu": 0.0},
+    )
+    m2 = BisectingMode(
+        sample_stage="eta",
+        detector_stage="delta",
+        frozen_angles={"mu": 0.0, "nu": 0.0},
+    )
+    assert m1 == m2
+
+
+def test_bisecting_mode_eq_different_sample_stage():
+    m1 = BisectingMode(sample_stage="eta", detector_stage="delta")
+    m2 = BisectingMode(sample_stage="omega", detector_stage="delta")
+    assert m1 != m2
+
+
+def test_bisecting_mode_eq_different_detector_stage():
+    m1 = BisectingMode(sample_stage="eta", detector_stage="delta")
+    m2 = BisectingMode(sample_stage="eta", detector_stage="ttheta")
+    assert m1 != m2
+
+
+def test_bisecting_mode_eq_different_frozen():
+    m1 = BisectingMode(
+        sample_stage="eta", detector_stage="delta", frozen_angles={"mu": 0.0}
+    )
+    m2 = BisectingMode(sample_stage="eta", detector_stage="delta")
+    assert m1 != m2
+
+
+def test_bisecting_mode_eq_different_type():
+    m1 = BisectingMode(sample_stage="omega", detector_stage="ttheta")
+    m2 = FixedAngleMode(stage="omega", value=0.0)
+    assert m1 != m2
+
+
+def test_bisecting_mode_eq_non_mode():
+    m = BisectingMode(sample_stage="omega", detector_stage="ttheta")
+    assert m != 42
+
+
+def test_bisecting_mode_constrained_stages_no_duplicate():
+    """
+    When a frozen_angles key equals the sample_stage name, it must NOT appear
+    twice in constrained_stages — the 'if name not in constrained' guard works.
+    """
+    mode = BisectingMode(
+        sample_stage="omega",
+        detector_stage="ttheta",
+        frozen_angles={"omega": 0.0, "chi": 90.0},  # omega also in frozen_angles
+    )
+    constrained = mode.constrained_stages
+    # omega must appear only once (deduplicated by the guard)
+    assert constrained.count("omega") == 1
+    assert "chi" in constrained
+    assert constrained[0] == "omega"  # sample_stage still first
+
+
+# ---------------------------------------------------------------------------
+# DiffractionMode.apply_cut_point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cut_points, stage, angle, expected, context",
+    [
+        pytest.param(
+            {"omega": -180.0},
+            "omega",
+            0.0,
+            0.0 + 0.0,
+            does_not_raise(),
+            id="cut-at-neg180-angle-0",
+        ),
+        pytest.param(
+            {"omega": -180.0},
+            "omega",
+            -180.0,
+            -180.0,
+            does_not_raise(),
+            id="cut-at-neg180-angle-is-cut",
+        ),
+        pytest.param(
+            {"omega": -180.0},
+            "omega",
+            185.0,
+            -175.0,
+            does_not_raise(),
+            id="cut-at-neg180-wraps-185",
+        ),
+        pytest.param(
+            {"omega": 0.0},
+            "omega",
+            350.0,
+            350.0,
+            does_not_raise(),
+            id="cut-at-0-350-stays",
+        ),
+        pytest.param(
+            {"omega": 0.0},
+            "omega",
+            -10.0,
+            350.0,
+            does_not_raise(),
+            id="cut-at-0-neg10-wraps",
+        ),
+        pytest.param(
+            {},
+            "omega",
+            350.0,
+            350.0,
+            does_not_raise(),
+            id="no-cut-point-passes-through",
+        ),
+        pytest.param(
+            {"chi": -180.0},
+            "omega",
+            350.0,
+            350.0,
+            does_not_raise(),
+            id="cut-for-different-stage-passes-through",
+        ),
+    ],
+)
+def test_apply_cut_point(cut_points, stage, angle, expected, context):
+    mode = FixedAngleMode(stage="phi", value=0.0, cut_points=cut_points)
+    with context:
+        result = mode.apply_cut_point(stage, angle)
+        assert abs(result - expected) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# ModeDict
+# ---------------------------------------------------------------------------
+
+
+def test_mode_dict_construction_empty():
+    md = ModeDict()
+    assert len(md) == 0
+
+
+def test_mode_dict_construction_from_dict():
+    modes = {
+        "bisecting": BisectingMode("omega", "ttheta"),
+        "fixed_chi": FixedAngleMode("chi", 90.0),
+    }
+    md = ModeDict(modes)
+    assert len(md) == 2
+    assert "bisecting" in md
+    assert "fixed_chi" in md
+
+
+def test_mode_dict_setitem_valid():
+    md = ModeDict()
+    md["m1"] = FixedAngleMode("chi", 90.0)
+    assert "m1" in md
+
+
+def test_mode_dict_setitem_invalid_type():
+    md = ModeDict()
+    with pytest.raises(TypeError, match=re.escape("DiffractionMode instances")):
+        md["bad"] = "not a mode"
+
+
+def test_mode_dict_getitem():
+    md = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    assert isinstance(md["m"], FixedAngleMode)
+
+
+def test_mode_dict_getitem_missing():
+    md = ModeDict()
+    with pytest.raises(KeyError):
+        _ = md["missing"]
+
+
+def test_mode_dict_delitem():
+    md = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    del md["m"]
+    assert "m" not in md
+
+
+def test_mode_dict_iter():
+    keys = ["a", "b", "c"]
+    md = ModeDict({k: FixedAngleMode("chi", 0.0) for k in keys})
+    assert list(md) == keys
+
+
+def test_mode_dict_keys():
+    md = ModeDict({"a": FixedAngleMode("chi", 0.0), "b": FixedAngleMode("phi", 0.0)})
+    assert set(md.keys()) == {"a", "b"}
+
+
+def test_mode_dict_values():
+    mode = FixedAngleMode("chi", 0.0)
+    md = ModeDict({"m": mode})
+    assert list(md.values()) == [mode]
+
+
+def test_mode_dict_items():
+    mode = FixedAngleMode("chi", 0.0)
+    md = ModeDict({"m": mode})
+    assert list(md.items()) == [("m", mode)]
+
+
+def test_mode_dict_repr():
+    md = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    r = repr(md)
+    assert "ModeDict" in r
+
+
+def test_mode_dict_eq_same():
+    m1 = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    m2 = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    assert m1 == m2
+
+
+def test_mode_dict_eq_different():
+    m1 = ModeDict({"m": FixedAngleMode("chi", 0.0)})
+    m2 = ModeDict({"m": FixedAngleMode("chi", 90.0)})
+    assert m1 != m2
+
+
+def test_mode_dict_eq_non_mode_dict():
+    md = ModeDict()
+    assert md != {}
+
+
+# ---------------------------------------------------------------------------
+# AdHocDiffractometer — mode integration
+# ---------------------------------------------------------------------------
+
+
+def test_geometry_no_modes_by_default():
+    """A geometry with no modes argument has an empty ModeDict."""
+    g = _simple_geometry()
+    assert isinstance(g.modes, ModeDict)
+    assert len(g.modes) == 0
+    assert g.mode_name is None
+    assert g.mode is None
+
+
+def test_geometry_modes_from_dict():
+    modes = {
+        "bisecting": BisectingMode("omega", "ttheta"),
+        "fixed_chi": FixedAngleMode("chi", 90.0),
+    }
+    g = _simple_geometry(modes=modes, default_mode="bisecting")
+    assert "bisecting" in g.modes
+    assert "fixed_chi" in g.modes
+    assert g.mode_name == "bisecting"
+    assert isinstance(g.mode, BisectingMode)
+
+
+def test_geometry_modes_from_mode_dict():
+    md = ModeDict({"bisecting": BisectingMode("omega", "ttheta")})
+    g = _simple_geometry(modes=md, default_mode="bisecting")
+    assert g.mode_name == "bisecting"
+
+
+def test_geometry_default_mode_none():
+    modes = {"bisecting": BisectingMode("omega", "ttheta")}
+    g = _simple_geometry(modes=modes)  # no default_mode
+    assert g.mode_name is None
+    assert g.mode is None
+
+
+def test_geometry_default_mode_invalid():
+    modes = {"bisecting": BisectingMode("omega", "ttheta")}
+    with pytest.raises(ValueError, match=re.escape("default_mode")):
+        _simple_geometry(modes=modes, default_mode="nonexistent")
+
+
+def test_geometry_mode_name_setter_valid():
+    modes = {
+        "bisecting": BisectingMode("omega", "ttheta"),
+        "fixed_chi": FixedAngleMode("chi", 90.0),
+    }
+    g = _simple_geometry(modes=modes, default_mode="bisecting")
+    g.mode_name = "fixed_chi"
+    assert g.mode_name == "fixed_chi"
+    assert isinstance(g.mode, FixedAngleMode)
+
+
+def test_geometry_mode_name_setter_none():
+    modes = {"bisecting": BisectingMode("omega", "ttheta")}
+    g = _simple_geometry(modes=modes, default_mode="bisecting")
+    g.mode_name = None
+    assert g.mode_name is None
+    assert g.mode is None
+
+
+def test_geometry_mode_name_setter_invalid():
+    modes = {"bisecting": BisectingMode("omega", "ttheta")}
+    g = _simple_geometry(modes=modes, default_mode="bisecting")
+    with pytest.raises(ValueError, match=re.escape("not available")):
+        g.mode_name = "nonexistent"
+
+
+def test_geometry_cut_points_default_empty():
+    g = _simple_geometry()
+    assert g.cut_points == {}
+
+
+def test_geometry_cut_points_set_at_construction():
+    g = _simple_geometry(cut_points={"omega": -180.0, "ttheta": -180.0})
+    assert g.cut_points == {"omega": -180.0, "ttheta": -180.0}
+
+
+def test_geometry_cut_points_mutable():
+    g = _simple_geometry()
+    g.cut_points["omega"] = -170.0
+    assert g.cut_points["omega"] == -170.0
+
+
+# ---------------------------------------------------------------------------
+# Factory canonical modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, expected_modes, expected_default",
+    [
+        pytest.param(
+            psic,
+            {"bisecting", "fixed_chi", "fixed_phi", "fixed_mu"},
+            "bisecting",
+            id="psic-modes",
+        ),
+        pytest.param(
+            fourcv,
+            {"bisecting", "fixed_chi", "fixed_phi"},
+            "bisecting",
+            id="fourcv-modes",
+        ),
+        pytest.param(
+            fourch,
+            {"bisecting", "fixed_chi", "fixed_phi"},
+            "bisecting",
+            id="fourch-modes",
+        ),
+        pytest.param(
+            kappa4cv,
+            {"bisecting", "fixed_kphi"},
+            "bisecting",
+            id="kappa4cv-modes",
+        ),
+        pytest.param(
+            kappa4ch,
+            {"bisecting", "fixed_kphi"},
+            "bisecting",
+            id="kappa4ch-modes",
+        ),
+        pytest.param(
+            kappa6c,
+            {"bisecting", "fixed_kphi", "fixed_mu"},
+            "bisecting",
+            id="kappa6c-modes",
+        ),
+    ],
+)
+def test_factory_canonical_modes(factory, expected_modes, expected_default):
+    g = factory()
+    assert set(g.modes.keys()) == expected_modes
+    assert g.mode_name == expected_default
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(sixc, id="sixc-no-modes"),
+        pytest.param(zaxis, id="zaxis-no-modes"),
+        pytest.param(s2d2, id="s2d2-no-modes"),
+        pytest.param(fivec, id="fivec-no-modes"),
+    ],
+)
+def test_factory_no_modes(factory):
+    """Geometries without canonical modes have empty ModeDict and no active mode."""
+    g = factory()
+    assert len(g.modes) == 0
+    assert g.mode_name is None
+
+
+def test_psic_bisecting_mode_correct_stages():
+    g = psic()
+    mode = g.modes["bisecting"]
+    assert isinstance(mode, BisectingMode)
+    assert mode.sample_stage == "eta"
+    assert mode.detector_stage == "delta"
+    assert mode.frozen_angles == {"mu": 0.0, "nu": 0.0}
+
+
+def test_fourcv_bisecting_mode_correct_stages():
+    g = fourcv()
+    mode = g.modes["bisecting"]
+    assert isinstance(mode, BisectingMode)
+    assert mode.sample_stage == "omega"
+    assert mode.detector_stage == "ttheta"
+    assert mode.frozen_angles == {}
+
+
+def test_kappa6c_bisecting_mode_correct_stages():
+    g = kappa6c()
+    mode = g.modes["bisecting"]
+    assert isinstance(mode, BisectingMode)
+    assert mode.sample_stage == "komega"
+    assert mode.detector_stage == "delta"
+    assert mode.frozen_angles == {"mu": 0.0, "nu": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Serialisation — mode round-trip via to_dict / from_dict
+# ---------------------------------------------------------------------------
+
+
+def test_fixed_angle_mode_to_dict_from_dict():
+    """FixedAngleMode round-trips through the geometry serialisation."""
+    modes = {"fixed_chi": FixedAngleMode("chi", 90.0, cut_points={"chi": -180.0})}
+    g = _simple_geometry(modes=modes, default_mode="fixed_chi")
+
+    d = g.to_dict()
+    assert "modes" in d
+    assert "fixed_chi" in d["modes"]
+    assert d["modes"]["fixed_chi"]["type"] == "FixedAngleMode"
+    assert d["modes"]["fixed_chi"]["stage"] == "chi"
+    assert d["modes"]["fixed_chi"]["value"] == 90.0
+    assert d["modes"]["fixed_chi"]["cut_points"] == {"chi": -180.0}
+    assert d["mode_name"] == "fixed_chi"
+
+    # Verify JSON-serialisable
+    assert json.dumps(d)
+
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert "fixed_chi" in g2.modes
+    assert g2.mode_name == "fixed_chi"
+    mode2 = g2.modes["fixed_chi"]
+    assert isinstance(mode2, FixedAngleMode)
+    assert mode2.frozen_angles == {"chi": 90.0}
+    assert mode2.cut_points == {"chi": -180.0}
+
+
+def test_bisecting_mode_to_dict_from_dict():
+    """BisectingMode round-trips through the geometry serialisation."""
+    modes = {
+        "bisecting": BisectingMode(
+            "omega",
+            "ttheta",
+            frozen_angles={"chi": 0.0},
+            cut_points={"omega": -180.0},
+        )
+    }
+    g = _simple_geometry(modes=modes, default_mode="bisecting")
+
+    d = g.to_dict()
+    md = d["modes"]["bisecting"]
+    assert md["type"] == "BisectingMode"
+    assert md["sample_stage"] == "omega"
+    assert md["detector_stage"] == "ttheta"
+    assert md["frozen_angles"] == {"chi": 0.0}
+    assert md["cut_points"] == {"omega": -180.0}
+
+    # Verify JSON-serialisable
+    assert json.dumps(d)
+
+    g2 = AdHocDiffractometer.from_dict(d)
+    mode2 = g2.modes["bisecting"]
+    assert isinstance(mode2, BisectingMode)
+    assert mode2.sample_stage == "omega"
+    assert mode2.detector_stage == "ttheta"
+    assert mode2.frozen_angles == {"chi": 0.0}
+    assert mode2.cut_points == {"omega": -180.0}
+
+
+def test_cut_points_round_trip():
+    """Geometry-level cut_points survive to_dict / from_dict."""
+    g = _simple_geometry(cut_points={"omega": -180.0, "ttheta": -170.0})
+    d = g.to_dict()
+    assert d["cut_points"] == {"omega": -180.0, "ttheta": -170.0}
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.cut_points == {"omega": -180.0, "ttheta": -170.0}
+
+
+def test_mode_name_none_round_trip():
+    """mode_name=None is stored and restored."""
+    modes = {"bisecting": BisectingMode("omega", "ttheta")}
+    g = _simple_geometry(modes=modes)  # no default_mode
+    d = g.to_dict()
+    assert d["mode_name"] is None
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.mode_name is None
+
+
+def test_psic_full_round_trip():
+    """psic() with all its modes survives to_dict / from_dict."""
+    g = psic()
+    d = g.to_dict()
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == {"bisecting", "fixed_chi", "fixed_phi", "fixed_mu"}
+    assert g2.mode_name == "bisecting"
+    assert isinstance(g2.modes["bisecting"], BisectingMode)
+    assert isinstance(g2.modes["fixed_chi"], FixedAngleMode)
+
+
+def test_geometry_no_modes_round_trip():
+    """Geometry with no modes serialises with empty modes dict."""
+    g = sixc()
+    d = g.to_dict()
+    assert d["modes"] == {}
+    assert d["mode_name"] is None
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert len(g2.modes) == 0
+    assert g2.mode_name is None
+
+
+# ---------------------------------------------------------------------------
+# DiffractionMode base-class repr
+# ---------------------------------------------------------------------------
+
+
+def test_diffraction_mode_base_repr():
+    """DiffractionMode.__repr__ includes class name and frozen/cut fields."""
+    mode = FixedAngleMode("chi", 90.0, cut_points={"chi": -180.0})
+    r = repr(mode)
+    # FixedAngleMode overrides repr — check it is informative
+    assert "chi" in r
+    assert "90.0" in r


### PR DESCRIPTION
## Summary

- closes #9

Adds first-class diffraction mode support to `AdHocDiffractometer` as described in the roadmap section 3.1 and You (1999) / SPEC #G0, #G4 documentation.

### What was added

**`mode.py`** — new module with four public types:
- `DiffractionMode` — abstract base class; declares `constrained_stages`, `frozen_angles` (SPEC #G0), `cut_points` (SPEC #G4), and `apply_cut_point(stage, angle)`
- `FixedAngleMode` — constrains one stage to a fixed angle
- `BisectingMode` — bisecting condition (sample_stage = detector_stage / 2) with optional additional frozen stages (e.g. mu=0, nu=0 for psic)
- `ModeDict` — guarded ordered dict; rejects non-`DiffractionMode` values

**`AdHocDiffractometer` additions:**
- `modes` / `default_mode` / `cut_points` constructor parameters
- `mode_name` — read/write property; validated against `modes` dict
- `mode` — read-only property returning the active `DiffractionMode` or `None`
- `cut_points` — geometry-level SPEC #G4 defaults per stage
- `to_dict` / `from_dict` round-trip for modes, `mode_name`, and `cut_points`

**Factory canonical modes:**
- `psic`: bisecting (eta=delta/2, mu=nu=0), fixed_chi, fixed_phi, fixed_mu (You 1999)
- `fourcv` / `fourch`: bisecting (omega=ttheta/2), fixed_chi, fixed_phi (BL1967)
- `kappa4cv` / `kappa4ch`: bisecting (komega=ttheta/2), fixed_kphi
- `kappa6c`: bisecting (komega=delta/2, mu=nu=0), fixed_kphi, fixed_mu
- `sixc`, `zaxis`, `s2d2`, `fivec`: no canonical modes declared
- All mode-supporting factories default to `"bisecting"`

**Tests:** 73 tests in `tests/test_mode.py`; 939 tests total; 100% line and branch coverage maintained.

**Roadmap:** `docs/roadmap.md` section 3.1 fully checked off.

---

### Bonus bug fix (not strictly part of #9, included for convenience)

**`sixc` stage axes were wrong.** From LV1993 Fig. 1 and §2.1 (x=vertical, y=longitudinal, z=lateral — same as You 1999 convention):
- `omega`, `phi`, `delta`: corrected from `+LONGITUDINAL` to `-LATERAL` (left-handed)
- `chi`: `+LONGITUDINAL` (right-handed) — was accidentally correct
- `alpha`, `gamma`: `+VERTICAL` (right-handed) — were correct

The geometry is also now noted in its description as the **IUCr six-circle**. Six explicit axis-vector assertions were added to `test_factories.py` to lock in the correct convention.

Contributed by: OpenCode (argo/claudesonnet46)