### PR TITLE
feat: 3.3 detector geometry parameters — distance, tilt, offset

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -342,9 +342,14 @@ how stages are declared.
 
 ### 3.3 Detector geometry parameters ([#10](https://github.com/prjemian/ad_hoc_diffractometer/issues/10))
 
-- [ ] Sample-to-detector distance (mm or m)
-- [ ] Detector tilt / offset angles (correction for non-ideal alignment)
-- [ ] Relevant primarily when using area detectors rather than point detectors
+- [x] `detector_distance` — sample-to-detector distance in mm; validated > 0;
+      ``None`` by default; settable and clearable after construction
+- [x] `detector_tilt` — detector tilt angle in degrees (pitch/roll correction
+      for non-ideal alignment); any real number; ``None`` by default
+- [x] `detector_offset` — in-plane beam-centre offset (dx, dy) in mm; ``None``
+      by default; validated as a 2-element numeric sequence
+- [x] All three properties serialised in `to_dict` / `from_dict` (JSON-safe)
+- [x] 17 tests; 1029 tests total; 100% coverage
 
 ### 3.4 Alternative calculation engines ([#12](https://github.com/prjemian/ad_hoc_diffractometer/issues/12))
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -103,6 +103,12 @@ class AdHocDiffractometer:
         Name of the currently active mode, or ``None`` if no mode is set.
     cut_points : dict[str, float]
         Geometry-level SPEC #G4 cut-points per stage; mirrors SPEC #G4.
+    detector_distance : float or None
+        Sample-to-detector distance in mm, or ``None`` if not set.
+    detector_tilt : float or None
+        Detector tilt angle in degrees, or ``None`` if not set.
+    detector_offset : tuple of float or None
+        In-plane detector offset (dx, dy) in mm, or ``None`` if not set.
     """
 
     DEFAULT_BASIS = {
@@ -131,6 +137,9 @@ class AdHocDiffractometer:
         self.kappa_alpha_deg = kappa_alpha_deg
         self.azimuthal_reference = azimuthal_reference  # validated via property setter
         self._surface_normal: tuple[float, float, float] | None = None
+        self._detector_distance: float | None = None
+        self._detector_tilt: float | None = None
+        self._detector_offset: tuple[float, float] | None = None
 
         # Diffraction modes
         if isinstance(modes, ModeDict):
@@ -957,6 +966,118 @@ class AdHocDiffractometer:
         self._surface_normal = (h, k, l)
 
     # ------------------------------------------------------------------
+    # Detector geometry parameters
+    # ------------------------------------------------------------------
+
+    @property
+    def detector_distance(self) -> float | None:
+        """
+        Sample-to-detector distance in millimetres, or ``None`` if not set.
+
+        Relevant primarily for area detectors, where the distance is needed
+        to convert pixel positions to scattering angles (and thence to Q).
+        Point detectors do not require this parameter.
+
+        Must be strictly positive when set.
+
+        Raises
+        ------
+        ValueError
+            If the supplied value is not positive.
+
+        Examples
+        --------
+        >>> g = psic()
+        >>> g.detector_distance = 500.0   # 500 mm
+        >>> g.detector_distance
+        500.0
+        >>> g.detector_distance = None    # clear
+        """
+        return self._detector_distance
+
+    @detector_distance.setter
+    def detector_distance(self, value: float | None) -> None:
+        if value is None:
+            self._detector_distance = None
+            return
+        value = float(value)
+        if value <= 0.0:
+            raise ValueError(f"detector_distance must be positive (got {value!r} mm).")
+        self._detector_distance = value
+
+    @property
+    def detector_tilt(self) -> float | None:
+        """
+        Detector tilt angle in degrees, or ``None`` if not set.
+
+        A non-zero tilt indicates that the detector plane is not perfectly
+        perpendicular to the diffracted beam at the nominal detector position.
+        The tilt is a rotation of the detector face about an axis parallel
+        to the detector plane (a pitch/roll correction for non-ideal
+        alignment).
+
+        Any real number is accepted (positive or negative; modulo 360° is
+        not applied).
+
+        Examples
+        --------
+        >>> g = psic()
+        >>> g.detector_tilt = 0.3    # 0.3° tilt
+        >>> g.detector_tilt
+        0.3
+        >>> g.detector_tilt = None   # clear
+        """
+        return self._detector_tilt
+
+    @detector_tilt.setter
+    def detector_tilt(self, value: float | None) -> None:
+        if value is None:
+            self._detector_tilt = None
+            return
+        self._detector_tilt = float(value)
+
+    @property
+    def detector_offset(self) -> tuple[float, float] | None:
+        """
+        In-plane detector offset (dx, dy) in millimetres, or ``None`` if not set.
+
+        Describes the displacement of the beam centre from the detector
+        centre in the detector plane.  ``dx`` is the horizontal offset and
+        ``dy`` is the vertical offset, both in millimetres.  A zero offset
+        means the beam strikes the geometric centre of the detector.
+
+        Must be a two-element sequence of real numbers.
+
+        Raises
+        ------
+        ValueError
+            If the supplied value is not a length-2 sequence of numbers.
+
+        Examples
+        --------
+        >>> g = psic()
+        >>> g.detector_offset = (2.5, -1.0)   # 2.5 mm right, 1.0 mm down
+        >>> g.detector_offset
+        (2.5, -1.0)
+        >>> g.detector_offset = None           # clear
+        """
+        return self._detector_offset
+
+    @detector_offset.setter
+    def detector_offset(self, value: tuple[float, float] | None) -> None:
+        if value is None:
+            self._detector_offset = None
+            return
+        try:
+            dx, dy = (float(x) for x in value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "detector_offset must be a length-2 sequence of numbers (dx, dy) "
+                f"in mm, or None; got {value!r}."
+            ) from exc
+        self._detector_offset = (dx, dy)
+
+    # ------------------------------------------------------------------
     # Surface geometry: incidence / emergence / Q-decomposition methods
     # ------------------------------------------------------------------
 
@@ -1565,6 +1686,13 @@ class AdHocDiffractometer:
             "surface_normal": (
                 list(self._surface_normal) if self._surface_normal is not None else None
             ),
+            "detector_distance": self._detector_distance,
+            "detector_tilt": self._detector_tilt,
+            "detector_offset": (
+                list(self._detector_offset)
+                if self._detector_offset is not None
+                else None
+            ),
             "basis": {k: [float(x) for x in v] for k, v in self.basis.items()},
             "stages": stages,
             "active_sample": self._active_ref[0],
@@ -1655,6 +1783,15 @@ class AdHocDiffractometer:
         sn = d.get("surface_normal")
         if sn is not None:
             geom.surface_normal = tuple(sn)
+
+        # Restore detector geometry parameters
+        if d.get("detector_distance") is not None:
+            geom.detector_distance = d["detector_distance"]
+        if d.get("detector_tilt") is not None:
+            geom.detector_tilt = d["detector_tilt"]
+        do = d.get("detector_offset")
+        if do is not None:
+            geom.detector_offset = tuple(do)
 
         # Restore samples.
         #

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1336,3 +1336,207 @@ def test_wh_logs_debug_when_psi_unavailable(caplog):
         g.wh(print=False)
 
     assert any("psi" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Detector geometry parameters (#10)
+# ---------------------------------------------------------------------------
+
+
+def test_detector_distance_default_none():
+    """detector_distance is None by default."""
+    from ad_hoc_diffractometer import psic
+
+    assert psic().detector_distance is None
+
+
+def test_detector_tilt_default_none():
+    """detector_tilt is None by default."""
+    from ad_hoc_diffractometer import psic
+
+    assert psic().detector_tilt is None
+
+
+def test_detector_offset_default_none():
+    """detector_offset is None by default."""
+    from ad_hoc_diffractometer import psic
+
+    assert psic().detector_offset is None
+
+
+def test_detector_distance_set_and_clear():
+    """detector_distance accepts a positive float and can be cleared to None."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_distance = 500.0
+    assert g.detector_distance == 500.0
+    g.detector_distance = None
+    assert g.detector_distance is None
+
+
+def test_detector_distance_coerces_to_float():
+    """detector_distance coerces integer input to float."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_distance = 300
+    assert isinstance(g.detector_distance, float)
+    assert g.detector_distance == 300.0
+
+
+def test_detector_distance_zero_raises():
+    """detector_distance = 0 raises ValueError."""
+    import re
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("must be positive")):
+        g.detector_distance = 0.0
+
+
+def test_detector_distance_negative_raises():
+    """detector_distance < 0 raises ValueError."""
+    import re
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("must be positive")):
+        g.detector_distance = -100.0
+
+
+def test_detector_tilt_set_and_clear():
+    """detector_tilt accepts any real number and can be cleared to None."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_tilt = 0.3
+    assert g.detector_tilt == pytest.approx(0.3)
+    g.detector_tilt = -1.5
+    assert g.detector_tilt == pytest.approx(-1.5)
+    g.detector_tilt = None
+    assert g.detector_tilt is None
+
+
+def test_detector_tilt_coerces_to_float():
+    """detector_tilt coerces integer input to float."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_tilt = 1
+    assert isinstance(g.detector_tilt, float)
+
+
+def test_detector_offset_set_and_clear():
+    """detector_offset accepts a 2-tuple and can be cleared to None."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_offset = (2.5, -1.0)
+    assert g.detector_offset == (2.5, -1.0)
+    g.detector_offset = None
+    assert g.detector_offset is None
+
+
+def test_detector_offset_coerces_to_float():
+    """detector_offset values are coerced to float."""
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_offset = (1, 2)
+    assert g.detector_offset == (1.0, 2.0)
+    assert isinstance(g.detector_offset[0], float)
+
+
+def test_detector_offset_invalid_length_raises():
+    """detector_offset with wrong length raises ValueError."""
+    import re
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("length-2 sequence")):
+        g.detector_offset = (1.0, 2.0, 3.0)
+
+
+def test_detector_offset_invalid_type_raises():
+    """detector_offset with non-numeric values raises ValueError."""
+    import re
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("length-2 sequence")):
+        g.detector_offset = "bad"
+
+
+# Serialisation round-trips
+
+
+def test_detector_distance_round_trip():
+    """detector_distance survives to_dict / from_dict."""
+    import json
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_distance = 750.0
+    d = g.to_dict()
+    assert d["detector_distance"] == 750.0
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.detector_distance == 750.0
+
+
+def test_detector_tilt_round_trip():
+    """detector_tilt survives to_dict / from_dict."""
+    import json
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_tilt = -0.7
+    d = g.to_dict()
+    assert d["detector_tilt"] == pytest.approx(-0.7)
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.detector_tilt == pytest.approx(-0.7)
+
+
+def test_detector_offset_round_trip():
+    """detector_offset survives to_dict / from_dict."""
+    import json
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.detector_offset = (3.0, -2.5)
+    d = g.to_dict()
+    assert d["detector_offset"] == [3.0, -2.5]
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.detector_offset == (3.0, -2.5)
+
+
+def test_detector_none_round_trip():
+    """None detector params are stored and restored as None."""
+    import json
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    d = g.to_dict()
+    assert d["detector_distance"] is None
+    assert d["detector_tilt"] is None
+    assert d["detector_offset"] is None
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert g2.detector_distance is None
+    assert g2.detector_tilt is None
+    assert g2.detector_offset is None


### PR DESCRIPTION
## Summary

- closes #10

Adds three properties to `AdHocDiffractometer` for describing the physical detector geometry, relevant primarily for area detectors.

| Property | Type | Description |
|---|---|---|
| `detector_distance` | `float \| None` | Sample-to-detector distance in mm; must be > 0 |
| `detector_tilt` | `float \| None` | Detector tilt angle in degrees (pitch/roll correction) |
| `detector_offset` | `tuple[float, float] \| None` | In-plane beam-centre offset (dx, dy) in mm |

All three are `None` by default, validated on assignment, serialised in `to_dict` / `from_dict` (JSON-safe), and clearable by assigning `None`.

### Tests

17 new tests in `test_geometry.py` covering: default `None`, set/clear, type coercion to `float`, validation errors (distance ≤ 0, offset wrong length/type), and `to_dict` / `from_dict` round-trips. 1029 tests total, 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)