### PR TITLE
3.4 Alternative calculation engines

### DIFF
--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -19,6 +19,16 @@ from .display import fmt
 from .display import get_precision
 from .display import precision_atol
 from .display import set_precision
+from .engines import Q_mag_to_two_theta
+from .engines import Q_to_d
+from .engines import Q_to_hkl
+from .engines import d_to_Q_mag
+from .engines import d_to_two_theta
+from .engines import hkl_to_d
+from .engines import hkl_to_Q
+from .engines import hkl_to_two_theta
+from .engines import two_theta_to_d
+from .engines import two_theta_to_Q_mag
 from .factories import BASIS_BL
 from .factories import BASIS_YOU
 from .factories import GEOMETRY_ENTRY_POINT_GROUP
@@ -107,6 +117,17 @@ __all__ = [
     "FixedAngleMode",
     "BisectingMode",
     "ModeDict",
+    # alternative calculation engines
+    "hkl_to_Q",
+    "Q_to_hkl",
+    "Q_to_d",
+    "d_to_Q_mag",
+    "hkl_to_d",
+    "d_to_two_theta",
+    "two_theta_to_d",
+    "hkl_to_two_theta",
+    "two_theta_to_Q_mag",
+    "Q_mag_to_two_theta",
     # forward calculation
     "compute_forward",
     # scan / trajectory

--- a/src/ad_hoc_diffractometer/engines.py
+++ b/src/ad_hoc_diffractometer/engines.py
@@ -1,0 +1,508 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+engines.py — Alternative calculation engines.
+
+Provides standalone conversion functions between the four representations
+of a diffraction position:
+
+- **hkl** — Miller indices (h, k, l); dimensionless integers or reals
+- **Q-vector** — scattering vector (Qx, Qy, Qz) in Å⁻¹ (reciprocal Cartesian)
+- **d-spacing** — interplanar spacing d in Å; scalar
+- **two-theta** — diffraction angle 2θ in degrees; requires wavelength
+
+All conversions follow Busing & Levy (1967) and You (1999).
+
+Functions
+---------
+hkl_to_Q(sample, h, k, l) -> np.ndarray
+    Miller indices → Q-vector (Å⁻¹) via Q = UB @ hkl.
+
+Q_to_hkl(sample, Qx, Qy, Qz) -> tuple[float, float, float]
+    Q-vector → Miller indices via hkl = UB⁻¹ @ Q.
+
+Q_to_d(Qx, Qy, Qz) -> float
+    Q-vector magnitude → d-spacing: d = 2π / |Q|.
+
+d_to_Q_mag(d) -> float
+    d-spacing → |Q|: |Q| = 2π / d.
+
+hkl_to_d(sample, h, k, l) -> float
+    Miller indices → d-spacing via |Q| = |UB @ hkl|, d = 2π / |Q|.
+
+d_to_two_theta(d, wavelength) -> float
+    d-spacing → 2θ (degrees) via Bragg's law: λ = 2d sin(θ).
+
+two_theta_to_d(two_theta_deg, wavelength) -> float
+    2θ (degrees) → d-spacing via Bragg's law.
+
+hkl_to_two_theta(sample, h, k, l, wavelength) -> float
+    Miller indices → 2θ (degrees).
+
+two_theta_to_Q_mag(two_theta_deg, wavelength) -> float
+    2θ (degrees) → |Q| (Å⁻¹): |Q| = 4π sin(θ) / λ.
+
+Q_mag_to_two_theta(Q_mag, wavelength) -> float
+    |Q| (Å⁻¹) → 2θ (degrees).
+
+References
+----------
+Busing & Levy, Acta Cryst. 22, 457-464 (1967) — B matrix, Q = UB @ hkl.
+You, J. Appl. Cryst. 32, 614-623 (1999) — Bragg condition, 2θ definition.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .sample import Sample
+
+_TWO_PI = 2.0 * math.pi
+
+
+# ---------------------------------------------------------------------------
+# hkl ↔ Q-vector
+# ---------------------------------------------------------------------------
+
+
+def hkl_to_Q(
+    sample: Sample,
+    h: float,
+    k: float,
+    l: float,  # noqa: E741
+) -> np.ndarray:
+    """
+    Convert Miller indices to the scattering vector Q in Å⁻¹.
+
+    Uses the UB matrix: **Q** = UB · **hkl**.
+
+    Parameters
+    ----------
+    sample : Sample
+        Sample with a UB matrix set.
+    h, k, l : float
+        Miller indices.
+
+    Returns
+    -------
+    numpy.ndarray, shape (3,)
+        Scattering vector (Qx, Qy, Qz) in Å⁻¹.
+
+    Raises
+    ------
+    ValueError
+        If ``sample.UB`` is None.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.sample.lattice = ahd.Lattice(a=3.905)
+    >>> ahd.ub_identity(g.sample)
+    >>> Q = ahd.hkl_to_Q(g.sample, 1, 0, 0)
+    >>> float(Q[0])  # doctest: +ELLIPSIS
+    1.6...
+    """
+    if sample.UB is None:
+        raise ValueError(
+            "hkl_to_Q() requires sample.UB to be set. "
+            "Call ub_identity() or ub_from_*() first."
+        )
+    return sample.UB @ np.array([float(h), float(k), float(l)], dtype=float)
+
+
+def Q_to_hkl(
+    sample: Sample,
+    Qx: float,
+    Qy: float,
+    Qz: float,
+) -> tuple[float, float, float]:
+    """
+    Convert a Q-vector (Å⁻¹) to Miller indices.
+
+    Solves **hkl** = UB⁻¹ · **Q**.
+
+    Parameters
+    ----------
+    sample : Sample
+        Sample with a UB matrix set.
+    Qx, Qy, Qz : float
+        Scattering vector components in Å⁻¹.
+
+    Returns
+    -------
+    tuple of float
+        Miller indices (h, k, l).
+
+    Raises
+    ------
+    ValueError
+        If ``sample.UB`` is None or singular.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> import numpy as np
+    >>> g = ahd.fourcv()
+    >>> g.sample.lattice = ahd.Lattice(a=3.905)
+    >>> ahd.ub_identity(g.sample)
+    >>> Q = ahd.hkl_to_Q(g.sample, 1, 0, 0)
+    >>> ahd.Q_to_hkl(g.sample, *Q)  # doctest: +ELLIPSIS
+    (1.0, 0.0, 0.0)
+    """
+    if sample.UB is None:
+        raise ValueError(
+            "Q_to_hkl() requires sample.UB to be set. "
+            "Call ub_identity() or ub_from_*() first."
+        )
+    Q = np.array([float(Qx), float(Qy), float(Qz)], dtype=float)
+    try:
+        hkl = np.linalg.solve(sample.UB, Q)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError("Q_to_hkl(): UB matrix is singular; cannot invert.") from exc
+    return (float(hkl[0]), float(hkl[1]), float(hkl[2]))
+
+
+# ---------------------------------------------------------------------------
+# Q-magnitude ↔ d-spacing
+# ---------------------------------------------------------------------------
+
+
+def Q_to_d(Qx: float, Qy: float, Qz: float) -> float:
+    """
+    Convert a Q-vector to the d-spacing.
+
+    d = 2π / |**Q**|
+
+    Parameters
+    ----------
+    Qx, Qy, Qz : float
+        Scattering vector components in Å⁻¹.
+
+    Returns
+    -------
+    float
+        d-spacing in Å.
+
+    Raises
+    ------
+    ValueError
+        If |Q| = 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.Q_to_d(1.0, 0.0, 0.0), 6)
+    6.283185
+    """
+    Q_mag = math.sqrt(Qx**2 + Qy**2 + Qz**2)
+    if Q_mag < 1e-14:
+        raise ValueError("Q_to_d(): |Q| is zero; d-spacing is undefined.")
+    return _TWO_PI / Q_mag
+
+
+def d_to_Q_mag(d: float) -> float:
+    """
+    Convert a d-spacing to the magnitude of the scattering vector.
+
+    |**Q**| = 2π / d
+
+    Parameters
+    ----------
+    d : float
+        d-spacing in Å.
+
+    Returns
+    -------
+    float
+        |Q| in Å⁻¹.
+
+    Raises
+    ------
+    ValueError
+        If ``d`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.d_to_Q_mag(1.0), 6)
+    6.283185
+    """
+    if d <= 0.0:
+        raise ValueError(f"d_to_Q_mag(): d must be > 0 Å; got {d}.")
+    return _TWO_PI / d
+
+
+def hkl_to_d(
+    sample: Sample,
+    h: float,
+    k: float,
+    l: float,  # noqa: E741
+) -> float:
+    """
+    Convert Miller indices to d-spacing.
+
+    d = 2π / |UB · **hkl**|
+
+    Parameters
+    ----------
+    sample : Sample
+        Sample with a UB matrix set.
+    h, k, l : float
+        Miller indices.
+
+    Returns
+    -------
+    float
+        d-spacing in Å.
+
+    Raises
+    ------
+    ValueError
+        If ``sample.UB`` is None or if **hkl** = (0, 0, 0).
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.sample.lattice = ahd.Lattice(a=3.905)
+    >>> ahd.ub_identity(g.sample)
+    >>> round(ahd.hkl_to_d(g.sample, 1, 0, 0), 4)
+    3.905
+    """
+    Q = hkl_to_Q(sample, h, k, l)
+    Q_mag = float(np.linalg.norm(Q))
+    if Q_mag < 1e-14:
+        raise ValueError(
+            f"hkl_to_d(): |UB @ ({h}, {k}, {l})| is zero; "
+            "d-spacing is undefined for the (0, 0, 0) reflection."
+        )
+    return _TWO_PI / Q_mag
+
+
+# ---------------------------------------------------------------------------
+# d-spacing ↔ two-theta  (Bragg's law)
+# ---------------------------------------------------------------------------
+
+
+def d_to_two_theta(d: float, wavelength: float) -> float:
+    """
+    Convert d-spacing to 2θ using Bragg's law.
+
+    λ = 2 d sin(θ)  →  2θ = 2 arcsin(λ / (2d))
+
+    Parameters
+    ----------
+    d : float
+        d-spacing in Å.
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        2θ in degrees.
+
+    Raises
+    ------
+    ValueError
+        If ``d`` ≤ 0, ``wavelength`` ≤ 0, or λ / (2d) > 1 (reflection
+        unreachable at this wavelength).
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.d_to_two_theta(2.0, 1.5406), 4)
+    22.6956
+    """
+    if d <= 0.0:
+        raise ValueError(f"d_to_two_theta(): d must be > 0 Å; got {d}.")
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"d_to_two_theta(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    sin_theta = wavelength / (2.0 * d)
+    if sin_theta > 1.0:
+        raise ValueError(
+            f"d_to_two_theta(): reflection unreachable at wavelength {wavelength} Å "
+            f"(λ/(2d) = {sin_theta:.4f} > 1). Use a shorter wavelength or larger d."
+        )
+    return 2.0 * math.degrees(math.asin(sin_theta))
+
+
+def two_theta_to_d(two_theta_deg: float, wavelength: float) -> float:
+    """
+    Convert 2θ to d-spacing using Bragg's law.
+
+    λ = 2 d sin(θ)  →  d = λ / (2 sin(θ))
+
+    Parameters
+    ----------
+    two_theta_deg : float
+        Diffraction angle 2θ in degrees.
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        d-spacing in Å.
+
+    Raises
+    ------
+    ValueError
+        If ``two_theta_deg`` is not in (0°, 180°) or ``wavelength`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.two_theta_to_d(22.6956, 1.5406), 4)
+    2.0
+    """
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"two_theta_to_d(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    if not (0.0 < two_theta_deg < 180.0):
+        raise ValueError(
+            f"two_theta_to_d(): 2θ must be in (0°, 180°); got {two_theta_deg}."
+        )
+    sin_theta = math.sin(math.radians(two_theta_deg / 2.0))
+    return wavelength / (2.0 * sin_theta)
+
+
+def hkl_to_two_theta(
+    sample: Sample,
+    h: float,
+    k: float,
+    l: float,  # noqa: E741
+    wavelength: float,
+) -> float:
+    """
+    Convert Miller indices to 2θ using the UB matrix and Bragg's law.
+
+    Parameters
+    ----------
+    sample : Sample
+        Sample with a UB matrix set.
+    h, k, l : float
+        Miller indices.
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        2θ in degrees.
+
+    Raises
+    ------
+    ValueError
+        If ``sample.UB`` is None, ``wavelength`` ≤ 0, **hkl** = (0, 0, 0),
+        or the reflection is unreachable at this wavelength.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.sample.lattice = ahd.Lattice(a=3.905)
+    >>> ahd.ub_identity(g.sample)
+    >>> round(ahd.hkl_to_two_theta(g.sample, 1, 0, 0, 1.5406), 4)
+    23.2066
+    """
+    d = hkl_to_d(sample, h, k, l)
+    return d_to_two_theta(d, wavelength)
+
+
+# ---------------------------------------------------------------------------
+# |Q| ↔ two-theta
+# ---------------------------------------------------------------------------
+
+
+def two_theta_to_Q_mag(two_theta_deg: float, wavelength: float) -> float:
+    """
+    Convert 2θ to |Q| using the Bragg relation.
+
+    |**Q**| = 4π sin(θ) / λ
+
+    Parameters
+    ----------
+    two_theta_deg : float
+        Diffraction angle 2θ in degrees.
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        |Q| in Å⁻¹.
+
+    Raises
+    ------
+    ValueError
+        If ``two_theta_deg`` is not in (0°, 180°) or ``wavelength`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.two_theta_to_Q_mag(30.0, 1.5406), 4)
+    2.0904
+    """
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"two_theta_to_Q_mag(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    if not (0.0 < two_theta_deg < 180.0):
+        raise ValueError(
+            f"two_theta_to_Q_mag(): 2θ must be in (0°, 180°); got {two_theta_deg}."
+        )
+    return 2.0 * _TWO_PI * math.sin(math.radians(two_theta_deg / 2.0)) / wavelength
+
+
+def Q_mag_to_two_theta(Q_mag: float, wavelength: float) -> float:
+    """
+    Convert |Q| to 2θ.
+
+    2θ = 2 arcsin(|Q| λ / (4π))
+
+    Parameters
+    ----------
+    Q_mag : float
+        Magnitude of the scattering vector in Å⁻¹.
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        2θ in degrees.
+
+    Raises
+    ------
+    ValueError
+        If ``Q_mag`` < 0, ``wavelength`` ≤ 0, or the reflection is
+        unreachable (|Q| λ / (4π) > 1).
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.Q_mag_to_two_theta(2.0904, 1.5406), 2)
+    30.0
+    """
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"Q_mag_to_two_theta(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    if Q_mag < 0.0:
+        raise ValueError(f"Q_mag_to_two_theta(): |Q| must be ≥ 0; got {Q_mag}.")
+    sin_theta = Q_mag * wavelength / (2.0 * _TWO_PI)
+    if sin_theta > 1.0:
+        raise ValueError(
+            f"Q_mag_to_two_theta(): reflection unreachable (|Q|λ/(4π) = "
+            f"{sin_theta:.4f} > 1). Use a longer wavelength or smaller |Q|."
+        )
+    return 2.0 * math.degrees(math.asin(sin_theta))

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,441 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Unit tests for ad_hoc_diffractometer.engines.
+
+Covers:
+  - hkl_to_Q: basic, no-UB raises, (0,0,0) gives zero vector
+  - Q_to_hkl: round-trip with hkl_to_Q, no-UB raises, singular-UB raises
+  - Q_to_d: basic, zero-Q raises
+  - d_to_Q_mag: basic, zero/negative raises, round-trip with Q_to_d
+  - hkl_to_d: cubic round-trip, (0,0,0) raises, no-UB raises
+  - d_to_two_theta: Bragg round-trips, bad-d raises, bad-wl raises, unreachable raises
+  - two_theta_to_d: round-trip with d_to_two_theta, bad-angle raises, bad-wl raises
+  - hkl_to_two_theta: cubic round-trip via known value, propagates raises
+  - two_theta_to_Q_mag: basic, bad-angle raises, bad-wl raises
+  - Q_mag_to_two_theta: round-trip with two_theta_to_Q_mag, unreachable raises
+  - Public API exports
+"""
+
+import math
+import re
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import Lattice
+from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import ub_identity
+from ad_hoc_diffractometer.engines import Q_mag_to_two_theta
+from ad_hoc_diffractometer.engines import Q_to_d
+from ad_hoc_diffractometer.engines import Q_to_hkl
+from ad_hoc_diffractometer.engines import d_to_Q_mag
+from ad_hoc_diffractometer.engines import d_to_two_theta
+from ad_hoc_diffractometer.engines import hkl_to_d
+from ad_hoc_diffractometer.engines import hkl_to_Q
+from ad_hoc_diffractometer.engines import hkl_to_two_theta
+from ad_hoc_diffractometer.engines import two_theta_to_d
+from ad_hoc_diffractometer.engines import two_theta_to_Q_mag
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+WAVELENGTH = 1.5406  # Cu Kα in Å
+A_CUBIC = 3.905  # SrTiO₃ lattice parameter (Å)
+TWO_PI = 2.0 * math.pi
+
+
+def _sample(a=A_CUBIC):
+    """Return a Sample with a cubic UB=B matrix."""
+    g = fourcv()
+    g.sample.lattice = Lattice(a=a)
+    ub_identity(g.sample)
+    return g.sample
+
+
+# ---------------------------------------------------------------------------
+# hkl_to_Q
+# ---------------------------------------------------------------------------
+
+
+class TestHklToQ:
+    def test_cubic_100(self):
+        """(1,0,0) gives Q along x with magnitude 2π/a."""
+        s = _sample()
+        Q = hkl_to_Q(s, 1, 0, 0)
+        expected = TWO_PI / A_CUBIC
+        assert Q == pytest.approx([expected, 0.0, 0.0], abs=1e-10)
+
+    def test_cubic_110(self):
+        """(1,1,0) gives |Q| = 2π/a * sqrt(2)."""
+        s = _sample()
+        Q = hkl_to_Q(s, 1, 1, 0)
+        assert float(np.linalg.norm(Q)) == pytest.approx(
+            TWO_PI / A_CUBIC * math.sqrt(2), rel=1e-10
+        )
+
+    def test_zero_hkl_gives_zero_vector(self):
+        """(0,0,0) maps to the zero vector."""
+        s = _sample()
+        Q = hkl_to_Q(s, 0, 0, 0)
+        assert np.allclose(Q, [0.0, 0.0, 0.0])
+
+    def test_no_ub_raises(self):
+        """Raises ValueError when UB is not set."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=A_CUBIC)
+        with pytest.raises(ValueError, match=re.escape("sample.UB")):
+            hkl_to_Q(g.sample, 1, 0, 0)
+
+    def test_returns_ndarray(self):
+        """Return type is numpy.ndarray."""
+        s = _sample()
+        Q = hkl_to_Q(s, 1, 0, 0)
+        assert isinstance(Q, np.ndarray)
+        assert Q.shape == (3,)
+
+
+# ---------------------------------------------------------------------------
+# Q_to_hkl
+# ---------------------------------------------------------------------------
+
+
+class TestQToHkl:
+    def test_round_trip(self):
+        """hkl → Q → hkl reproduces the original indices."""
+        s = _sample()
+        for hkl in [(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 0), (2, 1, 3)]:
+            Q = hkl_to_Q(s, *hkl)
+            result = Q_to_hkl(s, *Q)
+            assert result == pytest.approx(hkl, abs=1e-10)
+
+    def test_no_ub_raises(self):
+        """Raises ValueError when UB is not set."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=A_CUBIC)
+        with pytest.raises(ValueError, match=re.escape("sample.UB")):
+            Q_to_hkl(g.sample, 1.0, 0.0, 0.0)
+
+    def test_singular_ub_raises(self):
+        """Raises ValueError when UB is singular."""
+        s = _sample()
+        s.UB = np.zeros((3, 3))
+        with pytest.raises(ValueError, match=re.escape("singular")):
+            Q_to_hkl(s, 1.0, 0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Q_to_d
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "Qx, Qy, Qz, expected_d, context",
+    [
+        pytest.param(
+            TWO_PI,
+            0.0,
+            0.0,
+            1.0,
+            does_not_raise(),
+            id="Q=2pi-along-x-gives-d=1",
+        ),
+        pytest.param(
+            0.0,
+            TWO_PI,
+            0.0,
+            1.0,
+            does_not_raise(),
+            id="Q=2pi-along-y-gives-d=1",
+        ),
+        pytest.param(
+            0.0,
+            0.0,
+            0.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("|Q| is zero")),
+            id="zero-Q-raises",
+        ),
+    ],
+)
+def test_Q_to_d(Qx, Qy, Qz, expected_d, context):
+    with context:
+        result = Q_to_d(Qx, Qy, Qz)
+        assert result == pytest.approx(expected_d, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# d_to_Q_mag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "d, expected_Q_mag, context",
+    [
+        pytest.param(1.0, TWO_PI, does_not_raise(), id="d=1-gives-2pi"),
+        pytest.param(A_CUBIC, TWO_PI / A_CUBIC, does_not_raise(), id="cubic-lattice"),
+        pytest.param(
+            0.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("d must be > 0")),
+            id="zero-d",
+        ),
+        pytest.param(
+            -1.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("d must be > 0")),
+            id="negative-d",
+        ),
+    ],
+)
+def test_d_to_Q_mag(d, expected_Q_mag, context):
+    with context:
+        result = d_to_Q_mag(d)
+        assert result == pytest.approx(expected_Q_mag, rel=1e-10)
+
+
+def test_d_Q_mag_round_trip():
+    """d → |Q| → d recovers the original d."""
+    for d in [0.5, 1.0, 2.0, 3.905, 10.0]:
+        Q_mag = d_to_Q_mag(d)
+        # Q_to_d expects a Q-vector; supply as (Q_mag, 0, 0) so |Q| = Q_mag
+        assert Q_to_d(Q_mag, 0.0, 0.0) == pytest.approx(d, rel=1e-10)
+
+    def test_zero_hkl_raises(self):
+        """Raises ValueError for (0,0,0)."""
+        s = _sample()
+        with pytest.raises(ValueError, match=re.escape("(0, 0, 0)")):
+            hkl_to_d(s, 0, 0, 0)
+
+    def test_no_ub_raises(self):
+        """Raises ValueError when UB is not set."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=A_CUBIC)
+        with pytest.raises(ValueError, match=re.escape("sample.UB")):
+            hkl_to_d(g.sample, 1, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# d_to_two_theta / two_theta_to_d
+# ---------------------------------------------------------------------------
+
+
+class TestBraggLaw:
+    def test_d_to_two_theta_known(self):
+        """2θ for Si (111) at Cu Kα ≈ 28.44°."""
+        d_si_111 = 3.1356  # Å
+        two_theta = d_to_two_theta(d_si_111, WAVELENGTH)
+        assert two_theta == pytest.approx(28.44, abs=0.01)
+
+    def test_round_trip(self):
+        """d → 2θ → d recovers the original d."""
+        for d in [1.0, 2.0, 3.905]:
+            two_theta = d_to_two_theta(d, WAVELENGTH)
+            assert two_theta_to_d(two_theta, WAVELENGTH) == pytest.approx(d, rel=1e-10)
+
+    def test_two_theta_to_d_known(self):
+        """d from round-trip of d_to_two_theta recovers the original d."""
+        d_original = 2.0
+        two_theta = d_to_two_theta(d_original, WAVELENGTH)
+        assert two_theta_to_d(two_theta, WAVELENGTH) == pytest.approx(
+            d_original, rel=1e-10
+        )
+
+    @pytest.mark.parametrize(
+        "d, wl, context",
+        [
+            pytest.param(
+                0.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("d must be > 0")),
+                id="zero-d",
+            ),
+            pytest.param(
+                -1.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("d must be > 0")),
+                id="negative-d",
+            ),
+            pytest.param(
+                1.0,
+                0.0,
+                pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+                id="zero-wavelength",
+            ),
+            pytest.param(
+                0.1,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("unreachable")),
+                id="reflection-unreachable",
+            ),
+        ],
+    )
+    def test_d_to_two_theta_raises(self, d, wl, context):
+        with context:
+            d_to_two_theta(d, wl)
+
+    @pytest.mark.parametrize(
+        "two_theta, wl, context",
+        [
+            pytest.param(
+                0.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("(0°, 180°)")),
+                id="zero-angle",
+            ),
+            pytest.param(
+                180.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("(0°, 180°)")),
+                id="180-angle",
+            ),
+            pytest.param(
+                30.0,
+                0.0,
+                pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+                id="zero-wavelength",
+            ),
+        ],
+    )
+    def test_two_theta_to_d_raises(self, two_theta, wl, context):
+        with context:
+            two_theta_to_d(two_theta, wl)
+
+
+# ---------------------------------------------------------------------------
+# hkl_to_two_theta
+# ---------------------------------------------------------------------------
+
+
+class TestHklToTwoTheta:
+    def test_cubic_100_cu_kalpha(self):
+        """2θ for SrTiO₃ (100) at Cu Kα matches Bragg's law."""
+        s = _sample(A_CUBIC)
+        two_theta = hkl_to_two_theta(s, 1, 0, 0, WAVELENGTH)
+        expected = d_to_two_theta(A_CUBIC, WAVELENGTH)
+        assert two_theta == pytest.approx(expected, rel=1e-10)
+
+    def test_zero_hkl_raises(self):
+        """Propagates ValueError from hkl_to_d for (0,0,0)."""
+        s = _sample()
+        with pytest.raises(ValueError, match=re.escape("(0, 0, 0)")):
+            hkl_to_two_theta(s, 0, 0, 0, WAVELENGTH)
+
+    def test_no_ub_raises(self):
+        """Propagates ValueError when UB is not set."""
+        g = fourcv()
+        g.sample.lattice = Lattice(a=A_CUBIC)
+        with pytest.raises(ValueError, match=re.escape("sample.UB")):
+            hkl_to_two_theta(g.sample, 1, 0, 0, WAVELENGTH)
+
+    def test_unreachable_raises(self):
+        """Propagates ValueError when reflection is unreachable."""
+        s = _sample(a=0.05)  # tiny lattice → large |Q| → unreachable
+        with pytest.raises(ValueError, match=re.escape("unreachable")):
+            hkl_to_two_theta(s, 1, 0, 0, WAVELENGTH)
+
+
+# ---------------------------------------------------------------------------
+# two_theta_to_Q_mag / Q_mag_to_two_theta
+# ---------------------------------------------------------------------------
+
+
+class TestTwoThetaQMag:
+    def test_two_theta_to_Q_mag_known(self):
+        """|Q| = 4π sin(θ)/λ for 2θ = 30°, Cu Kα."""
+        expected = 4.0 * math.pi * math.sin(math.radians(15.0)) / WAVELENGTH
+        assert two_theta_to_Q_mag(30.0, WAVELENGTH) == pytest.approx(
+            expected, rel=1e-10
+        )
+
+    def test_Q_mag_to_two_theta_round_trip(self):
+        """2θ → |Q| → 2θ recovers the original angle."""
+        for two_theta in [10.0, 30.0, 60.0, 90.0, 120.0]:
+            Q_mag = two_theta_to_Q_mag(two_theta, WAVELENGTH)
+            assert Q_mag_to_two_theta(Q_mag, WAVELENGTH) == pytest.approx(
+                two_theta, rel=1e-10
+            )
+
+    @pytest.mark.parametrize(
+        "two_theta, wl, context",
+        [
+            pytest.param(
+                0.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("(0°, 180°)")),
+                id="zero-angle",
+            ),
+            pytest.param(
+                180.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("(0°, 180°)")),
+                id="180-angle",
+            ),
+            pytest.param(
+                30.0,
+                -1.0,
+                pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+                id="negative-wavelength",
+            ),
+        ],
+    )
+    def test_two_theta_to_Q_mag_raises(self, two_theta, wl, context):
+        with context:
+            two_theta_to_Q_mag(two_theta, wl)
+
+    @pytest.mark.parametrize(
+        "Q_mag, wl, context",
+        [
+            pytest.param(
+                -1.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("|Q| must be ≥ 0")),
+                id="negative-Q-mag",
+            ),
+            pytest.param(
+                100.0,
+                WAVELENGTH,
+                pytest.raises(ValueError, match=re.escape("unreachable")),
+                id="unreachable",
+            ),
+            pytest.param(
+                1.0,
+                -1.0,
+                pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+                id="negative-wavelength",
+            ),
+        ],
+    )
+    def test_Q_mag_to_two_theta_raises(self, Q_mag, wl, context):
+        with context:
+            Q_mag_to_two_theta(Q_mag, wl)
+
+    def test_consistency_with_d(self):
+        """two_theta_to_Q_mag and d_to_Q_mag agree via Bragg's law."""
+        d = 2.0
+        two_theta = d_to_two_theta(d, WAVELENGTH)
+        Q_from_tth = two_theta_to_Q_mag(two_theta, WAVELENGTH)
+        Q_from_d = d_to_Q_mag(d)
+        assert Q_from_tth == pytest.approx(Q_from_d, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Public API exports
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports():
+    """All engine functions are importable from the top-level package."""
+    assert ahd.hkl_to_Q is hkl_to_Q
+    assert ahd.Q_to_hkl is Q_to_hkl
+    assert ahd.Q_to_d is Q_to_d
+    assert ahd.d_to_Q_mag is d_to_Q_mag
+    assert ahd.hkl_to_d is hkl_to_d
+    assert ahd.d_to_two_theta is d_to_two_theta
+    assert ahd.two_theta_to_d is two_theta_to_d
+    assert ahd.hkl_to_two_theta is hkl_to_two_theta
+    assert ahd.two_theta_to_Q_mag is two_theta_to_Q_mag
+    assert ahd.Q_mag_to_two_theta is Q_mag_to_two_theta


### PR DESCRIPTION
- closes #12

Adds `engines.py` with standalone, pluggable conversion functions between
the four representations of a diffraction position: hkl, Q-vector (Å⁻¹),
d-spacing (Å), and 2θ (degrees).

## Functions added

| Function | Conversion |
|---|---|
| `hkl_to_Q(sample, h, k, l)` | hkl → Q-vector via `UB @ hkl` |
| `Q_to_hkl(sample, Qx, Qy, Qz)` | Q-vector → hkl via `UB⁻¹ @ Q` |
| `Q_to_d(Qx, Qy, Qz)` | Q-vector → d-spacing: `d = 2π/\|Q\|` |
| `d_to_Q_mag(d)` | d-spacing → `\|Q\|`: `\|Q\| = 2π/d` |
| `hkl_to_d(sample, h, k, l)` | Miller indices → d-spacing |
| `d_to_two_theta(d, wavelength)` | Bragg's law: `λ = 2d sinθ` |
| `two_theta_to_d(two_theta, wavelength)` | Bragg's law (inverse) |
| `hkl_to_two_theta(sample, h, k, l, wavelength)` | hkl → 2θ |
| `two_theta_to_Q_mag(two_theta, wavelength)` | 2θ → `\|Q\| = 4π sinθ/λ` |
| `Q_mag_to_two_theta(Q_mag, wavelength)` | `\|Q\|` → 2θ |

All functions exported from the top-level package.
40 tests; 1147 total; 100% coverage; all pass.

Contributed by: OpenCode (argo/claudesonnet46)