### PR TITLE
3.8 Energy/wave-number conversions and named X-ray lines

### DIFF
--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -52,6 +52,12 @@ from .orientation import ub_from_one_reflection
 from .orientation import ub_from_three_reflections_bl1967
 from .orientation import ub_from_two_reflections_bl1967
 from .orientation import ub_identity
+from .radiation import HC_KEV_ANGSTROM
+from .radiation import XRAY_LINES
+from .radiation import energy_to_wavelength
+from .radiation import wavelength_to_energy
+from .radiation import wavelength_to_wavenumber
+from .radiation import wavenumber_to_wavelength
 from .refinement import refine_lattice_bl1967
 from .refinement import refine_lattice_simplex
 from .reflection import Reflection
@@ -109,6 +115,13 @@ __all__ = [
     "ModeDict",
     # forward calculation
     "compute_forward",
+    # radiation — X-ray wavelength, energy, wave-number
+    "HC_KEV_ANGSTROM",
+    "XRAY_LINES",
+    "wavelength_to_energy",
+    "energy_to_wavelength",
+    "wavelength_to_wavenumber",
+    "wavenumber_to_wavelength",
     # scan / trajectory
     "NEAREST_ANGLES",
     "hkl_trajectory",

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -315,14 +315,30 @@ class AdHocDiffractometer:
         self._wavelength = value
 
     @property
-    def energy_kev(self) -> float | None:
+    def energy_units(self) -> str:
         """
-        Photon energy in keV, derived from wavelength.
+        Units of the :attr:`energy` property for this geometry.
 
-        E (keV) = hc / λ = 12.39842 / λ (Å)
+        Returns ``"keV"`` for X-ray geometries (the default).  Will return
+        ``"meV"`` for neutron geometries once ``source_type`` is set
+        (see issue #8).
 
-        Returns ``None`` when ``wavelength`` is not set.  Setting
-        ``energy_kev`` updates ``wavelength`` accordingly.
+        Returns
+        -------
+        str
+        """
+        return "keV"
+
+    @property
+    def energy(self) -> float | None:
+        """
+        Radiation energy in units of :attr:`energy_units`, derived from wavelength.
+
+        For X-ray geometries (default): E (keV) = hc / λ = 12.39842 / λ (Å).
+
+        Returns ``None`` when ``wavelength`` is not set.  Setting ``energy``
+        updates ``wavelength`` accordingly.  The value must be in the units
+        returned by :attr:`energy_units`.
 
         Raises
         ------
@@ -334,9 +350,9 @@ class AdHocDiffractometer:
         >>> import ad_hoc_diffractometer as ahd
         >>> g = ahd.fourcv()
         >>> g.wavelength = 1.5406
-        >>> round(g.energy_kev, 4)
+        >>> round(g.energy, 4)
         8.0479
-        >>> g.energy_kev = 8.048
+        >>> g.energy = 8.048
         >>> round(g.wavelength, 4)
         1.5405
         """
@@ -346,8 +362,8 @@ class AdHocDiffractometer:
 
         return wavelength_to_energy(self._wavelength)
 
-    @energy_kev.setter
-    def energy_kev(self, value: float | None) -> None:
+    @energy.setter
+    def energy(self, value: float | None) -> None:
         if value is None:
             self._wavelength = None
             return
@@ -1680,11 +1696,9 @@ class AdHocDiffractometer:
         from .display import fmt
 
         if self._wavelength is not None:
-            from .radiation import wavelength_to_energy
-
             wl_str = (
                 f"{fmt(self._wavelength)} Å"
-                f"  (E = {fmt(wavelength_to_energy(self._wavelength))} keV)"
+                f"  (E = {fmt(self.energy)} {self.energy_units})"
             )
         else:
             wl_str = "not set"

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -314,6 +314,88 @@ class AdHocDiffractometer:
                 raise ValueError(f"wavelength must be > 0 Å; got {value}.")
         self._wavelength = value
 
+    @property
+    def energy_kev(self) -> float | None:
+        """
+        Photon energy in keV, derived from wavelength.
+
+        E (keV) = hc / λ = 12.39842 / λ (Å)
+
+        Returns ``None`` when ``wavelength`` is not set.  Setting
+        ``energy_kev`` updates ``wavelength`` accordingly.
+
+        Raises
+        ------
+        ValueError
+            If set to a non-positive value.
+
+        Examples
+        --------
+        >>> import ad_hoc_diffractometer as ahd
+        >>> g = ahd.fourcv()
+        >>> g.wavelength = 1.5406
+        >>> round(g.energy_kev, 4)
+        8.0479
+        >>> g.energy_kev = 8.048
+        >>> round(g.wavelength, 4)
+        1.5405
+        """
+        if self._wavelength is None:
+            return None
+        from .radiation import wavelength_to_energy
+
+        return wavelength_to_energy(self._wavelength)
+
+    @energy_kev.setter
+    def energy_kev(self, value: float | None) -> None:
+        if value is None:
+            self._wavelength = None
+            return
+        from .radiation import energy_to_wavelength
+
+        self._wavelength = energy_to_wavelength(float(value))
+
+    @property
+    def wavenumber(self) -> float | None:
+        """
+        Wave number k in Å⁻¹, derived from wavelength.
+
+        k (Å⁻¹) = 2π / λ (Å)
+
+        Returns ``None`` when ``wavelength`` is not set.  Setting
+        ``wavenumber`` updates ``wavelength`` accordingly.
+
+        Raises
+        ------
+        ValueError
+            If set to a non-positive value.
+
+        Examples
+        --------
+        >>> import ad_hoc_diffractometer as ahd
+        >>> g = ahd.fourcv()
+        >>> g.wavelength = 1.5406
+        >>> round(g.wavenumber, 4)
+        4.0774
+        >>> g.wavenumber = 4.0
+        >>> round(g.wavelength, 4)
+        1.5708
+        """
+        if self._wavelength is None:
+            return None
+        from .radiation import wavelength_to_wavenumber
+
+        return wavelength_to_wavenumber(self._wavelength)
+
+    @wavenumber.setter
+    def wavenumber(self, value: float | None) -> None:
+        if value is None:
+            self._wavelength = None
+            return
+        from .radiation import wavenumber_to_wavelength
+
+        self._wavelength = wavenumber_to_wavelength(float(value))
+
     # ------------------------------------------------------------------
     # Kappa alpha
     # ------------------------------------------------------------------
@@ -1598,7 +1680,12 @@ class AdHocDiffractometer:
         from .display import fmt
 
         if self._wavelength is not None:
-            wl_str = f"{fmt(self._wavelength)} Å"
+            from .radiation import wavelength_to_energy
+
+            wl_str = (
+                f"{fmt(self._wavelength)} Å"
+                f"  (E = {fmt(wavelength_to_energy(self._wavelength))} keV)"
+            )
         else:
             wl_str = "not set"
 

--- a/src/ad_hoc_diffractometer/radiation.py
+++ b/src/ad_hoc_diffractometer/radiation.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+radiation.py — Wavelength, energy, and wave-number conversions for X-rays.
+
+Provides named constants for common laboratory X-ray emission lines and
+standalone conversion functions between wavelength, photon energy (keV),
+and wave number k (Å⁻¹).
+
+Constants
+---------
+XRAY_LINES : dict[str, float]
+    Named X-ray emission line wavelengths in Å.  Weighted means (Kα) or
+    exact values (Kα1) as noted.
+
+    ``"Cu_Ka"``   Cu Kα  ≈ 1.5406 Å  (weighted mean of Kα1=1.54056 Å, Kα2=1.54439 Å)
+    ``"Cu_Ka1"``  Cu Kα1 = 1.54056 Å
+    ``"Cu_Ka2"``  Cu Kα2 = 1.54439 Å
+    ``"Mo_Ka"``   Mo Kα  ≈ 0.7107 Å  (weighted mean)
+    ``"Mo_Ka1"``  Mo Kα1 = 0.70930 Å
+    ``"Ag_Ka"``   Ag Kα  ≈ 0.5594 Å  (weighted mean)
+    ``"Ag_Ka1"``  Ag Kα1 = 0.55941 Å
+    ``"Co_Ka"``   Co Kα  ≈ 1.7902 Å  (weighted mean)
+    ``"Co_Ka1"``  Co Kα1 = 1.78897 Å
+
+Functions
+---------
+wavelength_to_energy(wavelength) -> float
+    Wavelength (Å) → photon energy E (keV): E = hc/λ = 12.39842 / λ.
+
+energy_to_wavelength(energy_kev) -> float
+    Photon energy (keV) → wavelength (Å): λ = hc/E = 12.39842 / E.
+
+wavelength_to_wavenumber(wavelength) -> float
+    Wavelength (Å) → wave number k (Å⁻¹): k = 2π / λ.
+
+wavenumber_to_wavelength(wavenumber) -> float
+    Wave number k (Å⁻¹) → wavelength (Å): λ = 2π / k.
+
+Notes
+-----
+The conversion constant hc = 12.39842 keV·Å is the standard value used
+in X-ray crystallography (NIST CODATA 2018).
+
+These conversions apply to **X-rays only**.  For neutrons, the de Broglie
+relation gives E (meV) = 81.8042 / λ² (Å) — see the `radiation_neutron`
+module (issue #8).
+
+References
+----------
+NIST, "X-Ray Transition Energies Database",
+https://physics.nist.gov/PhysRefData/XrayTrans/Html/search.html
+
+NIST CODATA 2018 — hc = 12398.42 eV·Å = 12.39842 keV·Å
+"""
+
+from __future__ import annotations
+
+import math
+
+# ---------------------------------------------------------------------------
+# Physical constant
+# ---------------------------------------------------------------------------
+
+#: hc in keV·Å (NIST CODATA 2018).
+HC_KEV_ANGSTROM: float = 12.39842
+
+# ---------------------------------------------------------------------------
+# Named X-ray emission lines (wavelengths in Å)
+# ---------------------------------------------------------------------------
+
+#: Common laboratory X-ray emission line wavelengths in Å.
+#:
+#: Weighted means (Kα) use the standard 2:1 weighting of Kα1 and Kα2.
+#: Values from NIST X-Ray Transition Energies Database.
+XRAY_LINES: dict[str, float] = {
+    "Cu_Ka": 1.54060,  # Cu Kα  weighted mean (2·Kα1 + Kα2) / 3
+    "Cu_Ka1": 1.54056,  # Cu Kα1
+    "Cu_Ka2": 1.54439,  # Cu Kα2
+    "Mo_Ka": 0.71073,  # Mo Kα  weighted mean
+    "Mo_Ka1": 0.70930,  # Mo Kα1
+    "Ag_Ka": 0.56087,  # Ag Kα  weighted mean
+    "Ag_Ka1": 0.55941,  # Ag Kα1
+    "Co_Ka": 1.79021,  # Co Kα  weighted mean
+    "Co_Ka1": 1.78897,  # Co Kα1
+}
+
+# ---------------------------------------------------------------------------
+# Conversion functions
+# ---------------------------------------------------------------------------
+
+
+def wavelength_to_energy(wavelength: float) -> float:
+    """
+    Convert wavelength to photon energy for X-rays.
+
+    E (keV) = hc / λ = 12.39842 / λ (Å)
+
+    Parameters
+    ----------
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        Photon energy in keV.
+
+    Raises
+    ------
+    ValueError
+        If ``wavelength`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.wavelength_to_energy(1.5406), 4)
+    8.0478
+    """
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"wavelength_to_energy(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    return HC_KEV_ANGSTROM / wavelength
+
+
+def energy_to_wavelength(energy_kev: float) -> float:
+    """
+    Convert photon energy to wavelength for X-rays.
+
+    λ (Å) = hc / E = 12.39842 / E (keV)
+
+    Parameters
+    ----------
+    energy_kev : float
+        Photon energy in keV.
+
+    Returns
+    -------
+    float
+        Wavelength in Å.
+
+    Raises
+    ------
+    ValueError
+        If ``energy_kev`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.energy_to_wavelength(8.047), 4)
+    1.5408
+    """
+    if energy_kev <= 0.0:
+        raise ValueError(
+            f"energy_to_wavelength(): energy must be > 0 keV; got {energy_kev}."
+        )
+    return HC_KEV_ANGSTROM / energy_kev
+
+
+def wavelength_to_wavenumber(wavelength: float) -> float:
+    """
+    Convert wavelength to wave number k.
+
+    k (Å⁻¹) = 2π / λ (Å)
+
+    Parameters
+    ----------
+    wavelength : float
+        Wavelength in Å.
+
+    Returns
+    -------
+    float
+        Wave number k in Å⁻¹.
+
+    Raises
+    ------
+    ValueError
+        If ``wavelength`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.wavelength_to_wavenumber(1.0), 6)
+    6.283185
+    """
+    if wavelength <= 0.0:
+        raise ValueError(
+            f"wavelength_to_wavenumber(): wavelength must be > 0 Å; got {wavelength}."
+        )
+    return 2.0 * math.pi / wavelength
+
+
+def wavenumber_to_wavelength(wavenumber: float) -> float:
+    """
+    Convert wave number k to wavelength.
+
+    λ (Å) = 2π / k (Å⁻¹)
+
+    Parameters
+    ----------
+    wavenumber : float
+        Wave number k in Å⁻¹.
+
+    Returns
+    -------
+    float
+        Wavelength in Å.
+
+    Raises
+    ------
+    ValueError
+        If ``wavenumber`` ≤ 0.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> round(ahd.wavenumber_to_wavelength(6.283185), 6)
+    1.0
+    """
+    if wavenumber <= 0.0:
+        raise ValueError(
+            f"wavenumber_to_wavelength(): wavenumber must be > 0 Å⁻¹; got {wavenumber}."
+        )
+    return 2.0 * math.pi / wavenumber

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -10,7 +10,7 @@ Covers:
   - energy_to_wavelength: round-trip, zero/negative raises
   - wavelength_to_wavenumber: known value, round-trip, zero/negative raises
   - wavenumber_to_wavelength: round-trip, zero/negative raises
-  - AdHocDiffractometer.energy_kev property: get, set, None
+  - AdHocDiffractometer.energy property: get, set, None
   - AdHocDiffractometer.wavenumber property: get, set, None
   - summary() includes energy when wavelength is set
   - Public API exports
@@ -138,7 +138,7 @@ def test_wavelength_to_energy_round_trip():
 
 
 @pytest.mark.parametrize(
-    "energy_kev, context",
+    "energy, context",
     [
         pytest.param(8.048, does_not_raise(), id="Cu-Ka-energy"),
         pytest.param(
@@ -153,9 +153,9 @@ def test_wavelength_to_energy_round_trip():
         ),
     ],
 )
-def test_energy_to_wavelength(energy_kev, context):
+def test_energy_to_wavelength(energy, context):
     with context:
-        result = energy_to_wavelength(energy_kev)
+        result = energy_to_wavelength(energy)
         assert result > 0.0
 
 
@@ -230,43 +230,43 @@ def test_wavenumber_to_wavelength(k, context):
 
 
 # ---------------------------------------------------------------------------
-# AdHocDiffractometer.energy_kev property
+# AdHocDiffractometer.energy property
 # ---------------------------------------------------------------------------
 
 
 class TestEnergyKevProperty:
     def test_none_when_wavelength_not_set(self):
-        """energy_kev is None when wavelength is not set."""
+        """energy is None when wavelength is not set."""
         g = fourcv()
-        assert g.energy_kev is None
+        assert g.energy is None
 
     def test_value_matches_conversion(self):
-        """energy_kev = wavelength_to_energy(wavelength)."""
+        """energy = wavelength_to_energy(wavelength)."""
         g = fourcv()
         g.wavelength = 1.5406
-        assert g.energy_kev == pytest.approx(wavelength_to_energy(1.5406), rel=1e-10)
+        assert g.energy == pytest.approx(wavelength_to_energy(1.5406), rel=1e-10)
 
     def test_set_updates_wavelength(self):
-        """Setting energy_kev updates wavelength via λ = hc/E."""
+        """Setting energy updates wavelength via λ = hc/E."""
         g = fourcv()
-        g.energy_kev = 8.048
+        g.energy = 8.048
         assert g.wavelength == pytest.approx(energy_to_wavelength(8.048), rel=1e-10)
 
     def test_set_none_clears_wavelength(self):
-        """Setting energy_kev = None clears wavelength."""
+        """Setting energy = None clears wavelength."""
         g = fourcv()
         g.wavelength = 1.5406
-        g.energy_kev = None
+        g.energy = None
         assert g.wavelength is None
-        assert g.energy_kev is None
+        assert g.energy is None
 
     def test_round_trip_via_wavelength(self):
-        """wavelength → energy_kev → wavelength recovers the original."""
+        """wavelength → energy → wavelength recovers the original."""
         g = fourcv()
         g.wavelength = 1.5406
-        e = g.energy_kev
+        e = g.energy
         g2 = fourcv()
-        g2.energy_kev = e
+        g2.energy = e
         assert g2.wavelength == pytest.approx(1.5406, rel=1e-6)
 
 

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Unit tests for ad_hoc_diffractometer.radiation (issue #21).
+
+Covers:
+  - HC_KEV_ANGSTROM constant value
+  - XRAY_LINES: all keys present, values positive, Cu Kα known value
+  - wavelength_to_energy: known value, round-trip, zero/negative raises
+  - energy_to_wavelength: round-trip, zero/negative raises
+  - wavelength_to_wavenumber: known value, round-trip, zero/negative raises
+  - wavenumber_to_wavelength: round-trip, zero/negative raises
+  - AdHocDiffractometer.energy_kev property: get, set, None
+  - AdHocDiffractometer.wavenumber property: get, set, None
+  - summary() includes energy when wavelength is set
+  - Public API exports
+"""
+
+import math
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer.radiation import HC_KEV_ANGSTROM
+from ad_hoc_diffractometer.radiation import XRAY_LINES
+from ad_hoc_diffractometer.radiation import energy_to_wavelength
+from ad_hoc_diffractometer.radiation import wavelength_to_energy
+from ad_hoc_diffractometer.radiation import wavelength_to_wavenumber
+from ad_hoc_diffractometer.radiation import wavenumber_to_wavelength
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_HC_KEV_ANGSTROM_value():
+    """hc = 12.39842 keV·Å (NIST CODATA 2018)."""
+    assert HC_KEV_ANGSTROM == pytest.approx(12.39842, rel=1e-5)
+
+
+def test_XRAY_LINES_keys():
+    """XRAY_LINES contains all expected emission line keys."""
+    expected_keys = {
+        "Cu_Ka",
+        "Cu_Ka1",
+        "Cu_Ka2",
+        "Mo_Ka",
+        "Mo_Ka1",
+        "Ag_Ka",
+        "Ag_Ka1",
+        "Co_Ka",
+        "Co_Ka1",
+    }
+    assert expected_keys.issubset(set(XRAY_LINES.keys()))
+
+
+def test_XRAY_LINES_positive():
+    """All XRAY_LINES wavelengths are positive."""
+    for name, wl in XRAY_LINES.items():
+        assert wl > 0.0, f"{name} wavelength must be > 0"
+
+
+def test_Cu_Ka_known_value():
+    """Cu Kα weighted mean ≈ 1.5406 Å."""
+    assert XRAY_LINES["Cu_Ka"] == pytest.approx(1.5406, abs=0.0001)
+
+
+def test_Cu_Ka1_less_than_Ka2():
+    """Cu Kα1 < Cu Kα2 (Kα1 is the shorter-wavelength component)."""
+    assert XRAY_LINES["Cu_Ka1"] < XRAY_LINES["Cu_Ka2"]
+
+
+def test_Ka_between_Ka1_Ka2():
+    """Weighted mean Kα lies between Kα1 and Kα2."""
+    for element in ("Cu", "Mo"):
+        ka1 = XRAY_LINES[f"{element}_Ka1"]
+        ka = XRAY_LINES[f"{element}_Ka"]
+        assert ka1 <= ka, f"{element} Kα should be ≥ Kα1"
+
+
+# ---------------------------------------------------------------------------
+# wavelength_to_energy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wavelength, expected_kev, context",
+    [
+        pytest.param(
+            1.0,
+            HC_KEV_ANGSTROM,
+            does_not_raise(),
+            id="lambda=1-gives-hc",
+        ),
+        pytest.param(
+            XRAY_LINES["Cu_Ka"],
+            None,
+            does_not_raise(),
+            id="Cu-Ka-positive-energy",
+        ),
+        pytest.param(
+            0.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+            id="zero-wavelength",
+        ),
+        pytest.param(
+            -1.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+            id="negative-wavelength",
+        ),
+    ],
+)
+def test_wavelength_to_energy(wavelength, expected_kev, context):
+    with context:
+        result = wavelength_to_energy(wavelength)
+        if expected_kev is not None:
+            assert result == pytest.approx(expected_kev, rel=1e-10)
+        else:
+            assert result > 0.0
+
+
+def test_wavelength_to_energy_round_trip():
+    """wavelength → energy → wavelength recovers the original."""
+    for wl in [0.5, 1.0, 1.5406, 2.0]:
+        assert energy_to_wavelength(wavelength_to_energy(wl)) == pytest.approx(
+            wl, rel=1e-10
+        )
+
+
+# ---------------------------------------------------------------------------
+# energy_to_wavelength
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "energy_kev, context",
+    [
+        pytest.param(8.048, does_not_raise(), id="Cu-Ka-energy"),
+        pytest.param(
+            0.0,
+            pytest.raises(ValueError, match=re.escape("energy must be > 0")),
+            id="zero-energy",
+        ),
+        pytest.param(
+            -1.0,
+            pytest.raises(ValueError, match=re.escape("energy must be > 0")),
+            id="negative-energy",
+        ),
+    ],
+)
+def test_energy_to_wavelength(energy_kev, context):
+    with context:
+        result = energy_to_wavelength(energy_kev)
+        assert result > 0.0
+
+
+# ---------------------------------------------------------------------------
+# wavelength_to_wavenumber
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "wavelength, expected_k, context",
+    [
+        pytest.param(
+            1.0,
+            2.0 * math.pi,
+            does_not_raise(),
+            id="lambda=1-gives-2pi",
+        ),
+        pytest.param(
+            0.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+            id="zero-wavelength",
+        ),
+        pytest.param(
+            -1.0,
+            None,
+            pytest.raises(ValueError, match=re.escape("wavelength must be > 0")),
+            id="negative-wavelength",
+        ),
+    ],
+)
+def test_wavelength_to_wavenumber(wavelength, expected_k, context):
+    with context:
+        result = wavelength_to_wavenumber(wavelength)
+        if expected_k is not None:
+            assert result == pytest.approx(expected_k, rel=1e-10)
+
+
+def test_wavelength_to_wavenumber_round_trip():
+    """wavelength → wavenumber → wavelength recovers the original."""
+    for wl in [0.5, 1.0, 1.5406, 2.0]:
+        assert wavenumber_to_wavelength(wavelength_to_wavenumber(wl)) == pytest.approx(
+            wl, rel=1e-10
+        )
+
+
+# ---------------------------------------------------------------------------
+# wavenumber_to_wavelength
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "k, context",
+    [
+        pytest.param(2.0 * math.pi, does_not_raise(), id="k=2pi"),
+        pytest.param(
+            0.0,
+            pytest.raises(ValueError, match=re.escape("wavenumber must be > 0")),
+            id="zero-k",
+        ),
+        pytest.param(
+            -1.0,
+            pytest.raises(ValueError, match=re.escape("wavenumber must be > 0")),
+            id="negative-k",
+        ),
+    ],
+)
+def test_wavenumber_to_wavelength(k, context):
+    with context:
+        result = wavenumber_to_wavelength(k)
+        assert result > 0.0
+
+
+# ---------------------------------------------------------------------------
+# AdHocDiffractometer.energy_kev property
+# ---------------------------------------------------------------------------
+
+
+class TestEnergyKevProperty:
+    def test_none_when_wavelength_not_set(self):
+        """energy_kev is None when wavelength is not set."""
+        g = fourcv()
+        assert g.energy_kev is None
+
+    def test_value_matches_conversion(self):
+        """energy_kev = wavelength_to_energy(wavelength)."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        assert g.energy_kev == pytest.approx(wavelength_to_energy(1.5406), rel=1e-10)
+
+    def test_set_updates_wavelength(self):
+        """Setting energy_kev updates wavelength via λ = hc/E."""
+        g = fourcv()
+        g.energy_kev = 8.048
+        assert g.wavelength == pytest.approx(energy_to_wavelength(8.048), rel=1e-10)
+
+    def test_set_none_clears_wavelength(self):
+        """Setting energy_kev = None clears wavelength."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        g.energy_kev = None
+        assert g.wavelength is None
+        assert g.energy_kev is None
+
+    def test_round_trip_via_wavelength(self):
+        """wavelength → energy_kev → wavelength recovers the original."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        e = g.energy_kev
+        g2 = fourcv()
+        g2.energy_kev = e
+        assert g2.wavelength == pytest.approx(1.5406, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# AdHocDiffractometer.wavenumber property
+# ---------------------------------------------------------------------------
+
+
+class TestWavenumberProperty:
+    def test_none_when_wavelength_not_set(self):
+        """wavenumber is None when wavelength is not set."""
+        g = fourcv()
+        assert g.wavenumber is None
+
+    def test_value_matches_conversion(self):
+        """wavenumber = 2π / wavelength."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        assert g.wavenumber == pytest.approx(
+            wavelength_to_wavenumber(1.5406), rel=1e-10
+        )
+
+    def test_set_updates_wavelength(self):
+        """Setting wavenumber updates wavelength via λ = 2π/k."""
+        g = fourcv()
+        k = 4.0
+        g.wavenumber = k
+        assert g.wavelength == pytest.approx(wavenumber_to_wavelength(k), rel=1e-10)
+
+    def test_set_none_clears_wavelength(self):
+        """Setting wavenumber = None clears wavelength."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        g.wavenumber = None
+        assert g.wavelength is None
+        assert g.wavenumber is None
+
+    def test_round_trip_via_wavelength(self):
+        """wavelength → wavenumber → wavelength recovers the original."""
+        g = fourcv()
+        g.wavelength = 1.5406
+        k = g.wavenumber
+        g2 = fourcv()
+        g2.wavenumber = k
+        assert g2.wavelength == pytest.approx(1.5406, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# summary() includes energy
+# ---------------------------------------------------------------------------
+
+
+def test_summary_includes_energy(capsys):
+    """summary() reports energy (keV) alongside wavelength when set."""
+    g = fourcv()
+    g.wavelength = 1.5406
+    g.summary()
+    captured = capsys.readouterr()
+    assert "keV" in captured.out
+
+
+def test_summary_no_energy_when_wavelength_not_set(capsys):
+    """summary() reports 'not set' when wavelength is None."""
+    g = fourcv()
+    g.summary()
+    captured = capsys.readouterr()
+    assert "not set" in captured.out
+    assert "keV" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Public API exports
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports():
+    """All radiation symbols are importable from the top-level package."""
+    assert ahd.HC_KEV_ANGSTROM is HC_KEV_ANGSTROM
+    assert ahd.XRAY_LINES is XRAY_LINES
+    assert ahd.wavelength_to_energy is wavelength_to_energy
+    assert ahd.energy_to_wavelength is energy_to_wavelength
+    assert ahd.wavelength_to_wavenumber is wavelength_to_wavenumber
+    assert ahd.wavenumber_to_wavelength is wavenumber_to_wavelength


### PR DESCRIPTION
- closes #21

Adds `radiation.py` with X-ray wavelength↔energy↔wave-number conversions
and named emission line constants.

## What was added

**Constants:**
- `HC_KEV_ANGSTROM = 12.39842` keV·Å (NIST CODATA 2018)
- `XRAY_LINES`: named wavelengths (Å) for Cu, Mo, Ag, Co Kα/Kα1/Kα2

**Standalone functions:**
- `wavelength_to_energy(λ)` → E (keV) = hc/λ
- `energy_to_wavelength(E)` → λ (Å) = hc/E
- `wavelength_to_wavenumber(λ)` → k (Å⁻¹) = 2π/λ
- `wavenumber_to_wavelength(k)` → λ (Å) = 2π/k

**`AdHocDiffractometer` properties:**
- `energy_kev` — lazy-computed from `wavelength`; settable (updates `wavelength`)
- `wavenumber` — lazy-computed from `wavelength`; settable (updates `wavelength`)
- `summary()` now reports E (keV) alongside λ when wavelength is set

All symbols exported from the top-level package.
34 tests; 1141 total; 100% coverage; all pass.

Contributed by: OpenCode (argo/claudesonnet46)