### PR TITLE
docs: hide module-path prefix in AutoAPI signatures

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,13 @@
+/* In AutoAPI module pages, the "Module Contents" section shows inline
+   class/function signatures with their fully-qualified module prefix
+   (sig-prename), e.g. "ad_hoc_diffractometer.geometry." before
+   "AdHocDiffractometer".  The full import path is already shown in the
+   Import: container on each object's own page, so the prefix is
+   redundant here.
+
+   Hide sig-prename globally — the short name alone is unambiguous in
+   context, and the Import: line provides the canonical path.
+*/
+.sig-prename {
+    display: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,6 +165,7 @@ napoleon_use_rtype = True
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 
 html_theme_options = {
     "github_url": "https://github.com/prjemian/ad_hoc_diffractometer",


### PR DESCRIPTION
- closes #102

## Summary

AutoAPI module pages showed fully-qualified class/function signatures
like `ad_hoc_diffractometer.geometry.AdHocDiffractometer(...)` in the
**Module Contents** section because Sphinx automatically prepends the
module context to short-name directives.

**Fix:** `docs/source/_static/custom.css` hides `.sig-prename` globally.
The short name (`AdHocDiffractometer`) is unambiguous in context; the
full import path is already shown in the `Import:` container on each
object's own page.

Registered via `html_css_files` in `conf.py`.

Contributed by: OpenCode (argo/claudesonnet46)