### PR TITLE
docs: fix all AutoAPI warnings; adopt hklpy2 templates

### DIFF
--- a/docs/source/_templates/autoapi/python/attribute.rst
+++ b/docs/source/_templates/autoapi/python/attribute.rst
@@ -1,0 +1,1 @@
+{% extends "python/data.rst" %}

--- a/docs/source/_templates/autoapi/python/class.rst
+++ b/docs/source/_templates/autoapi/python/class.rst
@@ -1,0 +1,111 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name | length }}
+
+``{{ obj.short_name }}{% if obj.args %}({{ obj.args | shorten_type }}){% endif %}``
+
+   {% endif %}
+   {% set visible_children = obj.children|selectattr("display")|list %}
+   {% set own_page_children = visible_children|selectattr("type", "in", own_page_types)|list %}
+   {% if is_own_page and own_page_children %}
+.. toctree::
+   :hidden:
+
+      {% for child in own_page_children %}
+   {{ child.include_path }}
+      {% endfor %}
+
+   {% endif %}
+.. py:{{ obj.type }}:: {{ obj.short_name }}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}{% if obj.args %}({{ obj.args | tilde_type }}){% endif %}
+
+   {% for (args, return_annotation) in obj.overloads %}
+      {{ " " * (obj.type | length) }}   {{ obj.short_name }}{% if args %}({{ args | tilde_type }}){% endif %}
+
+   {% endfor %}
+
+   .. container:: import-path
+
+      Import: ``{{ obj.id }}``
+
+   {% if obj.bases %}
+      {% if "show-inheritance" in autoapi_options %}
+
+   Bases: {% for base in obj.bases %}{{ base|link_objs }}{% if not loop.last %}, {% endif %}{% endfor %}
+      {% endif %}
+
+
+      {% if "show-inheritance-diagram" in autoapi_options and obj.bases != ["object"] %}
+   .. autoapi-inheritance-diagram:: {{ obj.obj["full_name"] }}
+      :parts: 1
+         {% if "private-members" in autoapi_options %}
+      :private-bases:
+         {% endif %}
+
+      {% endif %}
+   {% endif %}
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+   {% for obj_item in visible_children %}
+      {% if obj_item.type not in own_page_types %}
+
+   {{ obj_item.render()|indent(3) }}
+      {% endif %}
+   {% endfor %}
+   {% if is_own_page and own_page_children %}
+      {% set visible_attributes = own_page_children|selectattr("type", "equalto", "attribute")|list %}
+      {% if visible_attributes %}
+Attributes
+----------
+
+.. autoapisummary::
+
+         {% for attribute in visible_attributes %}
+   {{ attribute.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_exceptions = own_page_children|selectattr("type", "equalto", "exception")|list %}
+      {% if visible_exceptions %}
+Exceptions
+----------
+
+.. autoapisummary::
+
+         {% for exception in visible_exceptions %}
+   {{ exception.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_classes = own_page_children|selectattr("type", "equalto", "class")|list %}
+      {% if visible_classes %}
+Classes
+-------
+
+.. autoapisummary::
+
+         {% for klass in visible_classes %}
+   {{ klass.id }}
+         {% endfor %}
+
+
+      {% endif %}
+      {% set visible_methods = own_page_children|selectattr("type", "equalto", "method")|list %}
+      {% if visible_methods %}
+Methods
+-------
+
+.. autoapisummary::
+
+            {% for method in visible_methods %}
+   {{ method.id }}
+            {% endfor %}
+
+
+      {% endif %}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/data.rst
+++ b/docs/source/_templates/autoapi/python/data.rst
@@ -1,0 +1,45 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:{% if obj.is_type_alias() %}type{% else %}{{ obj.type }}{% endif %}:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.name }}{% endif %}
+   {% if obj.is_type_alias() %}
+      {% if obj.value %}
+
+   :canonical: {{ obj.value }}
+      {% endif %}
+   {% else %}
+      {% if obj.annotation is not none %}
+
+   :type: {% if obj.annotation %} {{ obj.annotation | tilde_type }}{% endif %}
+      {% endif %}
+      {% if obj.value is not none %}
+
+         {% if obj.value.splitlines()|count > 1 %}
+   :value: Multiline-String
+
+   .. raw:: html
+
+      <details><summary>Show Value</summary>
+
+   .. code-block:: python
+
+      {{ obj.value|indent(width=6,blank=true) }}
+
+   .. raw:: html
+
+      </details>
+
+         {% else %}
+   :value: {{ obj.value|truncate(100) }}
+         {% endif %}
+      {% endif %}
+   {% endif %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/exception.rst
+++ b/docs/source/_templates/autoapi/python/exception.rst
@@ -1,0 +1,1 @@
+{% extends "python/class.rst" %}

--- a/docs/source/_templates/autoapi/python/function.rst
+++ b/docs/source/_templates/autoapi/python/function.rst
@@ -1,0 +1,28 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name | length }}
+
+``{{ obj.short_name }}({{ obj.args | shorten_type }}){% if obj.return_annotation is not none %} → {{ obj.return_annotation | shorten_type }}{% endif %}``
+
+   {% endif %}
+.. py:function:: {{ obj.short_name }}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}({{ obj.args | tilde_type }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation | tilde_type }}{% endif %}
+
+   {% for (args, return_annotation) in obj.overloads %}
+                 {%+ if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}({{ args | tilde_type }}){% if return_annotation is not none %} -> {{ return_annotation | tilde_type }}{% endif %}
+
+   {% endfor %}
+   {% for property in obj.properties %}
+   :{{ property }}:
+
+   {% endfor %}
+
+   .. container:: import-path
+
+      Import: ``{{ obj.id }}``
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/method.rst
+++ b/docs/source/_templates/autoapi/python/method.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:method:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}({{ obj.args | tilde_type }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation | tilde_type }}{% endif %}
+   {% for (args, return_annotation) in obj.overloads %}
+
+               {%+ if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}({{ args | tilde_type }}){% if return_annotation is not none %} -> {{ return_annotation | tilde_type }}{% endif %}
+   {% endfor %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/module.rst
+++ b/docs/source/_templates/autoapi/python/module.rst
@@ -1,0 +1,157 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.short_name }}
+{{ "=" * obj.short_name|length }}
+
+.. py:module:: {{ obj.name }}
+
+.. autoapi-nested-parse::
+
+   Import: ``{{ obj.id }}``
+
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+
+      {% block submodules %}
+         {% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
+         {% set visible_submodules = obj.submodules|selectattr("display")|list %}
+         {% set visible_submodules = (visible_subpackages + visible_submodules)|sort %}
+         {% if visible_submodules %}
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 1
+
+            {% for submodule in visible_submodules %}
+   {{ submodule.include_path }}
+            {% endfor %}
+
+
+         {% endif %}
+      {% endblock %}
+      {% block content %}
+         {% set visible_children = obj.children|selectattr("display")|list %}
+         {% if visible_children %}
+            {% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
+            {% if visible_attributes %}
+               {% if "attribute" in own_page_types or "show-module-summary" in autoapi_options %}
+Attributes
+----------
+
+                  {% if "attribute" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for attribute in visible_attributes %}
+   {{ attribute.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for attribute in visible_attributes %}
+   {{ attribute.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_exceptions = visible_children|selectattr("type", "equalto", "exception")|list %}
+            {% if visible_exceptions %}
+               {% if "exception" in own_page_types or "show-module-summary" in autoapi_options %}
+Exceptions
+----------
+
+                  {% if "exception" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for exception in visible_exceptions %}
+   {{ exception.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for exception in visible_exceptions %}
+   {{ exception.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
+            {% if visible_classes %}
+               {% if "class" in own_page_types or "show-module-summary" in autoapi_options %}
+Classes
+-------
+
+                  {% if "class" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for klass in visible_classes %}
+   {{ klass.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for klass in visible_classes %}
+   {{ klass.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
+            {% if visible_functions %}
+               {% if "function" in own_page_types or "show-module-summary" in autoapi_options %}
+Functions
+---------
+
+                  {% if "function" in own_page_types %}
+.. toctree::
+   :hidden:
+
+                     {% for function in visible_functions %}
+   {{ function.include_path }}
+                     {% endfor %}
+
+                  {% endif %}
+.. autoapisummary::
+
+                  {% for function in visible_functions %}
+   {{ function.id }}
+                  {% endfor %}
+               {% endif %}
+
+
+            {% endif %}
+            {% set this_page_children = visible_children|rejectattr("type", "in", own_page_types)|list %}
+            {% if this_page_children %}
+{{ obj.type|title }} Contents
+{{ "-" * obj.type|length }}---------
+
+               {% for obj_item in this_page_children %}
+{{ obj_item.render()|indent(0) }}
+               {% endfor %}
+            {% endif %}
+         {% endif %}
+      {% endblock %}
+   {% else %}
+.. py:module:: {{ obj.name }}
+
+      {% if obj.docstring %}
+   .. autoapi-nested-parse::
+
+      {{ obj.docstring|indent(6) }}
+
+      {% endif %}
+      {% for obj_item in visible_children %}
+   {{ obj_item.render()|indent(3) }}
+      {% endfor %}
+   {% endif %}
+{% endif %}

--- a/docs/source/_templates/autoapi/python/package.rst
+++ b/docs/source/_templates/autoapi/python/package.rst
@@ -1,0 +1,1 @@
+{% extends "python/module.rst" %}

--- a/docs/source/_templates/autoapi/python/property.rst
+++ b/docs/source/_templates/autoapi/python/property.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:property:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}
+   {% if obj.annotation %}
+
+   :type: {{ obj.annotation | tilde_type }}
+   {% endif %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 
 import os
 import pathlib
+import re
 import sys
 import tomllib
 from importlib.metadata import version as _version
@@ -79,12 +80,64 @@ autoapi_options = [
     "undoc-members",
     "show-inheritance",
     "show-module-summary",
-    "imported-members",
+    # "imported-members" is intentionally omitted: including it causes
+    # "more than one target" cross-reference warnings for every symbol
+    # re-exported via __init__.py.
 ]
 autoapi_member_order = "alphabetical"
 autoapi_python_class_content = "both"
 autoapi_template_dir = "_templates/autoapi"
+autoapi_add_toctree_entry = False  # toctree entry added manually in api.rst
 suppress_warnings = ["autoapi.python_import_resolution"]
+
+
+def autoapi_skip_member(app, what, name, obj, skip, options):
+    """Skip logger instances and private _version from the autoapi output."""
+    if what == "data" and name.endswith(".logger"):
+        return True
+    if "_version" in name:
+        return True
+    return skip
+
+
+def _shorten_type_str(s: str) -> str:
+    """Replace dotted.module.ClassName with ClassName in type annotation strings.
+
+    Used in literal code spans where Sphinx's domain resolver does not run.
+    Bare names (``str``, ``int``, ``None``) are left unchanged.
+    """
+    return re.sub(
+        r"(?<![.\w])([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)+)",
+        lambda m: m.group(0).split(".")[-1],
+        s,
+    )
+
+
+def _tilde_type_str(s: str) -> str:
+    """Prepend ~ to dotted.module.ClassName in type annotation strings.
+
+    Used inside ``.. py:*::`` directives so Sphinx resolves the full cross-
+    reference but displays only the short name (the ``~`` prefix convention).
+    Bare names (``str``, ``int``, ``None``) are left unchanged.
+    """
+    return re.sub(
+        r"(?<![.\w~])([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)+)",
+        lambda m: "~" + m.group(0),
+        s,
+    )
+
+
+def _prepare_jinja_env(jinja_env) -> None:
+    """Register custom Jinja2 filters for autoapi templates."""
+    jinja_env.filters["shorten_type"] = _shorten_type_str
+    jinja_env.filters["tilde_type"] = _tilde_type_str
+
+
+def setup(app):
+    """Connect autoapi events and register Jinja2 filters."""
+    app.connect("autoapi-skip-member", autoapi_skip_member)
+    app.config.autoapi_prepare_jinja_env = _prepare_jinja_env
+
 
 # -- Intersphinx -------------------------------------------------------------
 

--- a/src/ad_hoc_diffractometer/axes.py
+++ b/src/ad_hoc_diffractometer/axes.py
@@ -221,9 +221,8 @@ def kappa_axis(alpha_deg: float, basis: dict | None = None) -> np.ndarray:
         the lateral axis in the vertical-lateral plane.  Must be in (0, 90).
     basis : dict or None
         Mapping from physical direction names to numpy arrays.  If None,
-        the default You (1999) basis is used:
-            vertical  -> XHAT
-            lateral   -> ZHAT
+        the default You (1999) basis is used
+        (vertical -> XHAT, lateral -> ZHAT).
 
     Returns
     -------

--- a/src/ad_hoc_diffractometer/engines.py
+++ b/src/ad_hoc_diffractometer/engines.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
 # SPDX-License-Identifier: CC-BY-4.0
-"""
+r"""
 engines.py — Alternative calculation engines.
 
 Provides standalone conversion functions between the four representations
@@ -22,13 +22,13 @@ Q_to_hkl(sample, Qx, Qy, Qz) -> tuple[float, float, float]
     Q-vector → Miller indices via hkl = UB⁻¹ @ Q.
 
 Q_to_d(Qx, Qy, Qz) -> float
-    Q-vector magnitude → d-spacing: d = 2π / |Q|.
+    Q-vector magnitude → d-spacing: d = 2π / \|Q\|.
 
 d_to_Q_mag(d) -> float
-    d-spacing → |Q|: |Q| = 2π / d.
+    d-spacing → \|Q\|: \|Q\| = 2π / d.
 
 hkl_to_d(sample, h, k, l) -> float
-    Miller indices → d-spacing via |Q| = |UB @ hkl|, d = 2π / |Q|.
+    Miller indices → d-spacing via \|Q\| = \|UB @ hkl\|, d = 2π / \|Q\|.
 
 d_to_two_theta(d, wavelength) -> float
     d-spacing → 2θ (degrees) via Bragg's law: λ = 2d sin(θ).
@@ -40,10 +40,10 @@ hkl_to_two_theta(sample, h, k, l, wavelength) -> float
     Miller indices → 2θ (degrees).
 
 two_theta_to_Q_mag(two_theta_deg, wavelength) -> float
-    2θ (degrees) → |Q| (Å⁻¹): |Q| = 4π sin(θ) / λ.
+    2θ (degrees) → \|Q\| (Å⁻¹): \|Q\| = 4π sin(θ) / λ.
 
 Q_mag_to_two_theta(Q_mag, wavelength) -> float
-    |Q| (Å⁻¹) → 2θ (degrees).
+    \|Q\| (Å⁻¹) → 2θ (degrees).
 
 References
 ----------
@@ -173,10 +173,10 @@ def Q_to_hkl(
 
 
 def Q_to_d(Qx: float, Qy: float, Qz: float) -> float:
-    """
+    r"""
     Convert a Q-vector to the d-spacing.
 
-    d = 2π / |**Q**|
+    d = 2π / \|**Q**\|
 
     Parameters
     ----------
@@ -191,7 +191,7 @@ def Q_to_d(Qx: float, Qy: float, Qz: float) -> float:
     Raises
     ------
     ValueError
-        If |Q| = 0.
+        If \|Q\| = 0.
 
     Examples
     --------
@@ -206,10 +206,10 @@ def Q_to_d(Qx: float, Qy: float, Qz: float) -> float:
 
 
 def d_to_Q_mag(d: float) -> float:
-    """
+    r"""
     Convert a d-spacing to the magnitude of the scattering vector.
 
-    |**Q**| = 2π / d
+    \|**Q**\| = 2π / d
 
     Parameters
     ----------
@@ -219,7 +219,7 @@ def d_to_Q_mag(d: float) -> float:
     Returns
     -------
     float
-        |Q| in Å⁻¹.
+        \|Q\| in Å⁻¹.
 
     Raises
     ------
@@ -243,10 +243,10 @@ def hkl_to_d(
     k: float,
     l: float,  # noqa: E741
 ) -> float:
-    """
+    r"""
     Convert Miller indices to d-spacing.
 
-    d = 2π / |UB · **hkl**|
+    d = 2π / \|UB · **hkl**\|
 
     Parameters
     ----------
@@ -424,10 +424,10 @@ def hkl_to_two_theta(
 
 
 def two_theta_to_Q_mag(two_theta_deg: float, wavelength: float) -> float:
-    """
-    Convert 2θ to |Q| using the Bragg relation.
+    r"""
+    Convert 2θ to \|Q\| using the Bragg relation.
 
-    |**Q**| = 4π sin(θ) / λ
+    \|**Q**\| = 4π sin(θ) / λ
 
     Parameters
     ----------
@@ -439,7 +439,7 @@ def two_theta_to_Q_mag(two_theta_deg: float, wavelength: float) -> float:
     Returns
     -------
     float
-        |Q| in Å⁻¹.
+        \|Q\| in Å⁻¹.
 
     Raises
     ------
@@ -464,10 +464,10 @@ def two_theta_to_Q_mag(two_theta_deg: float, wavelength: float) -> float:
 
 
 def Q_mag_to_two_theta(Q_mag: float, wavelength: float) -> float:
-    """
-    Convert |Q| to 2θ.
+    r"""
+    Convert \|Q\| to 2θ.
 
-    2θ = 2 arcsin(|Q| λ / (4π))
+    2θ = 2 arcsin(\|Q\| λ / (4π))
 
     Parameters
     ----------
@@ -485,7 +485,7 @@ def Q_mag_to_two_theta(Q_mag: float, wavelength: float) -> float:
     ------
     ValueError
         If ``Q_mag`` < 0, ``wavelength`` ≤ 0, or the reflection is
-        unreachable (|Q| λ / (4π) > 1).
+        unreachable (\|Q\| λ / (4π) > 1).
 
     Examples
     --------

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -157,9 +157,11 @@ def register_geometry(func):
 
     Example
     -------
-    @register_geometry
-    def psic() -> AdHocDiffractometer:
-        ...
+    ::
+
+        @register_geometry
+        def psic() -> AdHocDiffractometer:
+            ...
     """
     _GEOMETRY_REGISTRY[func.__name__] = func
     return func
@@ -561,11 +563,12 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     making this a coupled geometry.  Useful for surface diffraction.
 
     From Fig. 1 and §2.1 of Lohmeier & Vlieg (1993):
-        alpha and gamma rotate about the vertical axis (x in LV convention).
-        omega, phi, and delta all rotate about the lateral axis (z in LV).
-        chi rotates about the longitudinal axis (y in LV).
+    alpha and gamma rotate about the vertical axis (x in LV convention).
+    omega, phi, and delta all rotate about the lateral axis (z in LV).
+    chi rotates about the longitudinal axis (y in LV).
 
-    Stack (floor first):
+    Stack (floor first)::
+
         alpha (shared base): vertical,     right-handed  [rotary table]
           --> omega (sample):  lateral,      left-handed
                 --> chi:       longitudinal, right-handed
@@ -822,18 +825,21 @@ def zaxis(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     parallel to the Z-axis, so the angle of incidence equals the alpha angle.
     The detector and sample both rotate about the shared alpha (base) axis.
 
-    Stack (floor first):
+    Stack (floor first)::
+
         alpha (shared base): vertical,     right-handed
           --> Z     (sample)  : longitudinal, right-handed
           --> delta (detector): lateral,      left-handed
                 --> gamma :     vertical,     right-handed
 
     The total scattering angle is a compound of gamma, delta, and alpha
-    (Walko 2016, eq. 17):
+    (Walko 2016, eq. 17)::
+
         ttheta = arccos(cos(gamma)*cos(delta)*cos(alpha) + sin(alpha)*sin(gamma))
 
-    References: J.M. Bloch, J. Appl. Cryst. 18, 33-36 (1985).
-                D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), eq. 17.
+    References:
+    J.M. Bloch, J. Appl. Cryst. 18, 33-36 (1985).
+    D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), eq. 17.
     """
     VERTICAL = basis["vertical"]
     LATERAL = basis["lateral"]
@@ -868,22 +874,25 @@ def s2d2(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     (nu, delta), all mechanically decoupled.  The angle of incidence is the
     mu angle; the surface normal is parallel to Z.
 
-    Sample stack (floor first):
+    Sample stack (floor first)::
+
         mu    : vertical,     right-handed
           --> Z : longitudinal, right-handed
 
-    Detector stack (floor first):
+    Detector stack (floor first)::
+
         nu    : vertical,     right-handed
           --> delta : lateral, left-handed
 
     mu and nu share the same vertical axis; mechanically independent.
 
-    The total scattering angle is (Walko 2016, eq. 18):
+    The total scattering angle is (Walko 2016, eq. 18)::
+
         ttheta = arccos(cos(nu) * cos(delta))
 
-    References: K.W. Evans-Lutterodt & M.-T. Tang, J. Appl. Cryst.
-                    28, 318-326 (1995).
-                D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), eq. 18.
+    References:
+    K.W. Evans-Lutterodt & M.-T. Tang, J. Appl. Cryst. 28, 318-326 (1995).
+    D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), eq. 18.
     """
     VERTICAL = basis["vertical"]
     LATERAL = basis["lateral"]
@@ -919,15 +928,17 @@ def fivec(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     through mu.  This provides an additional degree of freedom for accessing
     wider regions of reciprocal space, particularly at synchrotron sources.
 
-    Stack (floor first):
+    Stack (floor first)::
+
         mu (shared base): vertical,     right-handed
           --> omega (sample): lateral,      left-handed
                 --> chi:      longitudinal, right-handed
                       --> phi: lateral,     left-handed
           --> ttheta (detector): lateral,   left-handed
 
-    References: E. Vlieg et al., J. Appl. Cryst. 20, 330-337 (1987).
-                D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016).
+    References:
+    E. Vlieg et al., J. Appl. Cryst. 20, 330-337 (1987).
+    D.A. Walko, Ref. Module Mater. Sci. Mater. Eng. (2016).
     """
     VERTICAL = basis["vertical"]
     LATERAL = basis["lateral"]

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
 # SPDX-License-Identifier: CC-BY-4.0
-"""
+r"""
 forward.py — Forward diffraction calculation: (h, k, l) → motor angles.
 
 The forward calculation is the inverse of ``inverse()``: given a reciprocal-
@@ -22,9 +22,9 @@ BisectingMode (four-sample-stage geometries with one detector arm)
 
     Algorithm:
         1. Q_phi = UB @ (h, k, l)             — target in phi frame
-        2. |Q| → ttheta via Bragg's law
+        2. \|Q\| → ttheta via Bragg's law
         3. frozen stages set from mode.frozen_angles
-        4. detector_stage = ttheta (computed from |Q|)
+        4. detector_stage = ttheta (computed from \|Q\|)
         5. sample_stage   = ttheta / 2 (bisecting)
         6. Remaining free sample stages (chi, phi or kchi, kphi) solved
            from the direction of Q_phi, choosing among the standard
@@ -47,7 +47,7 @@ ValueError
 ValueError
     If (h, k, l) = (0, 0, 0).
 ValueError
-    If the requested |Q| exceeds the Ewald sphere (wavelength too long).
+    If the requested \|Q\| exceeds the Ewald sphere (wavelength too long).
 
 References
 ----------
@@ -79,7 +79,7 @@ def compute_forward(
     k: float,
     l: float,  # noqa: E741
 ) -> list[dict[str, float]]:
-    """
+    r"""
     Compute all valid motor-angle solutions for the reciprocal-lattice point
     (h, k, l) in the geometry's active diffraction mode.
 
@@ -109,7 +109,7 @@ def compute_forward(
         If (h, k, l) == (0, 0, 0).
     ValueError
         If the scattering vector magnitude exceeds the Ewald sphere
-        (|Q| > 4π/λ, i.e. Bragg condition cannot be satisfied).
+        (\|Q\| > 4π/λ, i.e. Bragg condition cannot be satisfied).
     NotImplementedError
         If no active mode is set or the active mode type is not supported
         for this geometry.

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -56,8 +56,8 @@ class AdHocDiffractometer:
         the stacking; the parent attribute of each Stage does.
     basis : dict, optional
         Mapping from physical direction names to Cartesian basis vectors.
-        Default is the You (1999) convention:
-            {'vertical': XHAT, 'longitudinal': YHAT, 'lateral': ZHAT}
+        Default is the You (1999) convention
+        ``{'vertical': XHAT, 'longitudinal': YHAT, 'lateral': ZHAT}``.
     description : str, optional
         Free-text description of the geometry.
     wavelength : float or None, optional
@@ -87,30 +87,6 @@ class AdHocDiffractometer:
         A cut-point C for stage X means the returned angle lies in
         ``[C, C + 360°)``.  ``None`` is equivalent to an empty dict.
 
-    Attributes
-    ----------
-    sample_stages : list of Stage
-        Stages with role='sample', in stacking order (floor first).
-    detector_stages : list of Stage
-        Stages with role='detector', in stacking order (floor first).
-    wavelength : float or None
-        Wavelength in Å, or None if not set.
-    kappa_alpha_deg : float or None
-        Kappa tilt angle in degrees, or None for non-kappa geometries.
-    azimuthal_reference : tuple of float or None
-        Azimuthal reference vector (h, k, l), or None if not set.
-    modes : ModeDict
-        The collection of named modes.  Empty if none were supplied.
-    mode_name : str or None
-        Name of the currently active mode, or ``None`` if no mode is set.
-    cut_points : dict[str, float]
-        Geometry-level SPEC #G4 cut-points per stage; mirrors SPEC #G4.
-    detector_distance : float or None
-        Sample-to-detector distance in mm, or ``None`` if not set.
-    detector_tilt : float or None
-        Detector tilt angle in degrees, or ``None`` if not set.
-    detector_offset : tuple of float or None
-        In-plane detector offset (dx, dy) in mm, or ``None`` if not set.
     """
 
     DEFAULT_BASIS = {
@@ -805,7 +781,7 @@ class AdHocDiffractometer:
         k: float,
         l: float,  # noqa: E741
     ) -> list[dict[str, float]]:
-        """
+        r"""
         Compute all valid motor-angle solutions for the reflection (h, k, l).
 
         This is the *forward* diffraction calculation: given a reciprocal-
@@ -843,7 +819,7 @@ class AdHocDiffractometer:
         ValueError
             If (h, k, l) == (0, 0, 0).
         ValueError
-            If the requested |Q| exceeds the Ewald sphere.
+            If the requested \|Q\| exceeds the Ewald sphere.
         NotImplementedError
             If no active mode is set or the mode type is not supported.
 

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -553,8 +553,8 @@ class Lattice:
         """
         B matrix in Å⁻¹ (with 2π factor, Busing & Levy 1967 / SPEC convention).
 
-        Transforms Miller indices **h** = (h, k, l) to the scattering vector
-        in Cartesian crystal-frame coordinates:
+        Transforms Miller indices ``h`` = (h, k, l) to the scattering vector
+        in Cartesian crystal-frame coordinates::
 
             Q_c = B @ h
 
@@ -783,14 +783,14 @@ def b_matrix(
     """
     Compute the B matrix from the reciprocal lattice vectors.
 
-    The B matrix transforms Miller indices **h** = (h, k, l) to the
+    The B matrix transforms Miller indices ``h`` = (h, k, l) to the
     scattering vector in Cartesian crystal-frame coordinates
-    (Busing & Levy, 1967, eq. 3):
+    (Busing & Levy, 1967, eq. 3)::
 
         Q_c = B @ h
 
-    The columns of B are the reciprocal lattice vectors **b**₁, **b**₂,
-    **b**₃ (each including the 2π factor), so:
+    The columns of B are the reciprocal lattice vectors b₁, b₂, b₃
+    (each including the 2π factor), so::
 
         B.T = [b1, b2, b3]    (column-stack of the reciprocal vectors)
 

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -79,12 +79,6 @@ class DiffractionMode(ABC):
         ``None`` is equivalent to an empty dict (no cut-points set, i.e.
         the default branch [-180, 180) is used).
 
-    Attributes
-    ----------
-    frozen_angles : dict[str, float]
-        Stages held fixed in this mode; mirrors SPEC #G0.
-    cut_points : dict[str, float]
-        Branch selection cut-points per stage; mirrors SPEC #G4.
     """
 
     def __init__(
@@ -102,6 +96,7 @@ class DiffractionMode(ABC):
         Return the list of stage names that are constrained (not free) in this mode.
 
         Constrained stages include both:
+
         - frozen stages (held at a fixed angle)
         - stages whose angle is determined by a relationship to another stage
           (e.g. bisecting: omega = ttheta/2)

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
 # SPDX-License-Identifier: CC-BY-4.0
-"""
+r"""
 orientation.py — U and UB matrix computation from orienting reflections.
 
 Functions
 ---------
-angles_to_phi_vector(geometry, **motor_angles)
+angles_to_phi_vector(geometry, \*\*motor_angles)
     Convert a set of motor angles to the scattering vector expressed in the
     phi-axis (innermost sample-stage) frame.  This is the foundational
     computation needed for U and UB matrix determination.

--- a/src/ad_hoc_diffractometer/reflection.py
+++ b/src/ad_hoc_diffractometer/reflection.py
@@ -201,11 +201,6 @@ class ReflectionList:
     valid_stages : set of str
         Stage names of the owning geometry.  Used to validate angle keys.
 
-    Attributes
-    ----------
-    geometry_name : str
-    valid_stages : set of str
-
     Examples
     --------
     >>> rl = ReflectionList(geometry_name="psic",

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -5,19 +5,18 @@ scan.py — Reciprocal-space trajectory computation.
 
 Functions
 ---------
-hkl_trajectory(geometry, trajectory, n_points, *, solution_key=NEAREST_ANGLES)
+``hkl_trajectory(geometry, trajectory, n_points, solution_key=NEAREST_ANGLES)``
     Compute motor-angle sequences along a specified reciprocal-space path.
 
-psi_trajectory(geometry, h, k, l, psi_values, *, solution_key=NEAREST_ANGLES)
+``psi_trajectory(geometry, h, k, l, psi_values, solution_key=NEAREST_ANGLES)``
     Compute motor-angle sequences for ψ (psi) rotation about the scattering
     vector Q while keeping the Bragg condition satisfied.
 
-trajectory_plan(geometry, hkl_start, hkl_end, n_points, *, space="hkl",
-                solution_key=NEAREST_ANGLES)
+``trajectory_plan(geometry, hkl_start, hkl_end, n_points, space="hkl", solution_key=NEAREST_ANGLES)``
     Plan a motor-angle path between two reciprocal-space points, flagging
     limit violations and inaccessible regions.
 
-NEAREST_ANGLES
+``NEAREST_ANGLES``
     Built-in solution-key callable: selects the candidate solution whose
     motor angles are closest (in least-squares sense) to the previous point.
     Suppresses branch-flip discontinuities across a trajectory.
@@ -42,14 +41,14 @@ preferring the candidate closest in motor space to the previous point.
 ~~~~~~~~~~~~~~~~
 Two distinct definitions of ψ exist in the literature.
 
-**geometry.psi()** implements You (1999) eqs. 10-11: ψ is the azimuthal
+``geometry.psi()`` implements You (1999) eqs. 10-11: ψ is the azimuthal
 angle of the reference vector **n** about **Q** measured from the projection
 of the fixed lab beam direction y_hat onto the phi-frame Q-perp plane.  For
 a given (hkl, UB, n_hkl) this value is *constant* across all motor-angle
 solutions that satisfy the Bragg condition — it is a crystal-orientation
 diagnostic, not a motor-angle observable.
 
-**psi_trajectory()** implements the Busing & Levy (1967) *operational* ψ:
+``psi_trajectory()`` implements the Busing & Levy (1967) *operational* ψ:
 the angle through which the sample has been rotated about the scattering
 vector Q relative to a chosen reference orientation.  This is the quantity
 physically varied during a ψ scan on a real diffractometer.
@@ -64,12 +63,12 @@ Algorithm (Busing & Levy 1967, Section "Angle settings"):
 4. Remove the contribution of any fixed outer stages and decompose the
    inner-three-stage part of Z(ψ) into motor angles analytically:
 
-   * **Eulerian** (fourcv, fourch, psic-style, fivec-style): the formula
+   * **Eulerian** (fourcv, fourch, psic-style, fivec-style):
      n_phi · Z · n_om = cos(χ) isolates χ; then ω and φ follow from
      projections of Z · n_om and Z^T · n_phi onto the plane perpendicular
      to their shared rotation axis.  Two χ branches are returned.
 
-   * **Kappa** (kappa4cv, kappa4ch, kappa6c): the formula
+   * **Kappa** (kappa4cv, kappa4ch, kappa6c):
      n_kphi · Z · n_komega = cos(κ)·cos²(α) + sin²(α) isolates κ (where
      α = kappa_alpha_deg); komega and kphi follow by the same projection
      method.  Two κ branches (positive and negative) are returned.
@@ -872,7 +871,7 @@ def trajectory_plan(
     space: str = "hkl",
     solution_key=NEAREST_ANGLES,
 ) -> list[dict]:
-    """
+    r"""
     Plan a motor-angle path between two reciprocal-space points.
 
     Interpolates between ``hkl_start`` and ``hkl_end`` in ``n_points``
@@ -894,7 +893,7 @@ def trajectory_plan(
         ``"hkl"`` (default)
             Linearly interpolate Miller indices.  Natural for L-scans,
             H-scans, and crystal-axis-aligned trajectories.  Equal steps in
-            hkl are *not* equal steps in |Q| for non-cubic lattices.
+            hkl are *not* equal steps in \|Q\| for non-cubic lattices.
 
         ``"Q"``
             Linearly interpolate in reciprocal Cartesian coordinates

--- a/src/ad_hoc_diffractometer/surface.py
+++ b/src/ad_hoc_diffractometer/surface.py
@@ -291,7 +291,7 @@ def q_components(
     geometry: AdHocDiffractometer,
     angles: dict[str, float] | None = None,
 ) -> dict[str, float]:
-    """
+    r"""
     Decompose Q into components perpendicular and parallel to the sample surface.
 
     ``Q_perp`` is the component of Q along the surface normal (out-of-plane).
@@ -325,7 +325,7 @@ def q_components(
             Signed out-of-plane component (Å⁻¹); positive when Q points
             along the outward surface normal.
         ``"Q_total"`` : float
-            Total |Q| (Å⁻¹).
+            Total \|Q\| (Å⁻¹).
 
     Raises
     ------


### PR DESCRIPTION
- closes #92

## Summary

- **Zero Sphinx warnings** (down from 89) — all AutoAPI, reST markup,
  duplicate-description, and cross-reference warnings eliminated.
- **hklpy2 AutoAPI templates** installed (`docs/source/_templates/autoapi/python/*.rst`):
  all 9 template types with `shorten_type` / `tilde_type` Jinja2 filters
  for clean type-annotation display.
- **`conf.py`** updated:
  - `autoapi_skip_member()` skips `logger` data objects and `_version` module
  - `_shorten_type_str()` / `_tilde_type_str()` Jinja2 filter helpers registered
    via `_prepare_jinja_env()` / `setup()`
  - `imported-members` removed from `autoapi_options` (was causing "more than
    one target" warnings for every symbol re-exported via `__init__.py`)
  - `autoapi_add_toctree_entry = False` (entry already in `api.rst`)
- **Docstring fixes** across 9 source modules:
  - `|Q|` / `|**Q**|` / `|UB @ hkl|` escaped in docstrings only (reST
    substitution references); runtime error strings untouched
  - Duplicate `Attributes` sections removed from `AdHocDiffractometer`,
    `DiffractionMode`, `ReflectionList` (were duplicating autoapi output)
  - Indented parameter-description continuations flattened into prose
  - Stack diagrams and formula lines converted to `::` literal blocks
  - Multi-line `References:` continuations reformatted
  - `**name()**` bold spans in `scan.py` and `orientation.py` replaced with
    backtick code spans
  - Blank line added before bullet list in `constrained_stages` docstring

All 1195 tests pass at 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)