### PR TITLE
feat: 3.7 diffractometer inclination matrix

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -446,25 +446,19 @@ to a chosen reference direction.  Two important classes:
 
 ### 3.7 Diffractometer inclination with respect to the incident beam ([#15](https://github.com/prjemian/ad_hoc_diffractometer/issues/15))
 
-- [ ] Some instruments (or experimental configurations) mount the entire
-      diffractometer at a non-zero angle relative to the incident beam
-      direction — for example, tilted to access a specific range of
-      incidence angles or to accommodate a grazing-incidence geometry
-- [ ] This is distinct from the individual motor angles; it is a property
-      of the overall instrument mounting
-- [ ] Representation options to consider:
-      - A single tilt angle (rotation about a specified axis)
-      - A full 3×3 rotation matrix describing the lab-frame orientation
-        of the diffractometer coordinate system relative to the beam
-      - Euler angles or a quaternion
-- [ ] The inclination would modify the effective basis vectors seen by the
-      beam, and would need to be folded into the sample and detector
-      rotation matrix products
-- [ ] Reference: relevant for grazing-incidence X-ray diffraction (GIXD)
-      and for instruments where the diffractometer is not aligned with
-      the beam axis by default
-- [ ] Raised by users; priority to be determined once Priority 1 and 2
-      items are complete
+- [x] `inclination_matrix` property on `AdHocDiffractometer` — a 3×3 proper
+      rotation matrix (orthonormal, det = +1); default `np.eye(3)` (no
+      inclination); validated on assignment
+- [x] `set_inclination(axis, angle_deg)` convenience method — builds the
+      rotation matrix from an axis vector and angle in degrees using the
+      existing `rotation_matrix` function
+- [x] Folded into `angles_to_phi_vector`: the effective incident-beam
+      direction becomes `R_inc.T @ ŷ`; zero inclination (identity) reproduces
+      the standard result exactly
+- [x] Serialised in `to_dict` / `from_dict` as a nested list (JSON-safe)
+- [x] 11 tests verifying default identity, set/validate, error paths,
+      Q-vector changes, and round-trip serialisation; 1023 tests total;
+      100% coverage
 
 ### 3.7a Refactor `wh` and `pa` as methods ([#51](https://github.com/prjemian/ad_hoc_diffractometer/issues/51))
 

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -142,6 +142,7 @@ class AdHocDiffractometer:
         self._detector_distance: float | None = None
         self._detector_tilt: float | None = None
         self._detector_offset: tuple[float, float] | None = None
+        self._inclination_matrix: np.ndarray = np.eye(3)
 
         # Diffraction modes
         if isinstance(modes, ModeDict):
@@ -1216,6 +1217,120 @@ class AdHocDiffractometer:
 
         return _is_evanescent(self, angles, critical_angle_deg)
 
+    # ------------------------------------------------------------------
+    # Diffractometer inclination
+    # ------------------------------------------------------------------
+
+    @property
+    def inclination_matrix(self) -> np.ndarray:
+        """
+        3×3 rotation matrix describing the diffractometer inclination
+        relative to the incident beam direction.
+
+        When the entire diffractometer is mounted at a non-zero angle with
+        respect to the incident beam (e.g. tilted for grazing-incidence
+        geometry or non-standard instrument mounting), this matrix encodes
+        that orientation.
+
+        The matrix **R** is applied as follows: the effective incident-beam
+        direction in the diffractometer coordinate frame is
+        ``R.T @ ŷ`` rather than ``ŷ``.  A zero inclination (identity matrix)
+        reproduces the standard geometry exactly.
+
+        The matrix must be a proper rotation (orthonormal, det = +1).
+
+        Default: ``numpy.eye(3)`` (no inclination).
+
+        Raises
+        ------
+        ValueError
+            If the supplied array is not shape (3, 3), not orthonormal
+            within 1e-8, or has det ≠ +1.
+
+        See Also
+        --------
+        set_inclination : Set the inclination from an axis and angle.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> g = psic()
+        >>> g.inclination_matrix  # default: identity
+        array([[1., 0., 0.],
+               [0., 1., 0.],
+               [0., 0., 1.]])
+        >>> g.set_inclination(axis=[0, 0, 1], angle_deg=2.0)  # 2° about z
+        >>> np.round(g.inclination_matrix, 4)
+        array([[ 0.9994,  0.0349,  0.    ],
+               [-0.0349,  0.9994,  0.    ],
+               [ 0.    ,  0.    ,  1.    ]])
+        """
+        return self._inclination_matrix
+
+    @inclination_matrix.setter
+    def inclination_matrix(self, value: np.ndarray) -> None:
+        arr = np.asarray(value, dtype=float)
+        if arr.shape != (3, 3):
+            raise ValueError(
+                f"inclination_matrix must be a (3, 3) array; got shape {arr.shape}."
+            )
+        # Check orthonormality
+        err = np.max(np.abs(arr.T @ arr - np.eye(3)))
+        if err > 1e-8:
+            raise ValueError(
+                f"inclination_matrix must be orthonormal (R.T @ R = I); "
+                f"max deviation = {err:.2e}."
+            )
+        det = float(np.linalg.det(arr))
+        if abs(det - 1.0) > 1e-8:
+            raise ValueError(
+                f"inclination_matrix must be a proper rotation (det = +1); "
+                f"got det = {det:.8f}."
+            )
+        self._inclination_matrix = arr
+
+    def set_inclination(
+        self,
+        axis: np.ndarray | list[float],
+        angle_deg: float,
+    ) -> None:
+        """
+        Set the inclination matrix from a rotation axis and angle.
+
+        Convenience wrapper around :attr:`inclination_matrix` that uses the
+        :func:`~.rotation.rotation_matrix` function to build R from an axis
+        vector and an angle in degrees.
+
+        A zero angle resets the inclination to the identity matrix.
+
+        Parameters
+        ----------
+        axis : array-like, shape (3,)
+            Rotation axis (need not be a unit vector; it is normalised
+            internally).
+        angle_deg : float
+            Rotation angle in degrees.
+
+        Raises
+        ------
+        ValueError
+            If ``axis`` is the zero vector.
+
+        Examples
+        --------
+        >>> g = psic()
+        >>> g.set_inclination(axis=[0, 0, 1], angle_deg=2.0)
+        >>> g.set_inclination(axis=[1, 0, 0], angle_deg=0.0)  # reset
+        """
+        from .rotation import rotation_matrix
+
+        ax = np.asarray(axis, dtype=float)
+        ax_norm = np.linalg.norm(ax)
+        if ax_norm < 1e-14:
+            raise ValueError("set_inclination(): axis must be a non-zero vector.")
+        ax = ax / ax_norm
+        self.inclination_matrix = rotation_matrix(ax, float(angle_deg))
+
     def wh(self, print: bool = True) -> str:
         """
         Terse one-screen status string (the SPEC ``wh`` command).
@@ -1695,6 +1810,7 @@ class AdHocDiffractometer:
                 if self._detector_offset is not None
                 else None
             ),
+            "inclination_matrix": self._inclination_matrix.tolist(),
             "basis": {k: [float(x) for x in v] for k, v in self.basis.items()},
             "stages": stages,
             "active_sample": self._active_ref[0],
@@ -1794,6 +1910,12 @@ class AdHocDiffractometer:
         do = d.get("detector_offset")
         if do is not None:
             geom.detector_offset = tuple(do)
+
+        # Restore inclination_matrix (always present in to_dict output; the
+        # 'is None' branch guards against hand-crafted or legacy dicts)
+        inc = d.get("inclination_matrix")
+        if inc is not None:  # pragma: no branch
+            geom.inclination_matrix = np.array(inc, dtype=float)
 
         # Restore samples.
         #

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -174,9 +174,16 @@ def angles_to_phi_vector(geometry, **motor_angles: float) -> np.ndarray:
     y_norm = np.linalg.norm(y_hat)
     y_hat = y_hat / y_norm
 
-    # Scattering vector in lab frame: Q_lab = (2π/λ) * (D @ ŷ - ŷ)
+    # Apply diffractometer inclination: when the instrument is mounted at a
+    # non-zero angle relative to the beam, the effective beam direction in the
+    # diffractometer frame is R_inc.T @ ŷ.  For a zero inclination (R_inc = I)
+    # this reduces to the standard y_hat.
+    R_inc = geometry.inclination_matrix
+    y_eff = R_inc.T @ y_hat
+
+    # Scattering vector in lab frame: Q_lab = (2π/λ) * (D @ ŷ_eff - ŷ_eff)
     two_pi_over_lambda = 2.0 * np.pi / geometry.wavelength
-    Q_lab = two_pi_over_lambda * (D @ y_hat - y_hat)
+    Q_lab = two_pi_over_lambda * (D @ y_eff - y_eff)
 
     # Rotate into phi frame: Q_phi = Z^T @ Q_lab  (Z is orthogonal)
     Q_phi = Z.T @ Q_lab

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1474,9 +1474,6 @@ def test_detector_offset_invalid_type_raises():
         g.detector_offset = "bad"
 
 
-# Serialisation round-trips
-
-
 def test_detector_distance_round_trip():
     """detector_distance survives to_dict / from_dict."""
     import json
@@ -1542,3 +1539,171 @@ def test_detector_none_round_trip():
     assert g2.detector_distance is None
     assert g2.detector_tilt is None
     assert g2.detector_offset is None
+
+
+# ---------------------------------------------------------------------------
+# Diffractometer inclination (#15)
+# ---------------------------------------------------------------------------
+
+
+def test_inclination_matrix_default_identity():
+    """inclination_matrix is the 3×3 identity by default."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    np.testing.assert_array_equal(g.inclination_matrix, np.eye(3))
+
+
+def test_inclination_matrix_set_valid():
+    """A valid rotation matrix can be assigned to inclination_matrix."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+    from ad_hoc_diffractometer import rotation_matrix
+
+    g = psic()
+    R = rotation_matrix(np.array([0.0, 0.0, 1.0]), 5.0)
+    g.inclination_matrix = R
+    np.testing.assert_allclose(g.inclination_matrix, R, atol=1e-12)
+
+
+def test_inclination_matrix_wrong_shape_raises():
+    """inclination_matrix rejects non-(3,3) arrays."""
+    import re
+
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("(3, 3)")):
+        g.inclination_matrix = np.eye(2)
+
+
+def test_inclination_matrix_not_orthonormal_raises():
+    """inclination_matrix rejects arrays that are not orthonormal."""
+    import re
+
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    bad = np.array([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    with pytest.raises(ValueError, match=re.escape("orthonormal")):
+        g.inclination_matrix = bad
+
+
+def test_inclination_matrix_improper_rotation_raises():
+    """inclination_matrix rejects improper rotations (det = -1)."""
+    import re
+
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    # Reflection matrix: det = -1
+    reflection = np.diag([-1.0, 1.0, 1.0])
+    with pytest.raises(ValueError, match=re.escape("det = +1")):
+        g.inclination_matrix = reflection
+
+
+def test_set_inclination_from_axis_angle():
+    """set_inclination() builds a rotation matrix from axis and angle."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.set_inclination(axis=[0, 0, 1], angle_deg=0.0)
+    np.testing.assert_allclose(g.inclination_matrix, np.eye(3), atol=1e-12)
+    g.set_inclination(axis=[1, 0, 0], angle_deg=5.0)
+    # det must still be +1
+    assert abs(np.linalg.det(g.inclination_matrix) - 1.0) < 1e-10
+
+
+def test_set_inclination_zero_axis_raises():
+    """set_inclination() raises for a zero axis vector."""
+    import re
+
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    with pytest.raises(ValueError, match=re.escape("non-zero vector")):
+        g.set_inclination(axis=[0.0, 0.0, 0.0], angle_deg=5.0)
+
+
+def test_zero_inclination_reproduces_standard_q():
+    """With identity inclination, angles_to_phi_vector is unchanged."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import Lattice
+    from ad_hoc_diffractometer import angles_to_phi_vector
+    from ad_hoc_diffractometer import fourcv
+    from ad_hoc_diffractometer import ub_identity
+
+    g = fourcv()
+    g.wavelength = 1.5406
+    g.sample.lattice = Lattice(a=5.431)
+    ub_identity(g.sample)
+    angles = {"omega": 14.22, "chi": 0.0, "phi": 0.0, "ttheta": 28.44}
+    Q_default = angles_to_phi_vector(g, **angles)
+    g.inclination_matrix = np.eye(3)
+    Q_identity = angles_to_phi_vector(g, **angles)
+    np.testing.assert_allclose(Q_default, Q_identity, atol=1e-12)
+
+
+def test_nonzero_inclination_changes_q():
+    """A non-trivial inclination changes the Q_phi vector."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import Lattice
+    from ad_hoc_diffractometer import angles_to_phi_vector
+    from ad_hoc_diffractometer import fourcv
+    from ad_hoc_diffractometer import ub_identity
+
+    g = fourcv()
+    g.wavelength = 1.5406
+    g.sample.lattice = Lattice(a=5.431)
+    ub_identity(g.sample)
+    angles = {"omega": 14.22, "chi": 0.0, "phi": 0.0, "ttheta": 28.44}
+    Q_default = angles_to_phi_vector(g, **angles)
+    g.set_inclination(axis=[1, 0, 0], angle_deg=2.0)
+    Q_tilted = angles_to_phi_vector(g, **angles)
+    assert not np.allclose(Q_default, Q_tilted, atol=1e-6)
+
+
+def test_inclination_matrix_round_trip():
+    """inclination_matrix survives to_dict / from_dict."""
+    import json
+
+    import numpy as np
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    g.set_inclination(axis=[0, 1, 0], angle_deg=3.0)
+    R = g.inclination_matrix.copy()
+    d = g.to_dict()
+    assert "inclination_matrix" in d
+    assert json.dumps(d)
+    g2 = AdHocDiffractometer.from_dict(d)
+    np.testing.assert_allclose(g2.inclination_matrix, R, atol=1e-12)
+
+
+def test_identity_inclination_round_trip():
+    """Identity inclination_matrix is serialised and restored."""
+    import numpy as np
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import psic
+
+    g = psic()
+    d = g.to_dict()
+    assert d["inclination_matrix"] == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    g2 = AdHocDiffractometer.from_dict(d)
+    np.testing.assert_array_equal(g2.inclination_matrix, np.eye(3))


### PR DESCRIPTION
## Summary

- closes #15

Adds support for a diffractometer mounted at a non-zero angle relative to the incident beam.

### New: `inclination_matrix` property

A 3×3 proper rotation matrix stored on `AdHocDiffractometer`. Default: `np.eye(3)` (no inclination, standard behaviour unchanged).

Validated on assignment: must be shape (3,3), orthonormal (R.T @ R = I within 1e-8), and a proper rotation (det = +1).

### New: `set_inclination(axis, angle_deg)` method

Convenience wrapper that builds the rotation matrix from an axis vector and angle using the existing `rotation_matrix()` function. Raises `ValueError` for a zero axis.

### Physics

The inclination is folded into `angles_to_phi_vector` by rotating the effective incident-beam direction:

```
y_eff = R_inc.T @ y_hat    (standard: y_eff = y_hat when R_inc = I)
Q_lab = (2π/λ) * (D @ y_eff − y_eff)
Q_phi = Z.T @ Q_lab
```

A zero inclination (identity) reproduces the standard result exactly — verified by test.

### Serialisation

`inclination_matrix` is stored as a nested 3×3 list in `to_dict` / `from_dict` (JSON-safe).

### Tests

11 new tests: default identity, valid assignment, three error paths (wrong shape, not orthonormal, improper rotation), `set_inclination` zero-axis error, Q-vector change verification, and round-trip serialisation. 1023 tests total, 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)