### PR TITLE
3.6 Reciprocal-space trajectory computation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -418,31 +418,27 @@ Diffractometers are often used to scan motor angles such that the
 scattering vector Q traces a specific path in reciprocal space relative
 to a chosen reference direction.  Two important classes:
 
-- [ ] **Arbitrary hkl vector scans**: given a reciprocal-space direction
-      (h, k, l) and a starting point, compute the sequence of motor
-      angles that keep Q on a specified trajectory — radially (along Q),
-      transversely (perpendicular to Q), or along a crystal axis.
-      Examples: L-scan, H-scan, radial scan, transverse scan.
-      Requires the UB matrix (item 2.2) and a mode selection (item 3.1).
-- [ ] **ψ (psi) scans**: rotation of the sample about the scattering
-      vector Q while keeping the reflection condition satisfied.  The
-      azimuthal angle ψ is the angle of rotation about Q (or d*).
-      For a given hkl, ψ is varied by adjusting ω, χ, φ (or their
-      kappa equivalents) while holding 2θ fixed.  Used to:
-      - measure anisotropic absorption (ψ-scan absorption correction)
-      - study crystal symmetry and orientation
-      - probe the azimuthal dependence of diffracted intensity
-        (resonant scattering, magnetic scattering)
-      ψ = 0 is conventionally defined when the reference vector N
-      (item 3.2) lies in the scattering plane.
-- [ ] **Reciprocal-space trajectory planning**: given start and end
-      points in (h, k, l) or (Qx, Qy, Qz), compute the motor-angle
-      path and flag any portions that exceed motor limits (item 1.2)
-      or enter inaccessible regions.
-- [ ] Reference: Busing & Levy (1967), section on ψ scans;
+- [x] **Arbitrary hkl vector scans**: `hkl_trajectory(geometry, trajectory,
+      n_points)` computes motor-angle sequences along line, radial, or
+      transverse reciprocal-space paths.  The `NEAREST_ANGLES` solution key
+      suppresses branch-flip discontinuities.
+- [x] **ψ (psi) scans**: `psi_trajectory(geometry, h, k, l, psi_values)`
+      computes motor angles for Busing & Levy (1967) operational ψ — the
+      rotation of the sample about Q relative to the base forward() solution.
+      Supports Eulerian (fourcv, fourch, psic) and kappa geometries
+      (kappa4cv, kappa4ch, kappa6c) via analytic Z-matrix decomposition.
+      Note: the BL1967 operational ψ differs from the You (1999) ψ computed
+      by `geometry.psi()` — see `scan.py` module docstring for the distinction.
+- [x] **Reciprocal-space trajectory planning**: `trajectory_plan(geometry,
+      hkl_start, hkl_end, n_points, space="hkl"|"Q")` computes motor-angle
+      paths and flags limit violations and inaccessible regions.  Both
+      hkl-space (uniform in Miller indices) and Q-space (uniform in Å⁻¹)
+      interpolation are supported.
+- [x] Reference: Busing & Levy (1967), section on ψ scans;
       You (1999), azimuthal angle definition;
       ITC Vol. C, Sec. 2.2.6 (ψ scan via ω, χ, φ adjustment).
-- [ ] Depends on: 2.0, 2.2, 3.1, 3.2.
+- [x] Depends on: 2.0, 2.2, 3.1, 3.2.
+- [x] 53 tests in `test_scan.py`.
 
 ### 3.7 Diffractometer inclination with respect to the incident beam ([#15](https://github.com/prjemian/ad_hoc_diffractometer/issues/15))
 

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -59,6 +59,10 @@ from .reflection import ReflectionList
 from .rotation import rotation_matrix
 from .sample import Sample
 from .sample import SampleDict
+from .scan import NEAREST_ANGLES
+from .scan import hkl_trajectory
+from .scan import psi_trajectory
+from .scan import trajectory_plan
 from .stage import Stage
 from .surface import alpha_f
 from .surface import alpha_i
@@ -105,6 +109,11 @@ __all__ = [
     "ModeDict",
     # forward calculation
     "compute_forward",
+    # scan / trajectory
+    "NEAREST_ANGLES",
+    "hkl_trajectory",
+    "psi_trajectory",
+    "trajectory_plan",
     # surface geometry
     "alpha_i",
     "alpha_f",

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -251,7 +251,7 @@ def _hkl_points(trajectory: dict, n_points: int) -> list[tuple[float, float, flo
                 "hkl_trajectory: transverse trajectory 'Q_ref' must be non-zero."
             )
         q_hat = q_ref / q_norm
-        for c in (
+        for c in (  # pragma: no branch
             np.array([1.0, 0.0, 0.0]),
             np.array([0.0, 1.0, 0.0]),
             np.array([0.0, 0.0, 1.0]),
@@ -274,6 +274,29 @@ def _hkl_points(trajectory: dict, n_points: int) -> list[tuple[float, float, flo
 # ---------------------------------------------------------------------------
 # Internal helpers — Euler decomposition  (BL1967, generalised)
 # ---------------------------------------------------------------------------
+
+
+def _perp_ref(axis: np.ndarray) -> np.ndarray:
+    """
+    Return a unit vector perpendicular to ``axis``.
+
+    Picks the first of [y, x, z] that is not nearly parallel to ``axis``,
+    then Gram-Schmidt-orthogonalises it.  This avoids the conditional
+    ``if abs(dot(ref, axis)) > 0.9`` scattered across the decomposition steps.
+    """
+    for candidate in (
+        np.array([0.0, 1.0, 0.0]),
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ):
+        v = candidate - np.dot(candidate, axis) * axis
+        norm = np.linalg.norm(v)
+        if norm > 0.1:
+            return v / norm
+    # Unreachable for any valid unit axis vector, but satisfies type checker.
+    raise ValueError(
+        f"Cannot find a reference perpendicular to {axis}"
+    )  # pragma: no cover
 
 
 def _euler_from_Z_standard(
@@ -339,11 +362,7 @@ def _euler_from_Z_standard(
         # --- Step 2: phi from Z · n_om = R_phi · (R_chi · n_om) -------------
         Rchi_nom = R_chi @ n_om_hat
         Z_nom = Z @ n_om_hat
-        ref = np.array([1.0, 0.0, 0.0])
-        if abs(float(np.dot(ref, n_phi_hat))) > 0.9:
-            ref = np.array([0.0, 1.0, 0.0])
-        e1 = ref - float(np.dot(ref, n_phi_hat)) * n_phi_hat
-        e1 /= np.linalg.norm(e1)
+        e1 = _perp_ref(n_phi_hat)
         e2 = np.cross(n_phi_hat, e1)
         phi_rad = math.atan2(
             float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
@@ -354,11 +373,7 @@ def _euler_from_Z_standard(
         # --- Step 3: omega from Z^T · n_phi = R_chi^T · n_phi ---------------
         Rchi_T_nphi = R_chi.T @ n_phi_hat
         ZT_nphi = Z.T @ n_phi_hat
-        ref2 = np.array([1.0, 0.0, 0.0])
-        if abs(float(np.dot(ref2, n_om_hat))) > 0.9:
-            ref2 = np.array([0.0, 1.0, 0.0])
-        f1 = ref2 - float(np.dot(ref2, n_om_hat)) * n_om_hat
-        f1 /= np.linalg.norm(f1)
+        f1 = _perp_ref(n_om_hat)
         f2 = np.cross(n_om_hat, f1)
         omega_rad = math.atan2(
             float(np.dot(Rchi_T_nphi, f2)), float(np.dot(Rchi_T_nphi, f1))
@@ -368,10 +383,10 @@ def _euler_from_Z_standard(
 
         results.append((omega_deg, chi_deg, phi_deg))
 
-    # De-duplicate degenerate case (chi = 0)
-    if len(results) == 2:
-        if abs(results[0][1] - results[1][1]) < 1e-8:
-            return [results[0]]
+    # De-duplicate degenerate case (chi = 0): both branches produce identical
+    # chi — return only the first.
+    if len(results) == 2 and abs(results[0][1] - results[1][1]) < 1e-8:
+        return [results[0]]
     return results
 
 
@@ -431,11 +446,7 @@ def _kappa_from_Z(
         # --- Step 2: kphi from Z · n_km = R_kphi · (R_kap · n_km) ----------
         Rk_nom = R_kap @ n_km
         Z_nom = Z @ n_km
-        ref = np.array([1.0, 0.0, 0.0])
-        if abs(float(np.dot(ref, n_kph))) > 0.9:
-            ref = np.array([0.0, 1.0, 0.0])
-        e1 = ref - float(np.dot(ref, n_kph)) * n_kph
-        e1 /= np.linalg.norm(e1)
+        e1 = _perp_ref(n_kph)
         e2 = np.cross(n_kph, e1)
         kphi_rad = math.atan2(
             float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
@@ -446,11 +457,7 @@ def _kappa_from_Z(
         # --- Step 3: komega from Z^T · n_kphi = R_kap^T · n_kphi ------------
         Rk_T_nkph = R_kap.T @ n_kph
         ZT_nkph = Z.T @ n_kph
-        ref2 = np.array([1.0, 0.0, 0.0])
-        if abs(float(np.dot(ref2, n_km))) > 0.9:
-            ref2 = np.array([0.0, 1.0, 0.0])
-        f1 = ref2 - float(np.dot(ref2, n_km)) * n_km
-        f1 /= np.linalg.norm(f1)
+        f1 = _perp_ref(n_km)
         f2 = np.cross(n_km, f1)
         kom_rad = math.atan2(
             float(np.dot(Rk_T_nkph, f2)), float(np.dot(Rk_T_nkph, f1))
@@ -460,10 +467,9 @@ def _kappa_from_Z(
 
         results.append((kom_deg, kap_deg, kphi_deg))
 
-    # De-duplicate (kappa = 0)
-    if len(results) == 2:
-        if abs(results[0][1] - results[1][1]) < 1e-8:
-            return [results[0]]
+    # De-duplicate (kappa = 0): both branches produce identical kappa values.
+    if len(results) == 2 and abs(results[0][1] - results[1][1]) < 1e-8:
+        return [results[0]]
     return results
 
 
@@ -552,23 +558,18 @@ def _measure_psi(
     y_eff: np.ndarray,
     q_hat_phi: np.ndarray,
     ref_dir: np.ndarray,
-) -> float | None:
+) -> float:
     """
     Measure the BL1967 operational ψ for ``angles`` relative to ``ref_dir``.
 
     ψ is the angle from ``ref_dir`` to (Z^T · y_eff)_⊥ about q̂_phi,
     where the perpendicular projection removes the Q component.
-
-    Returns None if the projection is degenerate (beam parallel to Q).
     """
     saved: dict[str, float] = {}
     try:
         for name, angle in angles.items():
-            try:
-                saved[name] = geometry.stage(name).angle
-                geometry.set_angle(name, float(angle))
-            except KeyError:
-                pass
+            saved[name] = geometry.stage(name).angle
+            geometry.set_angle(name, float(angle))
         Z_act = geometry.sample_rotation_matrix()
     finally:
         for name, angle in saved.items():
@@ -576,11 +577,7 @@ def _measure_psi(
 
     y_phi = Z_act.T @ y_eff
     y_perp = y_phi - np.dot(y_phi, q_hat_phi) * q_hat_phi
-    perp_mag = np.linalg.norm(y_perp)
-    if perp_mag < 1e-10:
-        return None
-
-    new_dir = y_perp / perp_mag
+    new_dir = y_perp / np.linalg.norm(y_perp)
     cos_a = float(np.clip(np.dot(ref_dir, new_dir), -1.0, 1.0))
     sin_a = float(np.dot(q_hat_phi, np.cross(ref_dir, new_dir)))
     return math.degrees(math.atan2(sin_a, cos_a))
@@ -804,11 +801,8 @@ def psi_trajectory(
     saved: dict[str, float] = {}
     try:
         for name, angle in base.items():
-            try:
-                saved[name] = geometry.stage(name).angle
-                geometry.set_angle(name, float(angle))
-            except KeyError:
-                pass
+            saved[name] = geometry.stage(name).angle
+            geometry.set_angle(name, float(angle))
         Z0 = geometry.sample_rotation_matrix()
         D = geometry.detector_rotation_matrix()
     finally:
@@ -827,18 +821,6 @@ def psi_trajectory(
     # Build reference direction: y_eff projected perp to Q in phi frame at Z0
     y_phi_0 = Z0.T @ y_eff
     y_perp_0 = y_phi_0 - np.dot(y_phi_0, q_hat_phi) * q_hat_phi
-    if np.linalg.norm(y_perp_0) < 1e-10:
-        # Degenerate: beam parallel to Q — psi undefined
-        msg = "beam direction is parallel to Q; psi is undefined for this reflection"
-        return [
-            {
-                "psi_target": float(p),
-                "psi_actual": None,
-                "angles": None,
-                "warning": msg,
-            }
-            for p in psi_values
-        ]
     ref_dir = y_perp_0 / np.linalg.norm(y_perp_0)
 
     results: list[dict] = []

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -1,0 +1,1053 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+scan.py — Reciprocal-space trajectory computation.
+
+Functions
+---------
+hkl_trajectory(geometry, trajectory, n_points, *, solution_key=NEAREST_ANGLES)
+    Compute motor-angle sequences along a specified reciprocal-space path.
+
+psi_trajectory(geometry, h, k, l, psi_values, *, solution_key=NEAREST_ANGLES)
+    Compute motor-angle sequences for ψ (psi) rotation about the scattering
+    vector Q while keeping the Bragg condition satisfied.
+
+trajectory_plan(geometry, hkl_start, hkl_end, n_points, *, space="hkl",
+                solution_key=NEAREST_ANGLES)
+    Plan a motor-angle path between two reciprocal-space points, flagging
+    limit violations and inaccessible regions.
+
+NEAREST_ANGLES
+    Built-in solution-key callable: selects the candidate solution whose
+    motor angles are closest (in least-squares sense) to the previous point.
+    Suppresses branch-flip discontinuities across a trajectory.
+
+Notes
+-----
+These functions *compute* trajectories; they do not move motors or
+communicate with hardware.  A future execution layer (not yet planned)
+will consume these outputs to drive real diffractometers.
+
+The ordering instability of ``geometry.forward()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``forward()`` returns multiple solutions in seed-discovery order, which is
+not reproducible and can switch between the positive-chi and negative-chi
+branches at adjacent trajectory points.  All three trajectory functions
+accept a ``solution_key`` parameter — a callable that scores each candidate
+solution against the previous point's chosen angles.  Passing
+``NEAREST_ANGLES`` (the module default) prevents branch flips by always
+preferring the candidate closest in motor space to the previous point.
+
+ψ-scan algorithm
+~~~~~~~~~~~~~~~~
+Two distinct definitions of ψ exist in the literature.
+
+**geometry.psi()** implements You (1999) eqs. 10-11: ψ is the azimuthal
+angle of the reference vector **n** about **Q** measured from the projection
+of the fixed lab beam direction y_hat onto the phi-frame Q-perp plane.  For
+a given (hkl, UB, n_hkl) this value is *constant* across all motor-angle
+solutions that satisfy the Bragg condition — it is a crystal-orientation
+diagnostic, not a motor-angle observable.
+
+**psi_trajectory()** implements the Busing & Levy (1967) *operational* ψ:
+the angle through which the sample has been rotated about the scattering
+vector Q relative to a chosen reference orientation.  This is the quantity
+physically varied during a ψ scan on a real diffractometer.
+
+Algorithm (Busing & Levy 1967, Section "Angle settings"):
+
+1. Obtain Z₀ — the sample rotation matrix at the base forward() solution.
+2. Compute Q̂_lab from the fixed detector position (ttheta unchanged).
+3. For each ψ_target build Z(ψ) = R(Q̂_lab, −ψ_target) · Z₀.
+   Left-multiplying by R(Q̂_lab, −ψ) rotates the sample about Q in the lab
+   frame while the Bragg condition Z · q̂_phi = Q̂_lab is preserved.
+4. Remove the contribution of any fixed outer stages and decompose the
+   inner-three-stage part of Z(ψ) into motor angles analytically:
+
+   * **Eulerian** (fourcv, fourch, psic-style, fivec-style): the formula
+     n_phi · Z · n_om = cos(χ) isolates χ; then ω and φ follow from
+     projections of Z · n_om and Z^T · n_phi onto the plane perpendicular
+     to their shared rotation axis.  Two χ branches are returned.
+
+   * **Kappa** (kappa4cv, kappa4ch, kappa6c): the formula
+     n_kphi · Z · n_komega = cos(κ)·cos²(α) + sin²(α) isolates κ (where
+     α = kappa_alpha_deg); komega and kphi follow by the same projection
+     method.  Two κ branches (positive and negative) are returned.
+
+5. All candidate solutions are filtered through stage limits; the
+   ``solution_key`` (default: ``NEAREST_ANGLES``) selects the one closest
+   in motor space to the previous ψ point, keeping motion continuous.
+
+The BL1967 ψ is measured as the angle between the beam direction projected
+perpendicular to Q in the phi frame at Z₀ versus at Z(ψ), rotating about
+q̂_phi.  ψ = 0 by definition at the base forward() solution.
+
+Trajectory dict specification for hkl_trajectory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``trajectory`` argument is a dict whose ``"type"`` key selects the
+scan shape.  Supported types:
+
+``"line"``
+    Linear interpolation between two hkl points.
+    Required keys: ``"start": (h, k, l)``, ``"end": (h, k, l)``.
+
+``"radial"``
+    Scan ±extent from center along a reciprocal-space direction.
+    Required keys: ``"center": (h, k, l)``, ``"direction": (dh, dk, dl)``,
+    ``"extent": delta``.  The direction is normalised; extent is in r.l.u.
+
+``"transverse"``
+    Scan ±extent from center perpendicular to a reference Q direction.
+    Required keys: ``"center": (h, k, l)``, ``"Q_ref": (dh, dk, dl)``,
+    ``"extent": delta``.  The transverse direction is the component of the
+    first non-collinear standard basis vector perpendicular to ``Q_ref``
+    (Gram-Schmidt).
+
+References
+----------
+Busing & Levy, Acta Cryst. 22, 457-464 (1967)
+    Four-circle geometry, ψ scan formulation, angle-setting equations.
+You, J. Appl. Cryst. 32, 614-623 (1999)
+    psic geometry, azimuthal angle definition (eqs. 10-11).
+ITC Vol. C, Sec. 2.2.6 (2006)
+    Kappa geometry, ψ scan via ω, χ, φ.
+D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016)
+    Kappa conversion formulae.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .geometry import AdHocDiffractometer
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Solution-key callables
+# ---------------------------------------------------------------------------
+
+
+def NEAREST_ANGLES(
+    candidate: dict[str, float],
+    previous: dict[str, float] | None,
+) -> float:
+    """
+    Score a candidate motor-angle solution by its distance from the previous point.
+
+    Returns the sum of squared angular differences between ``candidate`` and
+    ``previous`` over all stages present in ``candidate``.  Lower score means
+    closer to the previous point.
+
+    When ``previous`` is ``None`` (first trajectory point) every candidate
+    scores 0.0, so the first solution returned by ``forward()`` is used.
+
+    Parameters
+    ----------
+    candidate : dict[str, float]
+        Motor angles for one solution candidate.
+    previous : dict[str, float] or None
+        Motor angles chosen at the immediately preceding trajectory point.
+
+    Returns
+    -------
+    float
+        Non-negative score; lower is preferred.
+    """
+    if previous is None:
+        return 0.0
+    return sum((candidate.get(k, 0.0) - previous.get(k, 0.0)) ** 2 for k in candidate)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — solution selection
+# ---------------------------------------------------------------------------
+
+
+def _pick_solution(
+    solutions: list[dict[str, float]],
+    previous: dict[str, float] | None,
+    solution_key,
+) -> dict[str, float] | None:
+    """Return the best solution scored by ``solution_key``, or None if empty."""
+    if not solutions:
+        return None
+    if solution_key is None:
+        return solutions[0]
+    return min(solutions, key=lambda c: solution_key(c, previous))
+
+
+def _check_limits(
+    geometry: AdHocDiffractometer,
+    angles: dict[str, float],
+) -> bool:
+    """Return True if all supplied angles are within their stage limits."""
+    for name, angle in angles.items():
+        try:
+            stage = geometry.stage(name)
+        except KeyError:
+            continue
+        if not stage.in_limits(angle):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — hkl point generation
+# ---------------------------------------------------------------------------
+
+
+def _hkl_points(trajectory: dict, n_points: int) -> list[tuple[float, float, float]]:
+    """
+    Generate ``n_points`` evenly-spaced (h, k, l) tuples from a trajectory dict.
+
+    Raises
+    ------
+    ValueError
+        If ``n_points < 2``, type is unknown, or a direction/Q_ref is zero.
+    KeyError
+        If a required trajectory key is missing.
+    """
+    if n_points < 2:
+        raise ValueError(f"n_points must be at least 2; got {n_points}.")
+
+    ttype = trajectory.get("type")
+
+    if ttype == "line":
+        start = np.asarray(trajectory["start"], dtype=float)
+        end = np.asarray(trajectory["end"], dtype=float)
+        return [
+            tuple(float(v) for v in (start + t * (end - start)))
+            for t in np.linspace(0.0, 1.0, n_points)
+        ]
+
+    if ttype == "radial":
+        center = np.asarray(trajectory["center"], dtype=float)
+        direction = np.asarray(trajectory["direction"], dtype=float)
+        extent = float(trajectory["extent"])
+        d_norm = np.linalg.norm(direction)
+        if d_norm < 1e-14:
+            raise ValueError(
+                "hkl_trajectory: radial trajectory 'direction' must be non-zero."
+            )
+        d_hat = direction / d_norm
+        return [
+            tuple(float(v) for v in (center + t * d_hat))
+            for t in np.linspace(-extent, extent, n_points)
+        ]
+
+    if ttype == "transverse":
+        center = np.asarray(trajectory["center"], dtype=float)
+        q_ref = np.asarray(trajectory["Q_ref"], dtype=float)
+        extent = float(trajectory["extent"])
+        q_norm = np.linalg.norm(q_ref)
+        if q_norm < 1e-14:
+            raise ValueError(
+                "hkl_trajectory: transverse trajectory 'Q_ref' must be non-zero."
+            )
+        q_hat = q_ref / q_norm
+        for c in (
+            np.array([1.0, 0.0, 0.0]),
+            np.array([0.0, 1.0, 0.0]),
+            np.array([0.0, 0.0, 1.0]),
+        ):
+            perp = c - np.dot(c, q_hat) * q_hat
+            if np.linalg.norm(perp) > 0.1:
+                perp = perp / np.linalg.norm(perp)
+                break
+        return [
+            tuple(float(v) for v in (center + t * perp))
+            for t in np.linspace(-extent, extent, n_points)
+        ]
+
+    raise ValueError(
+        f"hkl_trajectory: unknown trajectory type {ttype!r}. "
+        "Supported types: 'line', 'radial', 'transverse'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — Euler decomposition  (BL1967, generalised)
+# ---------------------------------------------------------------------------
+
+
+def _euler_from_Z_standard(
+    Z: np.ndarray,
+    omega_stage: object,
+    chi_stage: object,
+    phi_stage: object,
+) -> list[tuple[float, float, float]]:
+    """
+    Decompose Z = R(n_φ, φ) · R(n_χ, χ) · R(n_ω, ω) into (ω, χ, φ) in degrees.
+
+    This is the innermost-first product order used by
+    ``geometry.sample_rotation_matrix()``: the outermost stage (omega/eta)
+    is applied first (rightmost), the innermost (phi) last (leftmost).
+
+    The decomposition generalises Busing & Levy (1967) eqs. 14-17 to
+    arbitrary signed stage axes.  Two χ branches are returned
+    (χ ∈ [0°, 180°] and χ ∈ [-180°, 0°]).
+
+    Notes
+    -----
+    **Chi** is extracted from the element n_φ · Z · n_ω, which equals
+    n_φ · R_χ · n_ω (since R_φ fixes n_φ and R_ω fixes n_ω).
+    For the standard case n_ω ∥ n_φ this equals cos(χ).
+
+    **Phi** is extracted from Z · n_ω = R_φ · (R_χ · n_ω): the angle in the
+    plane ⊥ n_φ between (R_χ · n_ω) and (Z · n_ω).
+
+    **Omega** is extracted from Z^T · n_φ = R_χ^T · n_φ: the angle in the
+    plane ⊥ n_ω between (R_χ^T · n_φ) and (Z^T · n_φ), with sign reversed.
+
+    Parameters
+    ----------
+    Z : ndarray, shape (3, 3)
+        Sample rotation matrix to decompose.
+    omega_stage, chi_stage, phi_stage : Stage
+        The three innermost sample stages in stacking order (floor → sample).
+
+    Returns
+    -------
+    list of (omega_deg, chi_deg, phi_deg)
+        One or two solutions.
+    """
+    from .rotation import rotation_matrix as _Rmat
+
+    n_om = np.asarray(omega_stage.axis, dtype=float)
+    n_chi = np.asarray(chi_stage.axis, dtype=float)
+    n_phi = np.asarray(phi_stage.axis, dtype=float)
+    n_om_hat = n_om / np.linalg.norm(n_om)
+    n_chi_hat = n_chi / np.linalg.norm(n_chi)
+    n_phi_hat = n_phi / np.linalg.norm(n_phi)
+
+    # --- Step 1: chi from n_phi · Z · n_om ----------------------------------
+    elem = float(np.dot(n_phi_hat, Z @ n_om_hat))
+    elem = max(-1.0, min(1.0, elem))
+    chi_pos = math.degrees(math.acos(elem))
+    chi_neg = -chi_pos
+
+    results = []
+    for chi_deg in (chi_pos, chi_neg):
+        R_chi = _Rmat(n_chi_hat, chi_deg)
+
+        # --- Step 2: phi from Z · n_om = R_phi · (R_chi · n_om) -------------
+        Rchi_nom = R_chi @ n_om_hat
+        Z_nom = Z @ n_om_hat
+        ref = np.array([1.0, 0.0, 0.0])
+        if abs(float(np.dot(ref, n_phi_hat))) > 0.9:
+            ref = np.array([0.0, 1.0, 0.0])
+        e1 = ref - float(np.dot(ref, n_phi_hat)) * n_phi_hat
+        e1 /= np.linalg.norm(e1)
+        e2 = np.cross(n_phi_hat, e1)
+        phi_rad = math.atan2(
+            float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
+        ) - math.atan2(float(np.dot(Rchi_nom, e2)), float(np.dot(Rchi_nom, e1)))
+        phi_rad = ((phi_rad + math.pi) % (2 * math.pi)) - math.pi
+        phi_deg = math.degrees(phi_rad)
+
+        # --- Step 3: omega from Z^T · n_phi = R_chi^T · n_phi ---------------
+        Rchi_T_nphi = R_chi.T @ n_phi_hat
+        ZT_nphi = Z.T @ n_phi_hat
+        ref2 = np.array([1.0, 0.0, 0.0])
+        if abs(float(np.dot(ref2, n_om_hat))) > 0.9:
+            ref2 = np.array([0.0, 1.0, 0.0])
+        f1 = ref2 - float(np.dot(ref2, n_om_hat)) * n_om_hat
+        f1 /= np.linalg.norm(f1)
+        f2 = np.cross(n_om_hat, f1)
+        omega_rad = math.atan2(
+            float(np.dot(Rchi_T_nphi, f2)), float(np.dot(Rchi_T_nphi, f1))
+        ) - math.atan2(float(np.dot(ZT_nphi, f2)), float(np.dot(ZT_nphi, f1)))
+        omega_rad = ((omega_rad + math.pi) % (2 * math.pi)) - math.pi
+        omega_deg = math.degrees(omega_rad)
+
+        results.append((omega_deg, chi_deg, phi_deg))
+
+    # De-duplicate degenerate case (chi = 0)
+    if len(results) == 2:
+        if abs(results[0][1] - results[1][1]) < 1e-8:
+            return [results[0]]
+    return results
+
+
+def _kappa_from_Z(
+    Z: np.ndarray,
+    komega_stage: object,
+    kappa_stage: object,
+    kphi_stage: object,
+    alpha_deg: float,
+) -> list[tuple[float, float, float]]:
+    """
+    Decompose Z = R(n_kφ, kφ) · R(n_κ, κ) · R(n_kω, kω) into (kω, κ, kφ).
+
+    Uses the kappa-specific chi element formula derived from the Rodrigues
+    expansion (ITC Vol. C Sec. 2.2.6 / Walko 2016):
+
+        n_kφ · Z · n_kω = cos(κ)·cos²(α) + sin²(α)
+
+    where α is ``alpha_deg`` (the kappa tilt angle).  This isolates κ;
+    komega and kphi are then extracted by the same projection method as
+    ``_euler_from_Z_standard``.
+
+    Parameters
+    ----------
+    Z : ndarray, shape (3, 3)
+    komega_stage, kappa_stage, kphi_stage : Stage
+    alpha_deg : float
+        Kappa tilt angle in degrees.
+
+    Returns
+    -------
+    list of (komega_deg, kappa_deg, kphi_deg)
+        Two solutions (positive and negative κ branches), or one if degenerate.
+    """
+    from .rotation import rotation_matrix as _Rmat
+
+    alpha_rad = math.radians(alpha_deg)
+    sin2a = math.sin(alpha_rad) ** 2
+    cos2a = math.cos(alpha_rad) ** 2
+
+    n_km = np.asarray(komega_stage.axis, dtype=float) / np.linalg.norm(
+        komega_stage.axis
+    )
+    n_kap = np.asarray(kappa_stage.axis, dtype=float) / np.linalg.norm(kappa_stage.axis)
+    n_kph = np.asarray(kphi_stage.axis, dtype=float) / np.linalg.norm(kphi_stage.axis)
+
+    # --- Step 1: kappa from n_kphi · Z · n_komega ---------------------------
+    elem = float(np.clip(np.dot(n_kph, Z @ n_km), -1.0, 1.0))
+    cos_kap = max(-1.0, min(1.0, (elem - sin2a) / cos2a))
+    kap_pos = math.degrees(math.acos(cos_kap))
+    kap_neg = -kap_pos
+
+    results = []
+    for kap_deg in (kap_pos, kap_neg):
+        R_kap = _Rmat(n_kap, kap_deg)
+
+        # --- Step 2: kphi from Z · n_km = R_kphi · (R_kap · n_km) ----------
+        Rk_nom = R_kap @ n_km
+        Z_nom = Z @ n_km
+        ref = np.array([1.0, 0.0, 0.0])
+        if abs(float(np.dot(ref, n_kph))) > 0.9:
+            ref = np.array([0.0, 1.0, 0.0])
+        e1 = ref - float(np.dot(ref, n_kph)) * n_kph
+        e1 /= np.linalg.norm(e1)
+        e2 = np.cross(n_kph, e1)
+        kphi_rad = math.atan2(
+            float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
+        ) - math.atan2(float(np.dot(Rk_nom, e2)), float(np.dot(Rk_nom, e1)))
+        kphi_rad = ((kphi_rad + math.pi) % (2 * math.pi)) - math.pi
+        kphi_deg = math.degrees(kphi_rad)
+
+        # --- Step 3: komega from Z^T · n_kphi = R_kap^T · n_kphi ------------
+        Rk_T_nkph = R_kap.T @ n_kph
+        ZT_nkph = Z.T @ n_kph
+        ref2 = np.array([1.0, 0.0, 0.0])
+        if abs(float(np.dot(ref2, n_km))) > 0.9:
+            ref2 = np.array([0.0, 1.0, 0.0])
+        f1 = ref2 - float(np.dot(ref2, n_km)) * n_km
+        f1 /= np.linalg.norm(f1)
+        f2 = np.cross(n_km, f1)
+        kom_rad = math.atan2(
+            float(np.dot(Rk_T_nkph, f2)), float(np.dot(Rk_T_nkph, f1))
+        ) - math.atan2(float(np.dot(ZT_nkph, f2)), float(np.dot(ZT_nkph, f1)))
+        kom_rad = ((kom_rad + math.pi) % (2 * math.pi)) - math.pi
+        kom_deg = math.degrees(kom_rad)
+
+        results.append((kom_deg, kap_deg, kphi_deg))
+
+    # De-duplicate (kappa = 0)
+    if len(results) == 2:
+        if abs(results[0][1] - results[1][1]) < 1e-8:
+            return [results[0]]
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — psi-scan core
+# ---------------------------------------------------------------------------
+
+
+def _psi_candidates(
+    geometry: AdHocDiffractometer,
+    Z0: np.ndarray,
+    Q_lab_hat: np.ndarray,
+    y_eff: np.ndarray,
+    psi_target: float,
+    base: dict[str, float],
+) -> list[dict[str, float]]:
+    """
+    Compute all in-limits motor-angle candidates for ``psi_target``.
+
+    Implements BL1967 step 3-4: builds Z(ψ) = R(Q̂_lab, −ψ) · Z₀ then
+    decomposes the inner three stages analytically.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Z0 : ndarray (3, 3)
+        Sample rotation matrix at the base forward() solution.
+    Q_lab_hat : ndarray (3,)
+        Unit scattering vector in the lab frame (from detector position).
+    y_eff : ndarray (3,)
+        Effective incident-beam direction (accounts for inclination).
+    psi_target : float
+        Target ψ in degrees.
+    base : dict[str, float]
+        Base motor angles (Bragg solution); used for outer stages and ttheta.
+
+    Returns
+    -------
+    list of dict[str, float]
+        All limit-passing candidate motor-angle dicts.
+    """
+    from .rotation import rotation_matrix as _Rmat
+
+    # Identify stage groups
+    sample_stages = geometry.sample_stages
+    if len(sample_stages) < 3:
+        return []
+
+    outer_stages = sample_stages[:-3]
+    omega_s, chi_s, phi_s = sample_stages[-3], sample_stages[-2], sample_stages[-1]
+
+    # Build R_outer from the base angles of any fixed outer stages
+    R_outer = np.eye(3)
+    for s in outer_stages:
+        R_outer = _Rmat(s.axis, base.get(s.name, s.angle)) @ R_outer
+
+    # Rotate Z0 about Q_lab by -psi_target (negative because the convention
+    # is that increasing psi rotates the sample such that the beam-perpendicular
+    # direction in the phi frame rotates by +psi relative to Z0)
+    Z_new = _Rmat(Q_lab_hat, -psi_target) @ Z0
+    Z_inner = R_outer.T @ Z_new
+
+    # Decompose the inner three stages
+    is_kappa = geometry.kappa_alpha_deg is not None
+    if is_kappa:
+        sols = _kappa_from_Z(Z_inner, omega_s, chi_s, phi_s, geometry.kappa_alpha_deg)
+    else:
+        sols = _euler_from_Z_standard(Z_inner, omega_s, chi_s, phi_s)
+
+    candidates = []
+    for a0, a1, a2 in sols:
+        angles = dict(base)
+        angles[omega_s.name] = a0
+        angles[chi_s.name] = a1
+        angles[phi_s.name] = a2
+        if _check_limits(geometry, angles):
+            candidates.append(angles)
+
+    return candidates
+
+
+def _measure_psi(
+    geometry: AdHocDiffractometer,
+    angles: dict[str, float],
+    Q_lab_hat: np.ndarray,
+    y_eff: np.ndarray,
+    q_hat_phi: np.ndarray,
+    ref_dir: np.ndarray,
+) -> float | None:
+    """
+    Measure the BL1967 operational ψ for ``angles`` relative to ``ref_dir``.
+
+    ψ is the angle from ``ref_dir`` to (Z^T · y_eff)_⊥ about q̂_phi,
+    where the perpendicular projection removes the Q component.
+
+    Returns None if the projection is degenerate (beam parallel to Q).
+    """
+    saved: dict[str, float] = {}
+    try:
+        for name, angle in angles.items():
+            try:
+                saved[name] = geometry.stage(name).angle
+                geometry.set_angle(name, float(angle))
+            except KeyError:
+                pass
+        Z_act = geometry.sample_rotation_matrix()
+    finally:
+        for name, angle in saved.items():
+            geometry.set_angle(name, angle)
+
+    y_phi = Z_act.T @ y_eff
+    y_perp = y_phi - np.dot(y_phi, q_hat_phi) * q_hat_phi
+    perp_mag = np.linalg.norm(y_perp)
+    if perp_mag < 1e-10:
+        return None
+
+    new_dir = y_perp / perp_mag
+    cos_a = float(np.clip(np.dot(ref_dir, new_dir), -1.0, 1.0))
+    sin_a = float(np.dot(q_hat_phi, np.cross(ref_dir, new_dir)))
+    return math.degrees(math.atan2(sin_a, cos_a))
+
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+
+def hkl_trajectory(
+    geometry: AdHocDiffractometer,
+    trajectory: dict,
+    n_points: int,
+    *,
+    solution_key=NEAREST_ANGLES,
+) -> list[dict]:
+    """
+    Compute motor-angle sequences along a reciprocal-space trajectory.
+
+    For each of the ``n_points`` equally-spaced hkl positions along the
+    trajectory, calls ``geometry.forward()`` to find all valid motor-angle
+    solutions, then uses ``solution_key`` to select one.  Points with no
+    valid solution are included with ``angles=None``.
+
+    The ``NEAREST_ANGLES`` solution key (the default) prevents branch-flip
+    discontinuities: at each point it selects the candidate whose motor
+    angles are closest to those of the previous point.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Must have ``wavelength`` and ``sample.UB`` set and an active mode.
+    trajectory : dict
+        Trajectory specification.  The ``"type"`` key selects the scan
+        shape; see module docstring for supported types and required keys.
+    n_points : int
+        Number of evenly-spaced points to compute (≥ 2).
+    solution_key : callable or None, optional
+        Scoring function ``(candidate, previous) -> float``; lower wins.
+        Default: ``NEAREST_ANGLES``.  Pass ``None`` to use ``forward()``'s
+        raw ordering.
+
+    Returns
+    -------
+    list of dict
+        One entry per trajectory point with keys:
+
+        ``"hkl"`` : tuple of float
+            The requested Miller indices (h, k, l).
+        ``"angles"`` : dict[str, float] or None
+            Motor angles in degrees, or ``None`` if no valid solution.
+        ``"warning"`` : str or None
+            Descriptive warning when ``angles`` is ``None``, else ``None``.
+
+    Raises
+    ------
+    ValueError
+        If ``n_points < 2``, trajectory type is unknown, or a required
+        trajectory key is missing.
+    ValueError
+        If ``geometry.wavelength`` is None or ``geometry.sample.UB`` is None.
+    NotImplementedError
+        If no active diffraction mode is set.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.wavelength = 1.5406
+    >>> g.sample.lattice = ahd.Lattice(a=4.0)
+    >>> ahd.ub_identity(g.sample)
+    >>> g.mode_name = "bisecting"
+    >>> result = ahd.hkl_trajectory(
+    ...     g,
+    ...     {"type": "line", "start": (1, 0, 0), "end": (3, 0, 0)},
+    ...     n_points=5,
+    ... )
+    >>> for pt in result:
+    ...     print(pt["hkl"], pt["angles"])
+    """
+    points = _hkl_points(trajectory, n_points)
+    results: list[dict] = []
+    previous: dict[str, float] | None = None
+
+    for hkl in points:
+        h, k, l = hkl  # noqa: E741
+        try:
+            solutions = geometry.forward(h, k, l)
+        except (ValueError, NotImplementedError) as exc:
+            results.append({"hkl": hkl, "angles": None, "warning": str(exc)})
+            continue
+
+        if not solutions:
+            results.append(
+                {
+                    "hkl": hkl,
+                    "angles": None,
+                    "warning": "no valid motor solution (all candidates outside limits)",
+                }
+            )
+            continue
+
+        chosen = _pick_solution(solutions, previous, solution_key)
+        results.append({"hkl": hkl, "angles": chosen, "warning": None})
+        previous = chosen
+
+    return results
+
+
+def psi_trajectory(
+    geometry: AdHocDiffractometer,
+    h: float,
+    k: float,
+    l: float,  # noqa: E741
+    psi_values,
+    *,
+    solution_key=NEAREST_ANGLES,
+) -> list[dict]:
+    """
+    Compute motor-angle sequences for ψ rotation about the scattering vector Q.
+
+    For the fixed reflection (h, k, l) and each target ψ in ``psi_values``,
+    finds motor angles that simultaneously satisfy the Bragg condition and
+    produce the requested BL1967 operational ψ.
+
+    ψ Definition (Busing & Levy 1967)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ψ is the angle through which the sample has rotated about Q relative to
+    the base ``forward()`` solution.  ψ = 0 at the base solution by definition.
+    Physically, ψ is varied by rotating the sample about Q (changing ω, χ, φ
+    or their kappa equivalents) while keeping 2θ fixed.
+
+    This differs from ``geometry.psi()``, which implements the You (1999)
+    definition and is constant for all Bragg solutions of a given hkl.  See
+    the module docstring for the full discussion.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Must have ``wavelength`` and ``sample.UB`` set, and an active
+        diffraction mode.  ``kappa_alpha_deg`` must be set for kappa
+        geometries (it is set automatically by the factory functions).
+    h, k, l : float
+        Miller indices of the fixed reflection.
+    psi_values : iterable of float
+        Target ψ angles in degrees relative to the base forward() solution.
+    solution_key : callable or None, optional
+        Scoring function ``(candidate, previous) -> float``; lower wins.
+        Default: ``NEAREST_ANGLES``.
+
+    Returns
+    -------
+    list of dict
+        One entry per ψ value with keys:
+
+        ``"psi_target"`` : float
+            The requested ψ (degrees).
+        ``"psi_actual"`` : float or None
+            Achieved ψ verified by internal measurement, or ``None``.
+        ``"angles"`` : dict[str, float] or None
+            Motor angles in degrees, or ``None``.
+        ``"warning"`` : str or None
+            Descriptive warning when ``angles`` is ``None``, else ``None``.
+
+    Raises
+    ------
+    ValueError
+        If ``geometry.wavelength`` is None or ``geometry.sample.UB`` is None.
+    ValueError
+        If ``(h, k, l) == (0, 0, 0)``.
+    NotImplementedError
+        If no active diffraction mode is set.
+
+    Notes
+    -----
+    The geometry must have at least three sample stages (omega/eta, chi/kappa,
+    phi/kphi).  Geometries with fewer sample stages are not supported.
+
+    References
+    ----------
+    Busing & Levy, Acta Cryst. 22, 457-464 (1967), angle-setting equations.
+    ITC Vol. C, Sec. 2.2.6 (2006), kappa ψ scan.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.wavelength = 1.5406
+    >>> g.sample.lattice = ahd.Lattice(a=4.0)
+    >>> ahd.ub_identity(g.sample)
+    >>> g.mode_name = "bisecting"
+    >>> result = ahd.psi_trajectory(g, 1, 1, 0, range(-90, 91, 30))
+    >>> for pt in result:
+    ...     print(pt["psi_target"], pt["psi_actual"])
+    """
+
+    # Obtain the Bragg base solutions (raises ValueError/NotImplementedError
+    # for bad preconditions — wavelength, UB, hkl=0, mode).
+    base_solutions = geometry.forward(h, k, l)
+
+    if not base_solutions:
+        no_bragg_msg = (
+            "no valid Bragg solution for this reflection "
+            "(all candidates outside limits)"
+        )
+        return [
+            {
+                "psi_target": float(p),
+                "psi_actual": None,
+                "angles": None,
+                "warning": no_bragg_msg,
+            }
+            for p in psi_values
+        ]
+
+    # Pick the base solution (used to compute Z0 and as the psi=0 reference)
+    base = base_solutions[0]
+
+    # Compute Z0 and Q_lab_hat from base (temporarily apply motor angles)
+    saved: dict[str, float] = {}
+    try:
+        for name, angle in base.items():
+            try:
+                saved[name] = geometry.stage(name).angle
+                geometry.set_angle(name, float(angle))
+            except KeyError:
+                pass
+        Z0 = geometry.sample_rotation_matrix()
+        D = geometry.detector_rotation_matrix()
+    finally:
+        for name, angle in saved.items():
+            geometry.set_angle(name, angle)
+
+    y_lab = np.asarray(geometry.basis["longitudinal"], dtype=float)
+    y_lab = y_lab / np.linalg.norm(y_lab)
+    y_eff = geometry.inclination_matrix.T @ y_lab
+    Q_lab_vec = (2.0 * math.pi / geometry.wavelength) * (D @ y_eff - y_eff)
+    Q_lab_hat = Q_lab_vec / np.linalg.norm(Q_lab_vec)
+
+    q_hat_phi = geometry.sample.UB @ np.array([float(h), float(k), float(l)])
+    q_hat_phi = q_hat_phi / np.linalg.norm(q_hat_phi)
+
+    # Build reference direction: y_eff projected perp to Q in phi frame at Z0
+    y_phi_0 = Z0.T @ y_eff
+    y_perp_0 = y_phi_0 - np.dot(y_phi_0, q_hat_phi) * q_hat_phi
+    if np.linalg.norm(y_perp_0) < 1e-10:
+        # Degenerate: beam parallel to Q — psi undefined
+        msg = "beam direction is parallel to Q; psi is undefined for this reflection"
+        return [
+            {
+                "psi_target": float(p),
+                "psi_actual": None,
+                "angles": None,
+                "warning": msg,
+            }
+            for p in psi_values
+        ]
+    ref_dir = y_perp_0 / np.linalg.norm(y_perp_0)
+
+    results: list[dict] = []
+    previous: dict[str, float] | None = None
+
+    for psi_target in psi_values:
+        psi_target = float(psi_target)
+
+        candidates = _psi_candidates(geometry, Z0, Q_lab_hat, y_eff, psi_target, base)
+
+        if not candidates:
+            results.append(
+                {
+                    "psi_target": psi_target,
+                    "psi_actual": None,
+                    "angles": None,
+                    "warning": (
+                        f"no motor solution achieves psi = {psi_target:.4g}° "
+                        "within stage limits"
+                    ),
+                }
+            )
+            continue
+
+        chosen = _pick_solution(candidates, previous, solution_key)
+        psi_actual = _measure_psi(
+            geometry, chosen, Q_lab_hat, y_eff, q_hat_phi, ref_dir
+        )
+
+        results.append(
+            {
+                "psi_target": psi_target,
+                "psi_actual": psi_actual,
+                "angles": chosen,
+                "warning": None,
+            }
+        )
+        previous = chosen
+
+    return results
+
+
+def trajectory_plan(
+    geometry: AdHocDiffractometer,
+    hkl_start: tuple[float, float, float],
+    hkl_end: tuple[float, float, float],
+    n_points: int,
+    *,
+    space: str = "hkl",
+    solution_key=NEAREST_ANGLES,
+) -> list[dict]:
+    """
+    Plan a motor-angle path between two reciprocal-space points.
+
+    Interpolates between ``hkl_start`` and ``hkl_end`` in ``n_points``
+    equally-spaced steps, calls ``geometry.forward()`` at each point, and
+    flags portions that are inaccessible (no valid motor solution) or that
+    exceed stage limits.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Must have ``wavelength`` and ``sample.UB`` set and an active mode.
+    hkl_start, hkl_end : tuple of float
+        Start and end Miller indices (h, k, l).
+    n_points : int
+        Number of evenly-spaced points including endpoints (≥ 2).
+    space : {"hkl", "Q"}, optional
+        Interpolation space.
+
+        ``"hkl"`` (default)
+            Linearly interpolate Miller indices.  Natural for L-scans,
+            H-scans, and crystal-axis-aligned trajectories.  Equal steps in
+            hkl are *not* equal steps in |Q| for non-cubic lattices.
+
+        ``"Q"``
+            Linearly interpolate in reciprocal Cartesian coordinates
+            (Qx, Qy, Qz = UB @ hkl).  Equal steps in Q regardless of
+            lattice distortion; intermediate hkl values are generally
+            non-integer.  Endpoints are exact by construction.
+
+    solution_key : callable or None, optional
+        Scoring function ``(candidate, previous) -> float``; lower wins.
+        Default: ``NEAREST_ANGLES``.
+
+    Returns
+    -------
+    list of dict
+        One entry per trajectory point with keys:
+
+        ``"hkl"`` : tuple of float
+            The (h, k, l) point.
+        ``"angles"`` : dict[str, float] or None
+            Motor angles, or ``None`` if inaccessible.
+        ``"accessible"`` : bool
+            ``True`` if a valid in-limits solution was found.
+        ``"warnings"`` : list of str
+            Empty when accessible; otherwise one or more warning strings.
+
+    Raises
+    ------
+    ValueError
+        If ``n_points < 2``.
+    ValueError
+        If ``space`` is not ``"hkl"`` or ``"Q"``.
+    ValueError
+        If ``space="Q"`` and ``geometry.sample.UB`` is None or singular.
+    ValueError
+        If ``geometry.wavelength`` is None or ``geometry.sample.UB`` is None.
+    NotImplementedError
+        If no active diffraction mode is set.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.wavelength = 1.5406
+    >>> g.sample.lattice = ahd.Lattice(a=4.0)
+    >>> ahd.ub_identity(g.sample)
+    >>> g.mode_name = "bisecting"
+    >>> plan = ahd.trajectory_plan(g, (1, 0, 0), (3, 0, 0), n_points=11)
+    >>> accessible = [pt for pt in plan if pt["accessible"]]
+    >>> print(f"{len(accessible)}/{len(plan)} points accessible")
+    """
+    if n_points < 2:
+        raise ValueError(f"n_points must be at least 2; got {n_points}.")
+    if space not in ("hkl", "Q"):
+        raise ValueError(f"trajectory_plan: space must be 'hkl' or 'Q'; got {space!r}.")
+
+    hkl_start_arr = np.asarray(hkl_start, dtype=float)
+    hkl_end_arr = np.asarray(hkl_end, dtype=float)
+
+    if space == "hkl":
+        hkl_points = [
+            tuple(float(v) for v in (hkl_start_arr + t * (hkl_end_arr - hkl_start_arr)))
+            for t in np.linspace(0.0, 1.0, n_points)
+        ]
+    else:  # space == "Q"
+        sample = geometry.sample
+        if sample.UB is None:
+            raise ValueError(
+                "trajectory_plan(space='Q') requires geometry.sample.UB to be set."
+            )
+        try:
+            UB_inv = np.linalg.inv(sample.UB)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError(
+                "trajectory_plan(space='Q'): UB matrix is singular."
+            ) from exc
+
+        Q_start = sample.UB @ hkl_start_arr
+        Q_end = sample.UB @ hkl_end_arr
+        hkl_points = []
+        for t in np.linspace(0.0, 1.0, n_points):
+            Q_interp = Q_start + t * (Q_end - Q_start)
+            hkl_points.append(tuple(float(v) for v in (UB_inv @ Q_interp)))
+        # Force exact endpoints
+        hkl_points[0] = tuple(float(v) for v in hkl_start_arr)
+        hkl_points[-1] = tuple(float(v) for v in hkl_end_arr)
+
+    results: list[dict] = []
+    previous: dict[str, float] | None = None
+
+    for hkl in hkl_points:
+        h, k, l = hkl  # noqa: E741
+        warnings_list: list[str] = []
+
+        try:
+            solutions = geometry.forward(h, k, l)
+        except (ValueError, NotImplementedError) as exc:
+            results.append(
+                {
+                    "hkl": hkl,
+                    "angles": None,
+                    "accessible": False,
+                    "warnings": [str(exc)],
+                }
+            )
+            continue
+
+        if not solutions:
+            results.append(
+                {
+                    "hkl": hkl,
+                    "angles": None,
+                    "accessible": False,
+                    "warnings": [
+                        "no valid motor solution (all candidates outside limits)"
+                    ],
+                }
+            )
+            continue
+
+        chosen = _pick_solution(solutions, previous, solution_key)
+
+        try:
+            geometry.check_limits(**chosen)
+        except ValueError as exc:
+            warnings_list.append(str(exc))
+
+        results.append(
+            {
+                "hkl": hkl,
+                "angles": chosen,
+                "accessible": len(warnings_list) == 0,
+                "warnings": warnings_list,
+            }
+        )
+        if not warnings_list:
+            previous = chosen
+
+    return results

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,748 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Unit tests for ad_hoc_diffractometer.scan.
+
+Covers:
+  - NEAREST_ANGLES: scoring, previous=None, minimises distance
+  - _hkl_points: line, radial, transverse; n_points<2; unknown type; zero direction
+  - _pick_solution: None key, custom key, empty list
+  - _euler_from_Z_standard: round-trip decomposition for fourcv and psic
+  - _kappa_from_Z: round-trip decomposition for kappa4cv
+  - hkl_trajectory: line/radial/transverse, round-trip invariant,
+      inaccessible points, NEAREST_ANGLES continuity, custom solution_key,
+      error cases
+  - psi_trajectory: BL1967 psi round-trip on fourcv, kappa4cv, psic;
+      NEAREST_ANGLES continuity; no-Bragg path; error cases
+  - trajectory_plan: hkl/Q space, accessible/inaccessible flags,
+      NEAREST_ANGLES continuity, space validation, n_points<2 raises
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import Lattice
+from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import kappa4cv
+from ad_hoc_diffractometer import psic
+from ad_hoc_diffractometer import ub_identity
+from ad_hoc_diffractometer.scan import NEAREST_ANGLES
+from ad_hoc_diffractometer.scan import _euler_from_Z_standard
+from ad_hoc_diffractometer.scan import _hkl_points
+from ad_hoc_diffractometer.scan import _kappa_from_Z
+from ad_hoc_diffractometer.scan import _pick_solution
+from ad_hoc_diffractometer.scan import hkl_trajectory
+from ad_hoc_diffractometer.scan import psi_trajectory
+from ad_hoc_diffractometer.scan import trajectory_plan
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+WAVELENGTH = 1.5406  # Cu Kα in Å
+HKL_TEST = (1, 1, 0)  # reflection used throughout psi tests
+
+
+def _setup(factory, a=4.0, *, mode="bisecting"):
+    """Return a geometry with wavelength set, cubic lattice, UB=B."""
+    g = factory()
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = Lattice(a=a)
+    ub_identity(g.sample)
+    g.mode_name = mode
+    return g
+
+
+def _round_trip_ok(g, angles, hkl, atol=1e-4):
+    """Return True if g.inverse(angles) ≈ hkl."""
+    return np.allclose(g.inverse(angles), hkl, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# NEAREST_ANGLES
+# ---------------------------------------------------------------------------
+
+
+def test_nearest_angles_previous_none():
+    """Score is 0.0 when previous is None."""
+    candidate = {"omega": 10.0, "chi": 45.0, "phi": 90.0, "ttheta": 20.0}
+    assert NEAREST_ANGLES(candidate, None) == 0.0
+
+
+def test_nearest_angles_identical():
+    """Score is 0.0 when candidate equals previous."""
+    angles = {"omega": 10.0, "chi": 45.0, "phi": 90.0}
+    assert NEAREST_ANGLES(angles, angles) == pytest.approx(0.0)
+
+
+def test_nearest_angles_nonzero():
+    """Score equals the expected sum of squares."""
+    candidate = {"omega": 11.0, "chi": 46.0}
+    previous = {"omega": 10.0, "chi": 45.0}
+    assert NEAREST_ANGLES(candidate, previous) == pytest.approx(2.0)
+
+
+def test_nearest_angles_picks_closer():
+    """_pick_solution with NEAREST_ANGLES picks the nearer of two candidates."""
+    previous = {"omega": 10.0, "chi": 45.0, "phi": 0.0}
+    close = {"omega": 10.5, "chi": 45.5, "phi": 0.5}
+    far = {"omega": 20.0, "chi": -45.0, "phi": 180.0}
+    assert _pick_solution([far, close], previous, NEAREST_ANGLES) is close
+
+
+# ---------------------------------------------------------------------------
+# _pick_solution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "solutions, previous, key, expected_idx, context",
+    [
+        pytest.param(
+            [],
+            None,
+            NEAREST_ANGLES,
+            None,
+            does_not_raise(),
+            id="empty-list-returns-none",
+        ),
+        pytest.param(
+            [{"a": 1.0}, {"a": 2.0}],
+            None,
+            None,
+            0,
+            does_not_raise(),
+            id="none-key-returns-first",
+        ),
+        pytest.param(
+            [{"a": 5.0}, {"a": 1.1}],
+            {"a": 1.0},
+            NEAREST_ANGLES,
+            1,  # {"a": 1.1} is much closer to {"a": 1.0} than {"a": 5.0}
+            does_not_raise(),
+            id="nearest-picks-closest",
+        ),
+    ],
+)
+def test_pick_solution(solutions, previous, key, expected_idx, context):
+    with context:
+        result = _pick_solution(solutions, previous, key)
+        if expected_idx is None:
+            assert result is None
+        else:
+            assert result is solutions[expected_idx]
+
+
+# ---------------------------------------------------------------------------
+# _hkl_points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "trajectory, n_points, expected_first, expected_last, context",
+    [
+        pytest.param(
+            {"type": "line", "start": (1, 0, 0), "end": (3, 0, 0)},
+            5,
+            (1.0, 0.0, 0.0),
+            (3.0, 0.0, 0.0),
+            does_not_raise(),
+            id="line-endpoints",
+        ),
+        pytest.param(
+            {
+                "type": "radial",
+                "center": (1, 0, 0),
+                "direction": (1, 0, 0),
+                "extent": 1.0,
+            },
+            5,
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+            does_not_raise(),
+            id="radial-endpoints",
+        ),
+        pytest.param(
+            {
+                "type": "transverse",
+                "center": (0, 0, 1),
+                "Q_ref": (0, 0, 1),
+                "extent": 0.5,
+            },
+            3,
+            None,
+            None,
+            does_not_raise(),
+            id="transverse-runs",
+        ),
+        pytest.param(
+            {"type": "line", "start": (0, 0, 1), "end": (0, 0, 2)},
+            1,
+            None,
+            None,
+            pytest.raises(ValueError, match=re.escape("n_points must be at least 2")),
+            id="n-points-too-small",
+        ),
+        pytest.param(
+            {"type": "unknown"},
+            3,
+            None,
+            None,
+            pytest.raises(ValueError, match=re.escape("unknown trajectory type")),
+            id="unknown-type",
+        ),
+        pytest.param(
+            {
+                "type": "radial",
+                "center": (0, 0, 1),
+                "direction": (0, 0, 0),
+                "extent": 1.0,
+            },
+            3,
+            None,
+            None,
+            pytest.raises(ValueError, match=re.escape("'direction' must be non-zero")),
+            id="radial-zero-direction",
+        ),
+        pytest.param(
+            {
+                "type": "transverse",
+                "center": (0, 0, 1),
+                "Q_ref": (0, 0, 0),
+                "extent": 0.5,
+            },
+            3,
+            None,
+            None,
+            pytest.raises(ValueError, match=re.escape("'Q_ref' must be non-zero")),
+            id="transverse-zero-qref",
+        ),
+    ],
+)
+def test_hkl_points(trajectory, n_points, expected_first, expected_last, context):
+    with context:
+        points = _hkl_points(trajectory, n_points)
+        assert len(points) == n_points
+        if expected_first is not None:
+            assert np.allclose(points[0], expected_first, atol=1e-12)
+        if expected_last is not None:
+            assert np.allclose(points[-1], expected_last, atol=1e-12)
+
+
+def test_hkl_points_transverse_perpendicular():
+    """Transverse points lie perpendicular to Q_ref from center."""
+    q_ref = np.array([0.0, 0.0, 1.0])
+    center = np.array([1.0, 0.0, 0.0])
+    points = _hkl_points(
+        {
+            "type": "transverse",
+            "center": tuple(center),
+            "Q_ref": tuple(q_ref),
+            "extent": 0.5,
+        },
+        n_points=5,
+    )
+    for pt in points:
+        disp = np.array(pt) - center
+        assert abs(np.dot(disp, q_ref)) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# Decomposition round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_euler_from_Z_round_trip_fourcv():
+    """_euler_from_Z_standard reproduces fourcv base angles to 1e-10."""
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = _setup(fourcv)
+    base = g.forward(1, 1, 0)[0]
+    for name, angle in base.items():
+        try:
+            g.set_angle(name, angle)
+        except KeyError:
+            pass
+    Z0 = g.sample_rotation_matrix()
+    omega_s, chi_s, phi_s = (
+        g.sample_stages[-3],
+        g.sample_stages[-2],
+        g.sample_stages[-1],
+    )
+    for om, chi, phi in _euler_from_Z_standard(Z0, omega_s, chi_s, phi_s):
+        Z_r = Rmat(phi_s.axis, phi) @ Rmat(chi_s.axis, chi) @ Rmat(omega_s.axis, om)
+        assert np.linalg.norm(Z0 - Z_r) < 1e-10, (
+            f"Recomposition error: {np.linalg.norm(Z0 - Z_r)}"
+        )
+
+
+def test_euler_from_Z_round_trip_psic():
+    """_euler_from_Z_standard recomposes psic inner-3 Z to 1e-10."""
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = _setup(psic)
+    # Use a non-degenerate reflection (chi ≠ 0) to avoid the chi=0 degeneracy
+    base = g.forward(1, 1, 0)[0]
+    # Force a non-trivial chi by using the negative-chi branch
+    solutions = g.forward(1, 1, 0)
+    base = max(solutions, key=lambda s: abs(s.get("chi", 0)))
+    for name, angle in base.items():
+        try:
+            g.set_angle(name, angle)
+        except KeyError:
+            pass
+    Z0 = g.sample_rotation_matrix()
+    omega_s, chi_s, phi_s = (
+        g.sample_stages[-3],
+        g.sample_stages[-2],
+        g.sample_stages[-1],
+    )
+    outer = g.sample_stages[:-3]
+    R_outer = np.eye(3)
+    for s in outer:
+        R_outer = Rmat(s.axis, base.get(s.name, s.angle)) @ R_outer
+    Z_inner = R_outer.T @ Z0
+    recompose_errors = []
+    for om, chi, phi in _euler_from_Z_standard(Z_inner, omega_s, chi_s, phi_s):
+        Z_r = Rmat(phi_s.axis, phi) @ Rmat(chi_s.axis, chi) @ Rmat(omega_s.axis, om)
+        recompose_errors.append(np.linalg.norm(Z_inner - Z_r))
+    assert min(recompose_errors) < 1e-10, f"Recomposition errors: {recompose_errors}"
+
+
+def test_kappa_from_Z_round_trip_kappa4cv():
+    """_kappa_from_Z reproduces kappa4cv base angles to 1e-10."""
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = _setup(kappa4cv)
+    base = g.forward(1, 1, 0)[0]
+    for name, angle in base.items():
+        try:
+            g.set_angle(name, angle)
+        except KeyError:
+            pass
+    Z0 = g.sample_rotation_matrix()
+    kom_s, kap_s, kph_s = g.sample_stages[-3], g.sample_stages[-2], g.sample_stages[-1]
+    sols = _kappa_from_Z(Z0, kom_s, kap_s, kph_s, g.kappa_alpha_deg)
+    # At least one solution must reproduce Z0 and match base angles
+    assert any(
+        np.linalg.norm(
+            Rmat(kph_s.axis, kph) @ Rmat(kap_s.axis, kap) @ Rmat(kom_s.axis, kom) - Z0
+        )
+        < 1e-10
+        for kom, kap, kph in sols
+    )
+    # One solution must match the base motor angles
+    base_match = any(
+        abs(kom - base["komega"]) < 1e-4
+        and abs(kap - base["kappa"]) < 1e-4
+        and abs(kph - base["kphi"]) < 1e-4
+        for kom, kap, kph in sols
+    )
+    assert base_match
+
+
+# ---------------------------------------------------------------------------
+# hkl_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestHklTrajectory:
+    def test_line_round_trip(self):
+        """Every accessible point satisfies inverse(angles) ≈ hkl."""
+        g = _setup(fourcv)
+        result = hkl_trajectory(
+            g,
+            {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
+            n_points=5,
+        )
+        assert len(result) == 5
+        for pt in result:
+            if pt["angles"] is not None:
+                assert _round_trip_ok(g, pt["angles"], pt["hkl"])
+                assert pt["warning"] is None
+
+    def test_radial_trajectory_endpoints(self):
+        """Radial trajectory: endpoints match expected hkl."""
+        g = _setup(fourcv)
+        result = hkl_trajectory(
+            g,
+            {
+                "type": "radial",
+                "center": (1, 0, 0),
+                "direction": (1, 0, 0),
+                "extent": 0.5,
+            },
+            n_points=3,
+        )
+        assert len(result) == 3
+        assert np.allclose(result[0]["hkl"], (0.5, 0.0, 0.0), atol=1e-12)
+        assert np.allclose(result[2]["hkl"], (1.5, 0.0, 0.0), atol=1e-12)
+
+    def test_transverse_perpendicular(self):
+        """Transverse points lie perpendicular to Q_ref from center."""
+        g = _setup(fourcv)
+        result = hkl_trajectory(
+            g,
+            {
+                "type": "transverse",
+                "center": (1, 0, 0),
+                "Q_ref": (1, 0, 0),
+                "extent": 0.1,
+            },
+            n_points=5,
+        )
+        center = np.array([1.0, 0.0, 0.0])
+        q_ref = np.array([1.0, 0.0, 0.0])
+        for pt in result:
+            disp = np.array(pt["hkl"]) - center
+            assert abs(np.dot(disp, q_ref)) < 1e-12
+
+    def test_inaccessible_gives_none_and_warning(self):
+        """When Q exceeds Ewald sphere, angles=None and warning is non-empty."""
+        g = _setup(fourcv, a=0.1)  # tiny lattice → very large |Q|
+        result = hkl_trajectory(
+            g,
+            {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
+            n_points=3,
+        )
+        inaccessible = [pt for pt in result if pt["angles"] is None]
+        assert len(inaccessible) > 0
+        for pt in inaccessible:
+            assert pt["warning"] is not None
+
+    def test_nearest_angles_prevents_branch_flip(self):
+        """chi values stay on the same branch (no sign flip) with NEAREST_ANGLES."""
+        g = _setup(fourcv)
+        result = hkl_trajectory(
+            g,
+            {"type": "line", "start": (0.5, 0, 0), "end": (1.5, 0, 0)},
+            n_points=7,
+            solution_key=NEAREST_ANGLES,
+        )
+        chi_values = [pt["angles"]["chi"] for pt in result if pt["angles"] is not None]
+        assert len(chi_values) >= 2
+        signs = {1 if v >= 0 else -1 for v in chi_values}
+        assert len(signs) == 1, f"Branch flip detected: chi = {chi_values}"
+
+    def test_custom_solution_key(self):
+        """A caller-supplied solution_key controls solution selection."""
+        g = _setup(fourcv)
+        # Always pick the solution with the largest (most positive) chi
+        max_chi_key = lambda c, p: -c.get("chi", 0.0)  # noqa: E731
+        result = hkl_trajectory(
+            g,
+            {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
+            n_points=2,
+            solution_key=max_chi_key,
+        )
+        for pt in result:
+            if pt["angles"] is not None:
+                assert pt["angles"]["chi"] >= 0.0
+
+    def test_none_solution_key_returns_result(self):
+        """solution_key=None runs and returns angles dicts."""
+        g = _setup(fourcv)
+        result = hkl_trajectory(
+            g,
+            {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
+            n_points=2,
+            solution_key=None,
+        )
+        assert all("angles" in pt for pt in result)
+
+    @pytest.mark.parametrize(
+        "trajectory, n_points, context",
+        [
+            pytest.param(
+                {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
+                1,
+                pytest.raises(
+                    ValueError, match=re.escape("n_points must be at least 2")
+                ),
+                id="n-points-too-small",
+            ),
+            pytest.param(
+                {"type": "bad_type"},
+                3,
+                pytest.raises(ValueError, match=re.escape("unknown trajectory type")),
+                id="unknown-trajectory-type",
+            ),
+        ],
+    )
+    def test_hkl_trajectory_raises(self, trajectory, n_points, context):
+        g = _setup(fourcv)
+        with context:
+            hkl_trajectory(g, trajectory, n_points)
+
+    def test_no_wavelength_gives_warnings(self):
+        """When wavelength is not set all points have warnings and angles=None."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=4.0)
+        ub_identity(g.sample)
+        g.mode_name = "bisecting"
+        result = hkl_trajectory(
+            g, {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)}, n_points=3
+        )
+        assert all(pt["angles"] is None for pt in result)
+        assert all(pt["warning"] is not None for pt in result)
+
+
+# ---------------------------------------------------------------------------
+# psi_trajectory
+# ---------------------------------------------------------------------------
+
+
+class TestPsiTrajectory:
+    """
+    psi_trajectory() uses the BL1967 operational ψ definition.
+    ψ = 0 at the base forward() solution; each psi_target specifies the
+    rotation of the sample about Q relative to that reference.
+    """
+
+    PSI_TARGETS = list(range(-90, 91, 30))
+
+    @staticmethod
+    def _psi_err(actual, target):
+        """Angular error mod 360, in (-180, 180]."""
+        diff = (actual - target + 180.0) % 360.0 - 180.0
+        return abs(diff)
+
+    def _psi_round_trip(self, geometry, hkl=HKL_TEST, targets=None, atol=0.05):
+        """Assert psi_actual ≈ psi_target (mod 360) for all accessible points."""
+        if targets is None:
+            targets = self.PSI_TARGETS
+        result = psi_trajectory(geometry, *hkl, targets)
+        assert len(result) == len(targets)
+        accessible = [pt for pt in result if pt["angles"] is not None]
+        assert len(accessible) >= len(targets) // 2, (
+            f"Too few accessible psi points: {[(pt['psi_target'], pt['warning']) for pt in result]}"
+        )
+        for pt in accessible:
+            err = self._psi_err(pt["psi_actual"], pt["psi_target"])
+            assert err <= atol, (
+                f"psi mismatch: target={pt['psi_target']}, actual={pt['psi_actual']}, err={err}"
+            )
+            assert pt["warning"] is None
+
+    def test_psi_round_trip_fourcv(self):
+        """BL1967 psi round-trip on fourcv."""
+        g = _setup(fourcv)
+        self._psi_round_trip(g)
+
+    def test_psi_round_trip_psic(self):
+        """BL1967 psi round-trip on psic using (0,1,1) which has non-zero chi."""
+        g = _setup(psic)
+        # (1,1,0) gives chi≈0 which is a degenerate case for Euler decomposition;
+        # use (0,1,1) instead which has chi ≈ ±75° (well-conditioned).
+        self._psi_round_trip(g, hkl=(0, 1, 1), targets=list(range(-60, 61, 30)))
+
+    def test_psi_round_trip_kappa4cv(self):
+        """BL1967 psi round-trip on kappa4cv (mid-range, avoids arm limits)."""
+        g = _setup(kappa4cv)
+        self._psi_round_trip(g, targets=list(range(-60, 61, 30)), atol=0.1)
+
+    def test_psi_zero_at_base(self):
+        """psi_actual = 0 when psi_target = 0 (base forward() solution)."""
+        g = _setup(fourcv)
+        result = psi_trajectory(g, *HKL_TEST, [0.0])
+        assert result[0]["psi_actual"] == pytest.approx(0.0, abs=1e-6)
+
+    def test_psi_smooth_motion_nearest_angles(self):
+        """phi values vary smoothly across a dense ψ sweep (no large jumps)."""
+        g = _setup(fourcv)
+        targets = list(range(-60, 61, 10))
+        result = psi_trajectory(g, *HKL_TEST, targets, solution_key=NEAREST_ANGLES)
+        phi_values = [pt["angles"]["phi"] for pt in result if pt["angles"] is not None]
+        assert len(phi_values) >= 2
+        for i in range(1, len(phi_values)):
+            diff = abs(phi_values[i] - phi_values[i - 1])
+            assert diff < 45.0, (
+                f"Large phi jump at index {i}: "
+                f"{phi_values[i - 1]:.1f}° → {phi_values[i]:.1f}°"
+            )
+
+    def test_psi_no_bragg_solution(self):
+        """When reflection is inaccessible all psi points have warning."""
+        g = _setup(fourcv)
+        g.stage("ttheta").limits = (0.0, 1.0)  # block the detector
+        result = psi_trajectory(g, *HKL_TEST, [0.0, 30.0])
+        for pt in result:
+            assert pt["angles"] is None
+            assert pt["warning"] is not None
+
+    def test_psi_no_wavelength_raises(self):
+        """Raises ValueError when wavelength is not set."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=4.0)
+        ub_identity(g.sample)
+        g.mode_name = "bisecting"
+        with pytest.raises(ValueError, match=re.escape("wavelength")):
+            psi_trajectory(g, *HKL_TEST, [0.0])
+
+    def test_psi_no_ub_raises(self):
+        """Raises ValueError when UB is not set."""
+        g = fourcv()
+        g.wavelength = WAVELENGTH
+        g.mode_name = "bisecting"
+        with pytest.raises(ValueError, match=re.escape("UB")):
+            psi_trajectory(g, *HKL_TEST, [0.0])
+
+    def test_psi_zero_hkl_raises(self):
+        """Raises ValueError for hkl = (0,0,0)."""
+        g = _setup(fourcv)
+        with pytest.raises(ValueError, match=re.escape("(0, 0, 0)")):
+            psi_trajectory(g, 0, 0, 0, [0.0])
+
+    def test_psi_result_keys(self):
+        """Every result entry has exactly the expected keys."""
+        g = _setup(fourcv)
+        result = psi_trajectory(g, *HKL_TEST, [0.0])
+        assert set(result[0].keys()) == {
+            "psi_target",
+            "psi_actual",
+            "angles",
+            "warning",
+        }
+
+    def test_psi_none_solution_key(self):
+        """solution_key=None runs without error."""
+        g = _setup(fourcv)
+        result = psi_trajectory(g, *HKL_TEST, [0.0], solution_key=None)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# trajectory_plan
+# ---------------------------------------------------------------------------
+
+
+class TestTrajectoryPlan:
+    def test_hkl_space_endpoints(self):
+        """Start and end hkl are exactly the requested values."""
+        g = _setup(fourcv)
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5)
+        assert len(plan) == 5
+        assert np.allclose(plan[0]["hkl"], (1, 0, 0), atol=1e-12)
+        assert np.allclose(plan[-1]["hkl"], (2, 0, 0), atol=1e-12)
+
+    def test_hkl_space_round_trip(self):
+        """All accessible points satisfy inverse(angles) ≈ hkl."""
+        g = _setup(fourcv)
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5)
+        for pt in plan:
+            if pt["accessible"]:
+                assert _round_trip_ok(g, pt["angles"], pt["hkl"])
+                assert pt["warnings"] == []
+
+    def test_q_space_endpoints_exact(self):
+        """space='Q': endpoints are exact despite Q interpolation."""
+        g = _setup(fourcv)
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5, space="Q")
+        assert np.allclose(plan[0]["hkl"], (1, 0, 0), atol=1e-12)
+        assert np.allclose(plan[-1]["hkl"], (2, 0, 0), atol=1e-12)
+
+    def test_q_space_equal_dq_steps(self):
+        """space='Q': consecutive Q-vector differences are equal in magnitude."""
+        g = _setup(fourcv)
+        # Tetragonal lattice: a≠c, so hkl-space is not uniform in Q-space.
+        g.sample.lattice = ahd.Lattice(a=3.0, c=6.0)
+        ub_identity(g.sample)
+
+        n = 5
+        plan_q = trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="Q")
+
+        # Compute Q vectors at each trajectory point
+        Q_vecs = [g.sample.UB @ np.array(pt["hkl"]) for pt in plan_q]
+        # Consecutive differences in Q should all be equal vectors
+        dQ = [Q_vecs[i + 1] - Q_vecs[i] for i in range(n - 1)]
+        dQ_mags = [np.linalg.norm(d) for d in dQ]
+        # All step sizes equal (Q-space interpolation is uniform)
+        assert np.std(dQ_mags) < 1e-10, f"Q step sizes not equal: {dQ_mags}"
+
+        # Verify both plans share the same exact endpoints regardless of space.
+        plan_hkl = trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="hkl")
+        assert np.allclose(plan_q[0]["hkl"], (1, 0, 0), atol=1e-12)
+        assert np.allclose(plan_q[-1]["hkl"], (0, 0, 2), atol=1e-12)
+        assert np.allclose(plan_hkl[0]["hkl"], (1, 0, 0), atol=1e-12)
+        assert np.allclose(plan_hkl[-1]["hkl"], (0, 0, 2), atol=1e-12)
+
+    def test_inaccessible_points_flagged(self):
+        """Points with no valid solution are accessible=False."""
+        g = _setup(fourcv, a=0.1)
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        inaccessible = [pt for pt in plan if not pt["accessible"]]
+        assert len(inaccessible) > 0
+        for pt in inaccessible:
+            assert pt["angles"] is None
+            assert len(pt["warnings"]) > 0
+
+    def test_nearest_angles_no_branch_flip(self):
+        """chi values stay on the same branch across the plan."""
+        g = _setup(fourcv)
+        plan = trajectory_plan(g, (0.5, 0, 0), (1.5, 0, 0), n_points=9)
+        chi_values = [pt["angles"]["chi"] for pt in plan if pt["accessible"]]
+        assert len(chi_values) >= 2
+        signs = {1 if v >= 0 else -1 for v in chi_values}
+        assert len(signs) == 1, f"Branch flip: chi = {chi_values}"
+
+    def test_n_points_too_small_raises(self):
+        g = _setup(fourcv)
+        with pytest.raises(ValueError, match=re.escape("n_points must be at least 2")):
+            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=1)
+
+    def test_invalid_space_raises(self):
+        g = _setup(fourcv)
+        with pytest.raises(ValueError, match=re.escape("space must be 'hkl' or 'Q'")):
+            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="crystal")
+
+    def test_q_space_no_ub_raises(self):
+        g = fourcv()
+        g.wavelength = WAVELENGTH
+        g.mode_name = "bisecting"
+        with pytest.raises(ValueError, match=re.escape("UB")):
+            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q")
+
+    def test_result_keys(self):
+        g = _setup(fourcv)
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        for pt in plan:
+            assert set(pt.keys()) == {"hkl", "angles", "accessible", "warnings"}
+
+    def test_n_points_respected(self):
+        g = _setup(fourcv)
+        for n in [2, 5, 11]:
+            plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=n)
+            assert len(plan) == n
+
+    def test_psic_accessible(self):
+        """psic geometry: most points on a simple trajectory should be accessible."""
+        g = _setup(psic)
+        plan = trajectory_plan(g, (0, 0, 1), (0, 0, 2), n_points=5)
+        assert sum(pt["accessible"] for pt in plan) >= 3
+
+    def test_no_wavelength_gives_inaccessible(self):
+        """When wavelength is not set all points are inaccessible."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=4.0)
+        ub_identity(g.sample)
+        g.mode_name = "bisecting"
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        assert all(not pt["accessible"] for pt in plan)
+        assert all(len(pt["warnings"]) > 0 for pt in plan)
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports():
+    """All scan symbols are importable from the top-level package."""
+    assert ahd.NEAREST_ANGLES is NEAREST_ANGLES
+    assert ahd.hkl_trajectory is hkl_trajectory
+    assert ahd.psi_trajectory is psi_trajectory
+    assert ahd.trajectory_plan is trajectory_plan

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -746,3 +746,236 @@ def test_public_api_exports():
     assert ahd.hkl_trajectory is hkl_trajectory
     assert ahd.psi_trajectory is psi_trajectory
     assert ahd.trajectory_plan is trajectory_plan
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: defensive / degenerate paths
+# ---------------------------------------------------------------------------
+
+
+def test_check_limits_unknown_stage_ignored():
+    """_check_limits ignores stage names not present in geometry."""
+    from ad_hoc_diffractometer.scan import _check_limits
+
+    g = _setup(fourcv)
+    # "nonexistent" is not a stage — should be silently skipped
+    assert _check_limits(g, {"omega": 10.0, "nonexistent": 999.0}) is True
+
+
+def test_check_limits_out_of_limits_returns_false():
+    """_check_limits returns False when an angle exceeds stage limits."""
+    from ad_hoc_diffractometer.scan import _check_limits
+
+    g = _setup(fourcv)
+    # ttheta default limit is (-180, 180); 200° is out
+    assert _check_limits(g, {"ttheta": 200.0}) is False
+
+
+def test_hkl_points_transverse_gram_schmidt_fallback():
+    """_hkl_points transverse works when Q_ref is nearly aligned with x-axis."""
+    # Q_ref near [1,0,0] forces Gram-Schmidt to fall back to [0,1,0]
+    pts = _hkl_points(
+        {
+            "type": "transverse",
+            "center": (0, 0, 1),
+            "Q_ref": (1.0, 0.0, 0.0),
+            "extent": 0.1,
+        },
+        n_points=3,
+    )
+    assert len(pts) == 3
+    # All points should be perpendicular to Q_ref from center
+    center = np.array([0.0, 0.0, 1.0])
+    q_ref = np.array([1.0, 0.0, 0.0])
+    for pt in pts:
+        disp = np.array(pt) - center
+        assert abs(np.dot(disp, q_ref)) < 1e-12
+
+
+def test_euler_dedup_chi_zero():
+    """_euler_from_Z_standard returns one solution when chi ≈ 0 (degenerate)."""
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = _setup(fourcv)
+    # Build a Z with chi = 0 exactly
+    omega_s, chi_s, phi_s = (
+        g.sample_stages[-3],
+        g.sample_stages[-2],
+        g.sample_stages[-1],
+    )
+    Z_chi0 = Rmat(phi_s.axis, 30.0) @ Rmat(chi_s.axis, 0.0) @ Rmat(omega_s.axis, 15.0)
+    sols = _euler_from_Z_standard(Z_chi0, omega_s, chi_s, phi_s)
+    # chi ≈ 0 means both branches are identical — dedup should leave one
+    for _, chi, _ in sols:
+        assert abs(chi) < 1e-6
+
+
+def test_kappa_dedup_kappa_zero():
+    """_kappa_from_Z returns one solution when kappa ≈ 0 (degenerate)."""
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = _setup(kappa4cv)
+    kom_s, kap_s, kph_s = g.sample_stages[-3], g.sample_stages[-2], g.sample_stages[-1]
+    # Build a Z with kappa = 0 (equivalent to chi = 0 Eulerian)
+    Z_kap0 = Rmat(kph_s.axis, 20.0) @ Rmat(kap_s.axis, 0.0) @ Rmat(kom_s.axis, 10.0)
+    sols = _kappa_from_Z(Z_kap0, kom_s, kap_s, kph_s, g.kappa_alpha_deg)
+    for _, kap, _ in sols:
+        assert abs(kap) < 1e-6
+
+
+def test_psi_trajectory_beam_parallel_to_Q():
+    """psi_trajectory returns warning when beam is parallel to Q."""
+    # (0,1,0) with UB=B in BL basis: Q_phi = B@[0,1,0] = (0, 2π/a, 0)
+    # The BL longitudinal (beam) direction is also [0,1,0], so beam ∥ Q.
+    g = _setup(fourcv)
+    result = psi_trajectory(g, 0, 1, 0, [0.0])
+    # Either no solution found (limits) or the beam-parallel warning fires
+    # — in any case the degenerate path must not raise
+    assert len(result) == 1
+    assert "angles" in result[0]
+
+
+def test_psi_trajectory_fewer_than_3_sample_stages():
+    """psi_trajectory returns no-solution entries for a geometry with < 3 sample stages."""
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import BisectingMode
+    from ad_hoc_diffractometer import Stage
+    from ad_hoc_diffractometer.constants import YHAT
+    from ad_hoc_diffractometer.constants import ZHAT
+
+    # Construct a minimal geometry with only 2 sample stages
+    stages = [
+        Stage("omega", -ZHAT, parent=None, role="sample"),
+        Stage("phi", -ZHAT, parent="omega", role="sample"),
+        Stage("ttheta", -ZHAT, parent=None, role="detector"),
+    ]
+    modes = {"bisecting": BisectingMode(sample_stage="omega", detector_stage="ttheta")}
+    g = AdHocDiffractometer(
+        name="minimal2",
+        stages=stages,
+        basis={
+            "vertical": ZHAT,
+            "longitudinal": YHAT,
+            "lateral": np.array([1.0, 0.0, 0.0]),
+        },
+        modes=modes,
+        default_mode="bisecting",
+    )
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ahd.ub_identity(g.sample)
+
+    result = psi_trajectory(g, 1, 0, 0, [0.0, 30.0])
+    # _psi_candidates returns [] for < 3 sample stages → warning entries
+    for pt in result:
+        assert pt["angles"] is None
+        assert pt["warning"] is not None
+
+
+def test_hkl_trajectory_all_candidates_outside_limits():
+    """hkl_trajectory produces angles=None when all solutions fail limits."""
+    g = _setup(fourcv)
+    # Lock chi to a range that excludes all forward() solutions for (1,0,0)
+    g.stage("chi").limits = (0.1, 0.2)
+    result = hkl_trajectory(
+        g, {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)}, n_points=2
+    )
+    for pt in result:
+        assert pt["angles"] is None
+        assert pt["warning"] is not None
+
+
+def test_trajectory_plan_all_candidates_outside_limits():
+    """trajectory_plan marks points inaccessible when all solutions fail limits."""
+    g = _setup(fourcv)
+    g.stage("chi").limits = (0.1, 0.2)
+    plan = trajectory_plan(g, (1, 0, 0), (1, 0, 0), n_points=2)
+    for pt in plan:
+        assert not pt["accessible"]
+        assert len(pt["warnings"]) > 0
+
+
+def test_trajectory_plan_singular_ub_raises():
+    """trajectory_plan(space='Q') raises ValueError when UB is singular."""
+    g = _setup(fourcv)
+    # Replace UB with a singular matrix
+    g.sample.UB = np.zeros((3, 3))
+    with pytest.raises(ValueError, match=re.escape("singular")):
+        trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q")
+
+
+def test_trajectory_plan_check_limits_warning_when_violated():
+    """trajectory_plan adds a warning and marks inaccessible when check_limits fails."""
+    # Use solution_key=None so forward()'s first solution is always picked.
+    # Then narrow the limits of a stage to exclude that solution after picking.
+    # We monkey-patch check_limits to always raise so the warning path is exercised.
+    import unittest.mock as mock
+
+    g = _setup(fourcv)
+    exc = ValueError("The following stages have angles outside their limits:\n  chi")
+    with mock.patch.object(g, "check_limits", side_effect=exc):
+        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, solution_key=None)
+
+    for pt in plan:
+        if pt["angles"] is not None:
+            assert not pt["accessible"]
+            assert len(pt["warnings"]) > 0
+
+
+def test_perp_ref_second_candidate():
+    """_perp_ref iterates to second candidate when axis is nearly parallel to y."""
+    from ad_hoc_diffractometer.scan import _perp_ref
+
+    # axis = [0,1,0]: first candidate [0,1,0] gives norm ≈ 0 → loop continues
+    # second candidate [1,0,0] gives norm = 1 → returned
+    axis = np.array([0.0, 1.0, 0.0])
+    result = _perp_ref(axis)
+    assert abs(np.dot(result, axis)) < 1e-10
+    assert abs(np.linalg.norm(result) - 1.0) < 1e-10
+
+
+def test_psi_trajectory_candidate_outside_limits_skipped():
+    """psi_trajectory returns no-solution when all psi candidates fail limits."""
+    from ad_hoc_diffractometer.scan import _psi_candidates
+
+    g = _setup(fourcv)
+    base = g.forward(1, 1, 0)[0]
+    for name, angle in base.items():
+        try:
+            g.set_angle(name, angle)
+        except KeyError:
+            pass
+    Z0 = g.sample_rotation_matrix()
+    D = g.detector_rotation_matrix()
+    y_eff = np.asarray(g.basis["longitudinal"], dtype=float)
+    y_eff /= np.linalg.norm(y_eff)
+    y_eff = g.inclination_matrix.T @ y_eff
+    Q_lab_vec = (2 * np.pi / g.wavelength) * (D @ y_eff - y_eff)
+    Q_lab_hat = Q_lab_vec / np.linalg.norm(Q_lab_vec)
+
+    # Tighten phi limits so the psi-rotated candidates fail _check_limits
+    g.stage("phi").limits = (-0.001, 0.001)
+    # psi=45° will produce chi/phi values outside these limits
+    candidates = _psi_candidates(g, Z0, Q_lab_hat, y_eff, 45.0, base)
+    # Some (or all) candidates should have been filtered out
+    # The key assertion: no candidate has phi outside limits
+    for c in candidates:
+        assert g.stage("phi").in_limits(c["phi"])
+
+
+def test_psi_trajectory_on_longitudinal_reflection():
+    """psi_trajectory on (0,1,0) — Q along beam — still returns results.
+
+    For fourcv BL basis, (0,1,0) has Q_phi ∝ [0,1,0] = beam direction.
+    The beam∥Q degenerate guard has been removed: psi_trajectory is only
+    called after a valid forward() solution exists.  At the Bragg position
+    Z is NOT the identity, so y_phi = Z.T @ y_eff is not parallel to q_hat_phi
+    and psi_actual is a well-defined float.
+    """
+    g = _setup(fourcv)
+    result = psi_trajectory(g, 0, 1, 0, [0.0, 30.0])
+    # Should find solutions (or gracefully report limits issues)
+    assert len(result) == 2
+    for pt in result:
+        assert "psi_target" in pt
+        assert "psi_actual" in pt


### PR DESCRIPTION
- closes #14

Adds a new `scan.py` module implementing roadmap item 3.6.

## What was added

**`hkl_trajectory(geometry, trajectory, n_points, *, solution_key=NEAREST_ANGLES)`**
Computes motor-angle sequences along line, radial, or transverse reciprocal-space paths. The `NEAREST_ANGLES` solution key prevents chi branch-flip discontinuities across the trajectory.

**`psi_trajectory(geometry, h, k, l, psi_values, *, solution_key=NEAREST_ANGLES)`**
Computes motor angles for the Busing & Levy (1967) operational ψ — rotation of the sample about Q relative to the base `forward()` solution. Algorithm: builds Z(ψ) = R(Q̂\_lab, −ψ) · Z₀ then decomposes analytically into Eulerian (fourcv, fourch, psic) or kappa (kappa4cv, kappa4ch, kappa6c) motor angles. Note: this is distinct from the You (1999) ψ computed by `geometry.psi()`, which is constant for a given hkl+UB combination — the module docstring documents the distinction.

**`trajectory_plan(geometry, hkl_start, hkl_end, n_points, *, space="hkl"|"Q")`**
Plans a motor-angle path between two reciprocal-space points with per-point limit/accessibility flagging. Supports hkl-space (uniform in Miller indices) and Q-space (uniform in Å⁻¹) interpolation.

**`NEAREST_ANGLES`** — built-in solution-key callable: suppresses branch-flip discontinuities by preferring the candidate closest in motor space to the previous trajectory point.

## Tests

53 tests in `tests/test_scan.py`; 1093 tests total; all pass. Pre-commit clean.

Contributed by: OpenCode (argo/claudesonnet46)