### PR TITLE
ci: automate switcher.json on tag push; add backfill workflow

### DIFF
--- a/.github/workflows/docs_backfill.yml
+++ b/.github/workflows/docs_backfill.yml
@@ -1,41 +1,52 @@
-name: Publish Sphinx Docs to GitHub Pages
+name: Backfill Docs for a Tagged Version
+
+# Use this workflow to publish docs for a tag that was released before
+# versioned docs were introduced.  Run manually from the Actions tab.
+#
+# Usage:
+#   1. Go to Actions -> "Backfill Docs for a Tagged Version"
+#   2. Click "Run workflow"
+#   3. Enter the tag (e.g. "v0.2.0") in the input field
+#   4. Click "Run workflow"
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
-      deploy:
-        description: 'Deploy documentation'
-        type: boolean
+      tag:
+        description: 'Tag to build and publish (e.g. v0.2.0)'
         required: true
-        default: false
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
 
-  docs:
-    name: Build and publish documentation
+  backfill:
+    name: Backfill docs for tag ${{ github.event.inputs.tag }}
     runs-on: ubuntu-latest
 
     steps:
 
-      - name: Checkout
+      - name: Deploy Information
+        run: |
+          echo "Building and publishing docs for tag: ${{ github.event.inputs.tag }}"
+
+      - name: Make Temporary Directory
+        run: |
+          echo "TMP_DIR=$(mktemp -d)" >> "${GITHUB_ENV}"
+          echo "DOC_VERSION=${{ github.event.inputs.tag }}" >> "${GITHUB_ENV}"
+
+      - name: Install pandoc
+        run: |
+          set -vxeuo pipefail
+          sudo apt-get update && sudo apt-get -y install pandoc
+
+      - name: Checkout tag
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # full history so hatch-vcs can read git tags
+          ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -43,74 +54,44 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install pandoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pandoc
-
-      - name: Install package with doc dependencies
+      - name: Install package and doc requirements
         run: pip install -e .[doc]
 
-      - name: Determine DOC_VERSION
+      - name: Build docs
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION="latest"
-          fi
-          echo "DOC_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "Publishing docs as: ${VERSION}"
+          HTML_DIR="${TMP_DIR}/build/${DOC_VERSION}"
+          echo "HTML_DIR=${HTML_DIR}" >> "${GITHUB_ENV}"
+          python3 -m sphinx -b html docs/source "${HTML_DIR}"
 
-      - name: Build Sphinx documentation
-        # Note: -W (warnings-as-errors) is intentionally omitted here.
-        # Pre-existing docstring formatting issues produce AutoAPI warnings
-        # that are tracked separately and will be fixed in Phase 2 content work.
-        run: |
-          python3 -m sphinx -b html docs/source docs/build/html
-
-      - name: Upload docs as workflow artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: docs-${{ env.DOC_VERSION }}
-          path: docs/build/html
+          path: ${{ env.HTML_DIR }}
 
-      - name: Deploy to gh-pages — latest/ (main push)
+      - name: Deploy to gh-pages/<version>/
         uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: docs/build/html
-          destination_dir: latest
-          keep_files: true
-
-      - name: Deploy to gh-pages — <version>/ (tag push)
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/build/html
+          publish_dir: ${{ env.HTML_DIR }}
           destination_dir: ${{ env.DOC_VERSION }}
           keep_files: true
 
-      - name: Update switcher.json on tag push
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      - name: Update switcher.json on gh-pages
         run: |
           set -euo pipefail
           VERSION="${DOC_VERSION}"
 
-          # Clone gh-pages to update switcher.json
           git clone --branch gh-pages --depth 1 \
             "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
             gh-pages-clone
 
           SWITCHER="gh-pages-clone/latest/_static/switcher.json"
 
-          # If switcher.json doesn't exist yet, bootstrap from source
           if [ ! -f "${SWITCHER}" ]; then
-            mkdir -p "$(dirname ${SWITCHER})"
-            cp docs/source/_static/switcher.json "${SWITCHER}"
+            echo "switcher.json not found at ${SWITCHER} — skipping update"
+            exit 0
           fi
 
           # Update switcher.json.
@@ -160,7 +141,7 @@ jobs:
               else:
                   new_entry = {"version": version, "url": f"{base_url}/{version}/", "preferred": True}
                   entries.insert(insert_pos, new_entry)
-                  print(f"Added {version} to switcher.json and marked preferred")
+                  print(f"Added {version} and marked preferred")
           else:
               # Pre-release: add without touching preferred.
               if version in versions:
@@ -168,7 +149,7 @@ jobs:
               else:
                   new_entry = {"version": version, "url": f"{base_url}/{version}/"}
                   entries.insert(insert_pos, new_entry)
-                  print(f"Added pre-release {version} to switcher.json (preferred unchanged)")
+                  print(f"Added pre-release {version} (preferred unchanged)")
 
           with open(switcher_path, "w") as f:
               json.dump(entries, f, indent=4)
@@ -179,8 +160,6 @@ jobs:
 
       - name: Remove pre-release doc directories from gh-pages on stable tag
         if: >
-          github.event_name == 'push' &&
-          startsWith(github.ref, 'refs/tags/') &&
           !contains(env.DOC_VERSION, 'a') &&
           !contains(env.DOC_VERSION, 'b') &&
           !contains(env.DOC_VERSION, 'rc')
@@ -202,24 +181,11 @@ jobs:
           fi
 
       - name: Commit switcher.json and pruned directories to gh-pages
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
           cd gh-pages-clone
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "ci: release ${DOC_VERSION}: update switcher.json, prune pre-release docs"
-          # Pull with rebase before pushing to avoid "fetch first" rejection
-          # when the earlier gh-pages deploy step has already pushed to the branch.
+          git diff --cached --quiet || git commit -m "ci: release ${DOC_VERSION}: update switcher.json, prune pre-release docs (backfill)"
           git pull --rebase origin gh-pages
           git push
-
-      - name: Deploy on manual trigger
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/build/html
-          destination_dir: latest
-          keep_files: true

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -586,6 +586,8 @@ Current coverage: 93% (119 uncovered lines).  ``pytest-cov`` is installed.
       Install (``install.md``), Changes (``changes.md`` includes ``CHANGES.md``)
 - [ ] User Guide per diataxis.fr (Phase 2)
 - [x] GitHub Actions workflow to build and publish docs (``docs.yml``)
+- [x] Versioned docs with ``switcher.json`` automation on tag push ([#91](https://github.com/prjemian/ad_hoc_diffractometer/issues/91))
+- [x] ``docs_backfill.yml`` workflow to publish docs for older tagged releases ([#91](https://github.com/prjemian/ad_hoc_diffractometer/issues/91))
 
 ### 3.9 Neutron radiation source support ([#8](https://github.com/prjemian/ad_hoc_diffractometer/issues/8))
 


### PR DESCRIPTION
- closes #91

## Summary

- **`docs.yml`**: after each tag-push deploy, clone `gh-pages`, run a Python
  script that inserts/updates the new version entry in
  `latest/_static/switcher.json`, prunes pre-release entries when a stable
  tag supersedes them, removes stale pre-release directories from `gh-pages`,
  then pushes back.  Stable releases gain `"preferred": true`; pre-releases
  are added without stealing `preferred`.
- **`docs_backfill.yml`**: new manual-trigger workflow (`workflow_dispatch`)
  that checks out any older tag, builds its docs, deploys to
  `gh-pages/<tag>/`, and updates `switcher.json` by the same logic — useful
  for tags that pre-date the versioned-docs system.
- **`roadmap.md`**: checked off the two versioned-docs items under §3.8e.

## Pattern source

Adapted from the [hklpy2 `docs.yml`](https://github.com/bluesky/hklpy2/blob/main/.github/workflows/docs.yml)
and [hklpy2 `docs_backfill.yml`](https://github.com/bluesky/hklpy2/blob/main/.github/workflows/docs_backfill.yml),
substituting `https://prjemian.github.io/ad_hoc_diffractometer` as the base URL.

Contributed by: OpenCode (argo/claudesonnet46)