### PR TITLE
docs: refactor existing content; enable notebook execution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,10 +43,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install system dependencies (pandoc, graphviz)
+      - name: Install system dependencies (graphviz)
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc graphviz
+          sudo apt-get install -y graphviz
 
       - name: Install package with doc dependencies
         run: pip install -e .[doc]

--- a/.github/workflows/docs_backfill.yml
+++ b/.github/workflows/docs_backfill.yml
@@ -37,10 +37,10 @@ jobs:
           echo "TMP_DIR=$(mktemp -d)" >> "${GITHUB_ENV}"
           echo "DOC_VERSION=${{ github.event.inputs.tag }}" >> "${GITHUB_ENV}"
 
-      - name: Install system dependencies (pandoc, graphviz)
+      - name: Install system dependencies (graphviz)
         run: |
           set -vxeuo pipefail
-          sudo apt-get update && sudo apt-get -y install pandoc graphviz
+          sudo apt-get update && sudo apt-get -y install graphviz
 
       - name: Checkout tag
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://prjemian.github.io/ad_hoc_diffractometer/latest/)
 [![License: CC-BY-4.0](https://img.shields.io/badge/License-CC--BY--4.0-brightgreen)](https://creativecommons.org/licenses/by/4.0/)
 
-`ad_hoc_diffractometer` is a **pure-Python** diffractometer simulation
-package for X-ray and neutron crystallography, built around a key design
-principle: **any multi-circle diffractometer geometry can be fully described
-by the caller** — no geometry is hard-coded, and new geometries require no
-changes to the package itself.
+`ad_hoc_diffractometer` is a **pure-Python** package for operating
+multi-circle diffractometers in reciprocal space for X-ray and neutron
+crystallography.  It is built around a key design principle: **any
+multi-circle diffractometer geometry can be fully described by the caller**
+— no geometry is hard-coded, and new geometries require no changes to the
+package itself.
 
 Its only runtime dependency beyond the Python Standard Library is
 [NumPy](https://numpy.org) — no scipy, sympy, or other scientific
 libraries are required.
+
+> **Note:** The package assumes **monochromatic radiation** throughout.
+> All diffraction calculations are performed at a fixed wavelength.
 
 ## Features
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,8 +38,7 @@ switcher_version_match = os.environ.get("DOC_VERSION", release)
 
 extensions = [
     "autoapi.extension",
-    "myst_parser",
-    "nbsphinx",
+    "myst_nb",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
@@ -55,8 +54,6 @@ exclude_patterns = [
     "_build",
     "Thumbs.db",
     ".DS_Store",
-    # Notebooks excluded until CI pandoc integration and content review (#95).
-    "*.ipynb",
     # roadmap.md lives in the repo root (not docs/source); guard against
     # accidental inclusion if the file is ever copied back here.
     "roadmap.md",
@@ -64,13 +61,20 @@ exclude_patterns = [
 
 myst_enable_extensions = ["colon_fence"]
 
-source_suffix = [".rst", ".md"]
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "restructuredtext",
+    ".ipynb": "myst-nb",
+}
 
 templates_path = ["_templates"]
 
-# Do not execute notebooks during doc build — notebooks may require
-# hardware or data not available in CI.
-nb_execution_mode = "off"
+# -- Notebook execution (myst-nb) --------------------------------------------
+
+# Execute notebooks during the doc build.  All notebooks in docs/source/
+# use only ad_hoc_diffractometer + NumPy + matplotlib — no hardware required.
+nb_execution_mode = "auto"  # execute only notebooks without stored outputs
+nb_execution_timeout = 120  # seconds per cell
 
 # -- AutoAPI -----------------------------------------------------------------
 

--- a/docs/source/direct-lattice.md
+++ b/docs/source/direct-lattice.md
@@ -1,92 +1,69 @@
-# Direct lattice in crystallography
+# Direct Lattice in Crystallography
 
-## Vector math order of operations
+This page summarises the vector mathematics underlying the direct lattice
+representation used throughout `ad_hoc_diffractometer`.  See the
+{mod}`~ad_hoc_diffractometer.lattice` module for the implementation.
 
-> Given the vector math expression: A dot B cross C, what is the order of operations?
+## Lattice vectors
 
-In the vector math expression **A · (B × C)**, the **cross product has
-higher precedence than the dot product**, so the order of operations is:
+The unit cell of a crystal is described by three edge vectors
+**A**, **B**, **C** expressed in a Cartesian frame.  With **A** along the
+$x$-axis and **B** in the $xy$-plane, the standard crystallographic choice is:
 
-1. **First: Calculate B × C** (the cross product)
-2. **Second: Calculate A · (result)** (the dot product)
+| Vector | Cartesian components |
+|--------|----------------------|
+| **A** | $(a,\ 0,\ 0)$ |
+| **B** | $(b\cos\gamma,\ b\sin\gamma,\ 0)$ |
+| **C** | $(c\cos\beta,\ c\,\tfrac{\cos\alpha - \cos\beta\cos\gamma}{\sin\gamma},\ c\,v)$ |
 
-This is the standard convention in vector mathematics. The cross product
-is always evaluated before the dot product unless parentheses explicitly
-indicate otherwise.
+where
 
-### Why this order matters
+$$v = \frac{\sqrt{1 - \cos^2\!\alpha - \cos^2\!\beta - \cos^2\!\gamma
+      + 2\cos\alpha\cos\beta\cos\gamma}}{\sin\gamma}$$
 
-This particular combination—**A · (B × C)**—is called the **scalar
-triple product** (or mixed product). It has a special geometric meaning:
-it gives the signed volume of the parallelepiped formed by the three
-vectors A, B, and C.
+and $a, b, c$ are the unit-cell edge lengths; $\alpha, \beta, \gamma$ are
+the inter-edge angles ($\alpha$ between **B** and **C**, $\beta$ between
+**A** and **C**, $\gamma$ between **A** and **B**).
 
-If you wanted to reverse the order, you'd need to write it explicitly as
-**(A · B) × C**, which would give you a vector result instead of a
-scalar, and it would have a completely different meaning.
+## Unit cell volume
 
-------------------------
+The unit cell volume is the scalar triple product of the three lattice vectors:
 
-I need to clarify the representation you're asking about, because there
-are different conventions for encoding crystal lattice parameters into
-vectors.
+$$V = \mathbf{A} \cdot (\mathbf{B} \times \mathbf{C})$$
 
-The most common approach in crystallography is to represent the lattice
-parameters using **lattice vectors** (the edge vectors of the unit
-cell). In this case:
+The cross product is evaluated first (standard vector-mathematics precedence),
+giving a vector perpendicular to **B** and **C**; the dot product with **A**
+then yields the signed volume of the parallelepiped spanned by the three
+vectors.  With the lattice vectors defined above, this reduces to:
 
-| Vector | Represents | Formula |
-|--------|-----------|---------|
-| **A** | Lattice vector a | **(a, 0, 0)** |
-| **B** | Lattice vector b | **(b·cos(γ), b·sin(γ), 0)** |
-| **C** | Lattice vector c | **(c·cos(β), c·sin(α)·sin(β), c·cos(α))** |
+$$V = a\,b\,c\,v\,\sin\gamma$$
 
-where:
+## Reciprocal lattice
 
-- **a, b, c** are the lattice parameters (edge lengths)
-- **α, β, γ** are the angles between the edges (α between b and c, β
-  between a and c, γ between a and b)
+The reciprocal lattice vectors $\mathbf{b}_1, \mathbf{b}_2, \mathbf{b}_3$
+satisfy the orthogonality condition
 
-### Why this representation?
+$$\mathbf{b}_i \cdot \mathbf{a}_j = 2\pi\,\delta_{ij}$$
 
-With vectors defined this way, **A · (B × C)** gives you the **unit cell
-volume**—a fundamental property in crystallography. This is exactly why
-the scalar triple product is so important in crystallography
-calculations.
+where $\mathbf{a}_1 = \mathbf{A}$, $\mathbf{a}_2 = \mathbf{B}$,
+$\mathbf{a}_3 = \mathbf{C}$.  Each reciprocal vector includes the $2\pi$
+factor (the convention used in `ad_hoc_diffractometer` and by Busing & Levy 1967).
 
-## Standard form of lattice
+## The B matrix
 
-Perfect. Here are the **lattice vectors** in standard crystallographic form:
+The **B matrix** encodes the reciprocal lattice vectors as its columns:
 
-| Vector | Formula |
-|--------|---------|
-| **A** | **(a, 0, 0)** |
-| **B** | **(b·cos(γ), b·sin(γ), 0)** |
-| **C** | **(c·cos(β), c·sin(α)·sin(β), c·cos(α))** |
+$$\mathbf{B}^T = [\mathbf{b}_1\ \mathbf{b}_2\ \mathbf{b}_3]$$
 
-### Breaking down each vector
+It maps Miller indices $\mathbf{h} = (h, k, l)^T$ to the scattering vector
+in Cartesian crystal-frame coordinates (Busing & Levy 1967, eq. 3):
 
-**Vector A** is the simplest—it lies along the x-axis:
+$$\mathbf{Q}_c = \mathbf{B}\,\mathbf{h}$$
 
-- Component 1: **a**
-- Component 2: **0**
-- Component 3: **0**
+The magnitude $|\mathbf{Q}_c| = |\mathbf{B}\,\mathbf{h}| = 2\pi / d_{hkl}$,
+where $d_{hkl}$ is the interplanar spacing.
 
-**Vector B** lies in the xy-plane, making angle **γ** (gamma) with vector A:
+## Reference
 
-- Component 1: **b·cos(γ)**
-- Component 2: **b·sin(γ)**
-- Component 3: **0**
-
-**Vector C** points into 3D space, with **β** (beta) defining its angle
-from the x-axis and **α** (alpha) defining the tilt:
-
-- Component 1: **c·cos(β)**
-- Component 2: **c·sin(α)·sin(β)**
-- Component 3: **c·cos(α)**
-
-### Key point
-
-When you compute **A · (B × C)** using these vectors, you get the **unit
-cell volume** of the crystal lattice. This is the fundamental reason
-this scalar triple product is so important in crystallography.
+- W.R. Busing & H.A. Levy, *Acta Cryst.* **22**, 457–464 (1967).
+  DOI: [10.1107/S0365110X67000970](https://doi.org/10.1107/S0365110X67000970)

--- a/docs/source/fourcv_alignment_howto.ipynb
+++ b/docs/source/fourcv_alignment_howto.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```{note}\nThis page was generated from a Jupyter notebook.  [Download the notebook](fourcv_alignment_howto.ipynb) to run it locally — it requires only `ad_hoc_diffractometer`, NumPy, and Matplotlib.\n```\n\n",
     "# How to Align a Four-Circle Diffractometer (`fourcv`)\n",
     "\n",
     "This notebook is a **how-to guide** for aligning a crystal on a four-circle\n",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,15 +6,24 @@
 
 **Version:** |release|
 
-``ad_hoc_diffractometer`` is a **pure-Python** diffractometer simulation
-package for X-ray and neutron crystallography, built around a key design
-principle: **any multi-circle diffractometer geometry can be fully described
-by the caller** — no geometry is hard-coded, and new geometries require no
-changes to the package itself.
+``ad_hoc_diffractometer`` is a **pure-Python** package for operating
+multi-circle diffractometers in reciprocal space for X-ray and neutron
+crystallography.  It is built around a key design principle: **any
+multi-circle diffractometer geometry can be fully described by the caller**
+— no geometry is hard-coded, and new geometries require no changes to the
+package itself.
 
 Its only runtime dependency beyond the Python Standard Library is
 `NumPy <https://numpy.org>`_ — no scipy, sympy, or other scientific
-libraries are required.  It provides:
+libraries are required.
+
+.. note::
+
+   The package assumes **monochromatic radiation** throughout.  All
+   diffraction calculations (Bragg angles, Q-vector magnitudes,
+   forward/inverse problems) are performed at a fixed wavelength.
+
+It provides:
 
 - A class-based description of diffractometer stages (rotary axes) and
   their stacking order
@@ -25,7 +34,10 @@ libraries are required.  It provides:
 - U and UB matrix computation from orienting reflections
 - Forward diffraction calculations (hkl → motor angles), with
   diffraction modes controlling which stages are free, fixed, or coupled
-- Reciprocal-space trajectory planning
+- Wavelength, energy, d-spacing, and Q-vector conversions for X-ray
+  and neutron sources
+- Reciprocal-space operations: Q-vector magnitude, d-spacing, two-theta,
+  and trajectory planning along arbitrary paths in reciprocal space
 
 .. toctree::
    :hidden:
@@ -37,6 +49,7 @@ libraries are required.  It provides:
    direct-lattice
    problem1
    problem2
+   fourcv_alignment_howto
 
 .. icons: https://fonts.google.com/icons
 
@@ -86,7 +99,7 @@ libraries are required.  It provides:
 Background
 ----------
 
-.. grid:: 3
+.. grid:: 2
 
    .. grid-item-card:: :material-outlined:`functions;3em` Direct Lattice
       :link: direct-lattice
@@ -106,6 +119,13 @@ Background
 
       Coordinate conventions and B/U/UB matrix derivation following
       You (1999) and Busing & Levy (1967).
+
+   .. grid-item-card:: :material-outlined:`align_horizontal_center;3em` Alignment How-to
+      :link: fourcv_alignment_howto
+      :link-type: doc
+
+      Step-by-step crystal alignment on a four-circle diffractometer,
+      with a real sapphire example from APS 7-ID-C.
 
 About
 -----

--- a/docs/source/problem1.md
+++ b/docs/source/problem1.md
@@ -1,78 +1,77 @@
-# Our equipment
+# Case Study: Describing a Diffractometer
 
-We have a piece of equipment we'll use to examine an object.  The equipment will rotate the object in a 3-D space.  The equipment will also position a detector for our observations.
+This case study presents the diffractometer geometry problem that started the
+`ad_hoc_diffractometer` project.  The equipment described here is a six-circle
+diffractometer matching the You (1999) psic geometry; the analysis leads
+directly to the {mod}`~ad_hoc_diffractometer.factories` factory functions and
+the {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer` class.
+
+For a full analysis of how this geometry maps to the You (1999) convention,
+see [You (1999) Geometry](problem2.md).
+
+---
+
+## The equipment
+
+We have a piece of mechanical equipment consisting of rotary stages only
+(no translational stages).  The rotational axes of all stages ideally
+coincide at a single point of intersection — the sample position.  In
+practice, engineering tolerances cause this point to expand into a small
+3-D volume known as the *sphere of confusion*.
+
+The equipment rotates the sample in three-dimensional space and positions a
+detector to observe the scattered radiation.  All stage angles are described
+at their zero-degree positions.
 
 ## Reference frame
 
-We'll describe our reference frame for now with reference only to the floor.
+The reference frame is defined relative to the floor:
 
-- vertical: The positive vertical direction is normal to the plane of the floor
-  and points out of the floor.
-- longitudinal: The positive longitudinal direction is along our line of sight
-  towards the equipment and normal to the vertical direction.
-- lateral: The lateral direction is normal to both the vertical and
-  longitudinal directions, which positive direction is to our left.
+- **vertical**: positive direction is normal to the floor, pointing upward.
+- **longitudinal**: positive direction is along the line of sight toward the
+  equipment, normal to the vertical.
+- **lateral**: positive direction is normal to both vertical and longitudinal,
+  pointing to our left when facing the equipment.
 
-We can see the equipment by looking in the positive longitudinal direction,
-normal to the lateral-vertical plane.
+## Equipment description
 
-## Equipment Description
+The equipment consists of two independent stage stacks that share a common
+axis at their base.
 
-There is a piece of mechanical equipment consisting of various rotary stages.
-No translational stages are involved. The rotational axes of all stages coincide
-ideally at a single point of intersection in a cartesian space. The object to be
-examined is mounted at this point of intersection.
+**Stack 1 — detector stack** (2 stages)
 
-In practice, due to engineering precision, this point of intersection devolves
-into a 3-D volume termed a "sphere of confusion".
+- Stage 1 (base)
+  - Axis of rotation: vertical
+  - Sign of rotation: right-handed (consistent with coordinate system)
+- Stage 2 (sits on stage 1)
+  - Axis of rotation: lateral
+  - Positive rotation: from longitudinal toward vertical
+  - The detector is mounted on a long radial arm pointing at the sample
 
-The axes and sign for each of the rotary stages will be described when all
-stages are at their 0 degree positions.
+**Stack 2 — sample stack** (4 stages)
 
-In its default orientation, with each axis at its 0 degree position, the
-equipment can be subdivided into two independent stacks of stages.
+- Stage 1 (base)
+  - Axis of rotation: vertical, colinear with stack 1 stage 1
+  - Sign of rotation: same as stack 1 stage 1
+- Stage 2 (sits on stage 1)
+  - Axis of rotation: lateral
+  - Sign of rotation: same as stack 1 stage 2
+- Stage 3 (sits on stage 2)
+  - Axis of rotation: longitudinal
+  - Sign of rotation: right-handed (consistent with coordinate system)
+- Stage 4 (sits on stage 3)
+  - Axis of rotation: vertical
+  - Sign of rotation: right-handed (consistent with coordinate system)
 
-The stack 1 sits on the floor and has two rotary stages.
+## Questions
 
-- Stack 1
-  - sits on the floor
-  - stage 1
-    - axis of rotation in the vertical direction
-    - sign of motion consistent with coordinate system
-  - stage 2
-    - sits on stage 1
-    - axis of rotation in the lateral direction
-    - positive rotation (from the 0 degree position): positive longitudinal
-      towards positive vertical
-    - our detector is mounted on a long arm radial from this stage looking at the point of intersection
--Stack 2
-  - sits on the floor
-  - stage 1
-    - axis of rotation in the vertical direction
-    - axis is colinear with stack 1 stage 1
-    - same sign of motion
-  - stage 2
-    - sits on stage 1
-    - axis of rotation in the lateral direction
-    - same sign of motion as stack 1 stage 2
-  - stage 3
-    - sits on stage 2
-    - axis of rotation in the longitudinal direction
-    - sign of motion consistent with coordinate system
-  - stage 4
-    - sits on stage 3
-    - axis of rotation in the vertical direction
-    - sign of motion consistent with coordinate system
+1. Assign basis vectors (xHat, yHat, zHat) to each axis of the reference
+   frame.  Describe the orientation of each stack and stage in terms of these
+   basis vectors, including the sign of rotation.  Describe the steps to
+   compute the orientation matrix U.
 
-## Problem 1
+2. Is it possible to make different assignments of the basis vectors?  What
+   are the resulting stage orientation vectors?  How does the U matrix differ?
 
-- Assign basis vectors (xHat, yHat, zHat) to each of the axes in our reference frame.
-- Describe the orientation of each stack and stage in terms of these basis
-  vectors, including the sign of rotation.
-- Describe the steps to compute orientation matrix, U.
-
-## Problem 2
-
-- Is it possible to make different assignments of the basis vectors?
-- What are the stage orientation vectors?
-- How is the U matrix different?
+The answers to both questions are worked out in [You (1999) Geometry](problem2.md),
+which shows how this equipment maps exactly to the six-circle psic geometry.

--- a/docs/source/problem2.md
+++ b/docs/source/problem2.md
@@ -1,155 +1,161 @@
-# Diffractometer with Specified Reference Frame
+# You (1999) Geometry — Coordinate Convention and UB Matrix
 
-Given the equipment described in problem1.md, I now wish to use it with a different choice of basis vectors.  In this description:
+This page analyses the [case study diffractometer](problem1.md) using the
+You (1999) coordinate convention and derives the B, U, and UB matrices used
+throughout `ad_hoc_diffractometer`.
 
-- xHat: vertical
-- yHat: longitudinal
-- zHat: lateral
+**Reference:** H. You, *J. Appl. Cryst.* **32**, 614–623 (1999).
+DOI: [10.1107/S0021889899001223](https://doi.org/10.1107/S0021889899001223)
 
-The sample will be a single crystal with the usual lattice constants: a, b, c, alpha, beta, gamma
+---
 
-The incident monochromatic radiation will have wavelength lambda
+## Basis vector assignment
 
-## Directions:
+The You (1999) convention assigns:
 
-- Compare the geometry with this [article](https://doi.org/10.1107/S0021889899001223): You (1999) J Appl Cryst 32, 614-623.
+- **xHat**: vertical (along the mu and nu rotation axes)
+- **yHat**: longitudinal (along the incoming beam direction)
+- **zHat**: lateral
 
-## Analysis
+This is a valid right-handed system: xHat × yHat = zHat.
+From You (1999) §2: *"the x axis is defined along the vertical mu and nu
+axes and the y axis is defined along the incoming beam direction."*
 
-### Basis Vector Assignment
+## Correspondence with You (1999)
 
-The basis vectors specified here differ from those chosen in problem1.md.  The
-new assignment is:
+The You (1999) paper describes a 4S+2D six-circle geometry: four
+sample-orienting stages (mu, eta, chi, phi) and two detector stages (nu,
+delta).  This matches the case study equipment exactly.
 
-- xHat: vertical
-- yHat: longitudinal (along the incoming beam direction)
-- zHat: lateral
+Using **R** to denote a rotation matrix whose invariant axis is identified
+by a 1 on the diagonal:
 
-This is a valid right-handed system: xHat x yHat = zHat (vertical x longitudinal
-= lateral).  This is the same coordinate convention used by You (1999).  From
-section 2 of that paper: "the x axis is defined along the vertical mu and nu
-axes and the y axis is defined along the incoming beam direction."
+- **R xHat**: 1 at position [1,1] — rotation about the vertical axis
+- **R yHat**: 1 at position [2,2] — rotation about the longitudinal axis
+- **R zHat**: 1 at position [3,3] — rotation about the lateral axis
 
-### Correspondence with You (1999)
+Right-handed rotation places +sin below the diagonal; left-handed rotation
+(equivalently, right-handed rotation about the negated axis) places +sin
+above the diagonal.
 
-The You (1999) paper describes a 4S+2D six-circle diffractometer: four
-sample-orienting stages and two detector stages.  This matches our equipment
-exactly (S2-1 through S2-4 for the sample stack, S1-1 and S1-2 for the detector
-stack).  DOI: 10.1107/S0021889899001223
-
-Using R to denote the reference rotation matrix with 1 on the diagonal identifying
-the invariant axis:
-
-- R xHat: 1 at position [1,1], rotation about the vertical axis
-- R yHat: 1 at position [2,2], rotation about the longitudinal axis
-- R zHat: 1 at position [3,3], rotation about the lateral axis
-
-Right-handed rotation uses +sin below the diagonal; left-handed (equivalently,
-rotation about the negated axis) uses -sin below the diagonal, i.e. +sin above.
-
-The rotation matrices in You (1999) (equations 5, 7, 8) correspond to our stages
-as follows:
-
-| You angle | You matrix | Our stage | Physical axis | Axis vector |
-|-----------|------------|-----------|---------------|-------------|
-| mu        | U          | S2-1      | vertical      | +xHat       |
-| eta       | X          | S2-2      | lateral       | -zHat       |
-| chi       | H          | S2-3      | longitudinal  | +yHat       |
-| phi       | M          | S2-4      | lateral       | -zHat       |
-| nu        | P          | S1-1      | vertical      | +xHat       |
-| delta     | D          | S1-2      | lateral       | -zHat       |
+| You angle | You matrix | Stage | Physical axis | Axis vector |
+|-----------|------------|-------|---------------|-------------|
+| mu        | U          | S2-1  | vertical      | +xHat       |
+| eta       | X          | S2-2  | lateral       | −zHat       |
+| chi       | H          | S2-3  | longitudinal  | +yHat       |
+| phi       | M          | S2-4  | lateral       | −zHat       |
+| nu        | P          | S1-1  | vertical      | +xHat       |
+| delta     | D          | S1-2  | lateral       | −zHat       |
 
 Notes:
-- mu and nu share the same vertical axis (+xHat) and the same right-handed sense
-  of rotation.  Their rotation axes are colinear; the stages are mechanically
-  independent.
-- eta, phi, and delta share the same lateral axis (-zHat) and the same
-  left-handed sense of rotation.
-- chi is the only stage with a longitudinal axis (+yHat), with right-handed
+
+- mu and nu share a colinear vertical axis (+xHat) with the same
+  right-handed sense of rotation; the stages are mechanically independent.
+- eta, phi, and delta share the lateral axis (−zHat) with left-handed
   rotation.
+- chi is the only stage with a longitudinal axis (+yHat), right-handed.
 
-### Left-Handed Angles and Sign Convention
+## Sign convention
 
-A left-handed angle about an axis is equivalent to a right-handed angle of
-opposite sign about the same axis, or equivalently, a right-handed angle of the
-same sign about the negated axis:
+A left-handed rotation about an axis is equivalent to a right-handed
+rotation about the negated axis:
 
-    R_left-handed(+nHat, theta) = R_right-handed(-nHat, theta)
-                                 = R_right-handed(+nHat, -theta)
+```
+R_left-handed(+nHat, θ) = R_right-handed(−nHat, θ)
+                         = R_right-handed(+nHat, −θ)
+```
 
-For stages where You (1999) uses a left-handed convention (eta, phi, delta), the
-signed axis vector is given as -zHat rather than +zHat.  The physical rotation
-axes are the same; only the sign convention for positive rotation differs.
+For stages where You (1999) uses a left-handed convention (eta, phi,
+delta), the signed axis vector is −zHat rather than +zHat.  The physical
+rotation axes are the same; only the sign convention for positive rotation
+differs.
 
-### Crystallography Connection and Common Naming
+## The B, U, and UB matrices
 
-The introduction of lattice constants a, b, c, alpha, beta, gamma and wavelength
-lambda sets up the UB matrix formalism of Busing & Levy (1967), Acta Cryst. 22,
-457-464.
+The introduction of lattice constants a, b, c, α, β, γ and a fixed
+wavelength λ sets up the UB matrix formalism of Busing & Levy (1967).
 
-#### The B matrix
+### B matrix
 
-Busing & Levy define the B matrix (their equation 3) to transform Miller indices
-h = (h,k,l) to Cartesian coordinates in the crystal frame:
+The B matrix (Busing & Levy 1967, eq. 3) transforms Miller indices
+**h** = (h, k, l)ᵀ to the scattering vector in Cartesian crystal-frame
+coordinates:
 
-    hc = B h
+```
+Q_c = B h
+```
 
-B is constructed from the reciprocal lattice parameters derived from a, b, c,
-alpha, beta, gamma.  B is not in general orthonormal (the crystal need not be
-cubic).
+B is constructed from the reciprocal lattice parameters derived from
+a, b, c, α, β, γ.  B is not in general orthonormal.
+See [Direct Lattice](direct-lattice.md) for the explicit construction.
 
-#### The U matrix
+### U matrix
 
-Busing & Levy define U (their equation 4) as the orthogonal matrix relating the
-phi-axis system (attached to the innermost sample stage) to the crystal Cartesian
-frame:
+The U matrix (Busing & Levy 1967, eq. 4) is the orthogonal matrix relating
+the phi-axis frame (attached to the innermost sample stage) to the crystal
+Cartesian frame:
 
-    h_phi = U hc
+```
+h_phi = U Q_c = U B h
+```
 
-U is orthonormal and corrects for the misalignment between the crystal axes and
-the diffractometer axes when all motor angles are zero.  Busing & Levy call U the
-"orientation matrix", as do most other sources.  However, Walko (2016) explicitly
-notes that UB is also sometimes called the "orientation matrix", making the term
-ambiguous.  To avoid this ambiguity entirely, we do not use "orientation matrix"
-at all.  We adopt the following unambiguous names:
+U corrects for the misalignment between the crystal axes and the
+diffractometer axes when all motor angles are zero.
 
-| Symbol | Name we use | Meaning                                                     |
-|--------|-------------|-------------------------------------------------------------|
-| B      | B matrix    | maps Miller indices to crystal Cartesian coords;            |
-|        |             | encodes a, b, c, alpha, beta, gamma                         |
-| U      | U matrix    | orthonormal; relates crystal Cartesian frame to the         |
-|        |             | phi-axis (innermost sample stage) frame                     |
-| UB     | UB matrix   | maps Miller indices directly to the phi-axis frame;         |
-|        |             | can be determined as a unit from three reflections          |
+To avoid the ambiguity noted by Walko (2016) — where both U and UB are
+sometimes called the "orientation matrix" — this package uses the
+following unambiguous names:
 
-Busing & Levy treat UB as a single practical entity (their equations 29-31):
+| Symbol | Name | Meaning |
+|--------|------|---------|
+| B | B matrix | Maps Miller indices to crystal Cartesian coords; encodes a, b, c, α, β, γ |
+| U | U matrix | Orthonormal; relates crystal Cartesian frame to the phi-axis frame |
+| UB | UB matrix | Maps Miller indices directly to the phi-axis frame; determinable from reflections alone |
 
-    UB = Hc H^{-1}
+### UB as a practical entity
 
-where Hc and H are matrices of observed and indexed reflection vectors
-respectively.  This allows UB to be determined even when lattice parameters are
-unknown.
+Busing & Levy treat UB as a single practical entity (eqs. 29–31):
 
-#### Full diffraction equation
+```
+UB = Hc H⁻¹
+```
 
-The full diffraction equation from You (1999) (equations 10-11) relates Miller
-indices h = (h, k, l)^T to the sample stack rotation and the detector position
-in the laboratory frame:
+where **Hc** and **H** are matrices of observed and indexed reflection
+vectors respectively.  This allows UB to be determined even when lattice
+parameters are unknown.
 
-    h^M = M H X U_mu . UB . h
+## Full diffraction equation
 
-where:
-- UB   is the UB matrix (U times B, as defined above)
-- U_mu, X, H, M are the motor rotation matrices for mu, eta, chi, phi
-- h^M  is the diffraction vector in the laboratory frame
+The full diffraction equation (You 1999, eqs. 10–11) relates Miller indices
+**h** to the sample rotation matrices and the detector position:
 
-The detector position is determined separately by the detector stack:
+```
+h^M = M H X U_mu · UB · h
+```
 
-    kf = k P D kf0
+where U_mu, X, H, M are the motor rotation matrices for mu, eta, chi, phi
+respectively, and **h**^M is the diffraction vector in the laboratory frame.
 
-where D and P are the motor rotation matrices for delta and nu respectively,
-k = 2*pi/lambda is the wave number, and kf0 is the forward beam direction.
+The detector position is determined by:
 
-Note: You (1999) uses the symbol U for both the mu motor rotation matrix and
-for the U matrix.  We use U_mu for the mu motor rotation to avoid ambiguity
-with U (the U matrix).
+```
+kf = k P D kf0
+```
+
+where D and P are the rotation matrices for delta and nu, k = 2π/λ is the
+wave number, and **kf0** is the forward beam direction.
+
+```{note}
+You (1999) uses the symbol U for both the mu motor rotation matrix and the
+U (orientation) matrix.  This package uses U_mu for the mu motor rotation
+to avoid ambiguity.
+```
+
+## References
+
+- W.R. Busing & H.A. Levy, *Acta Cryst.* **22**, 457–464 (1967).
+  DOI: [10.1107/S0365110X67000970](https://doi.org/10.1107/S0365110X67000970)
+- H. You, *J. Appl. Cryst.* **32**, 614–623 (1999).
+  DOI: [10.1107/S0021889899001223](https://doi.org/10.1107/S0021889899001223)
+- D.A. Walko, *Reference Module in Materials Science and Materials
+  Engineering*, Elsevier (2016).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "ad_hoc_diffractometer"
 dynamic = ["version"]
-description = "Multi-circle diffractometer geometry and related calculations"
+description = "Operating multi-circle diffractometers in reciprocal space"
 authors = [{ name = "Pete Jemian", email = "prjemian+chewacla@gmail.com" }]
 maintainers = [{ name = "Pete Jemian", email = "prjemian+chewacla@gmail.com" }]
 requires-python = ">=3.10"
@@ -36,8 +36,8 @@ dev = [
     "scipy",
 ]
 doc = [
-    "myst-parser",
-    "nbsphinx",
+    "matplotlib",
+    "myst-nb",
     "pydata-sphinx-theme",
     "sphinx",
     "sphinx-autoapi",


### PR DESCRIPTION
- closes #95

## Summary

### Notebook execution
- Switch from `nbsphinx` (requires pandoc) to `myst-nb` (parses notebook
  markdown cells natively as MyST, no pandoc required)
- Enable notebook execution in docs build (`nb_execution_mode = 'auto'`)
- Drop pandoc from CI `apt-get`; keep graphviz
- Add `matplotlib` to `[doc]` dependencies
- Add download note (MyST admonition) to first notebook cell

### Package description update
- `pyproject.toml`: *"Operating multi-circle diffractometers in reciprocal space"*
- `index.rst` and `README.md`: same reframe; monochromatic radiation
  presented as a fundamental assumption (note block), not a feature bullet

### `direct-lattice.md` — full rewrite
- Remove Q&A transcript framing entirely
- Expository prose with LaTeX equations via MathJax
- Sections: Lattice vectors, Unit cell volume, Reciprocal lattice, B matrix
- Cross-links to `lattice` module; BL1967 reference with DOI

### `problem1.md` — reframed as case study
- Title: *"Case Study: Describing a Diffractometer"*
- Intro links to `problem2.md` and factory functions
- Fix `-Stack 2` typo; restructure list with bold headings
- All original content preserved

### `problem2.md` — reframed as background reference
- Title: *"You (1999) Geometry — Coordinate Convention and UB Matrix"*
- Proper intro with reference and DOI
- Fenced code blocks, improved section structure
- References section with DOIs for all three key papers

### `index.rst`
- `fourcv_alignment_howto` added to hidden toctree
- Background grid expanded to 2-column with Alignment How-to card
- Radiation and reciprocal-space feature bullets refined

Contributed by: OpenCode (argo/claudesonnet46)