### PR TITLE
docs: batch quick-doc fixes for issues #100 #101 #103 #105 #107 #109 #110 #112 #113

### DIFF
--- a/docs/source/_templates/autoapi/python/module.rst
+++ b/docs/source/_templates/autoapi/python/module.rst
@@ -10,7 +10,7 @@
    Import: ``{{ obj.id }}``
 
    {% if obj.docstring %}
-   {{ obj.docstring|indent(3) }}
+   {{ obj.docstring|strip_module_header|indent(3) }}
    {% endif %}
 
       {% block submodules %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,10 +135,26 @@ def _tilde_type_str(s: str) -> str:
     )
 
 
+def _strip_module_header(docstring: str) -> str:
+    """Remove the leading '<filename>.py — <summary>' line from module docstrings.
+
+    The filename stub is redundant on the AutoAPI module page where the page
+    title already shows the module short name.  Strip the first line if it
+    matches the pattern ``<word>.py — <rest>``.
+    """
+    import re
+
+    lines = docstring.split("\n", 1)
+    if lines and re.match(r"^\S+\.py\s*[—–-]\s*", lines[0]):
+        return lines[1].lstrip("\n") if len(lines) > 1 else ""
+    return docstring
+
+
 def _prepare_jinja_env(jinja_env) -> None:
     """Register custom Jinja2 filters for autoapi templates."""
     jinja_env.filters["shorten_type"] = _shorten_type_str
     jinja_env.filters["tilde_type"] = _tilde_type_str
+    jinja_env.filters["strip_module_header"] = _strip_module_header
 
 
 def setup(app):

--- a/src/ad_hoc_diffractometer/axes.py
+++ b/src/ad_hoc_diffractometer/axes.py
@@ -5,16 +5,20 @@ axes.py — caller-facing axis notation and physical direction mapping.
 
 Provides a human-readable string notation for signed rotation axes:
 
-    "+x"  ->  +XHAT  (right-handed rotation about the x-axis)
-    "-x"  ->  -XHAT  (left-handed rotation about the x-axis)
-    "+y"  ->  +YHAT
-    "-y"  ->  -YHAT
-    "+z"  ->  +ZHAT
-    "-z"  ->  -ZHAT
+- ``"+x"`` → +XHAT (right-handed rotation about the x-axis)
+- ``"-x"`` → −XHAT (left-handed rotation about the x-axis)
+- ``"+y"`` → +YHAT, ``"-y"`` → −YHAT
+- ``"+z"`` → +ZHAT, ``"-z"`` → −ZHAT
 
-Physical direction names ("vertical", "longitudinal", "lateral") are also
-accepted and resolved against a caller-supplied basis dict that maps each
-name to one of the three signed axis vectors.
+The standard Cartesian basis vectors are:
+
+- :data:`~ad_hoc_diffractometer.constants.XHAT` (+x)
+- :data:`~ad_hoc_diffractometer.constants.YHAT` (+y)
+- :data:`~ad_hoc_diffractometer.constants.ZHAT` (+z)
+
+Physical direction names (``"vertical"``, ``"longitudinal"``, ``"lateral"``)
+are also accepted and resolved against a caller-supplied basis dict that maps
+each name to one of the three signed axis vectors.
 
 For diffractometer geometries with tilted axes (e.g. kappa), kappa_axis()
 computes the axis vector from the kappa angle alpha and the basis dict.

--- a/src/ad_hoc_diffractometer/constants.py
+++ b/src/ad_hoc_diffractometer/constants.py
@@ -6,10 +6,11 @@ constants.py — shared Cartesian basis vectors.
 These are the internal numpy representations used throughout the package.
 The caller-facing notation (+x, -z, etc.) is handled in axes.py.
 
-Convention follows You (1999):
-    XHAT = vertical (out of floor)
-    YHAT = longitudinal (along beam / toward equipment)
-    ZHAT = lateral (to our left)
+Default coordinate convention (You 1999):
+
+- XHAT (+x) — vertical (out of the floor)
+- YHAT (+y) — longitudinal (along the beam, toward equipment)
+- ZHAT (+z) — lateral (to our left when facing equipment)
 """
 
 import logging
@@ -20,6 +21,18 @@ logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 
+#: Unit vector along the +x axis.
+#: In the You (1999) convention this is the **vertical** direction (out of the floor).
+#: In the Busing & Levy (1967) convention this is the **lateral** direction.
 XHAT = np.array([1.0, 0.0, 0.0])
+
+#: Unit vector along the +y axis.
+#: **Longitudinal** direction (along the beam, toward the equipment) in both
+#: the You (1999) and Busing & Levy (1967) conventions.
 YHAT = np.array([0.0, 1.0, 0.0])
+
+#: Unit vector along the +z axis.
+#: In the You (1999) convention this is the **lateral** direction (to our left
+#: when facing the equipment).
+#: In the Busing & Levy (1967) convention this is the **vertical** direction.
 ZHAT = np.array([0.0, 0.0, 1.0])

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -356,7 +356,15 @@ def make_geometry(name: str, **kwargs) -> AdHocDiffractometer:
 # Shared basis definitions
 # ---------------------------------------------------------------------------
 
-# You (1999) convention: xHat=vertical, yHat=longitudinal, zHat=lateral
+#: Basis vector dictionary for the You (1999) coordinate convention.
+#: Maps physical direction names to Cartesian unit vectors:
+#:
+#: - ``"vertical"`` → ``XHAT`` (+x, out of the floor)
+#: - ``"longitudinal"`` → ``YHAT`` (+y, along the beam)
+#: - ``"lateral"`` → ``ZHAT`` (+z, to our left facing the equipment)
+#:
+#: This is the default basis used by :func:`psic`, :func:`sixc`,
+#: :func:`kappa6c`, :func:`zaxis`, :func:`s2d2`, and :func:`fivec`.
 BASIS_YOU = {
     "vertical": XHAT,
     "longitudinal": YHAT,
@@ -365,7 +373,14 @@ BASIS_YOU = {
 #: Alias for backward compatibility.
 _BASIS_YOU = BASIS_YOU
 
-# Busing & Levy (1967) convention: xHat=lateral, yHat=longitudinal, zHat=vertical
+#: Basis vector dictionary for the Busing & Levy (1967) coordinate convention.
+#: Maps physical direction names to Cartesian unit vectors:
+#:
+#: - ``"lateral"`` → +x
+#: - ``"longitudinal"`` → +y (along the beam)
+#: - ``"vertical"`` → +z (out of the floor)
+#:
+#: Used by :func:`fourcv`, :func:`fourch`, :func:`kappa4cv`, and :func:`kappa4ch`.
 BASIS_BL = {
     "lateral": np.array([1.0, 0.0, 0.0]),
     "longitudinal": np.array([0.0, 1.0, 0.0]),

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -279,10 +279,31 @@ class Lattice:
     """
     A crystal lattice described by up to six parameters (a, b, c, α, β, γ).
 
-    The crystal system is deduced automatically from the parameters supplied.
-    Missing parameters are filled in according to the symmetry constraints of
-    the deduced system.  The default (no arguments) is a cubic lattice with
-    a = 1 Å.
+    The crystal system is deduced automatically from the **minimum set** of
+    parameters supplied.  Missing parameters are filled in according to the
+    symmetry constraints of the deduced system.  The default (no arguments)
+    is a cubic lattice with a = 1 Å.
+
+    .. list-table:: Minimum parameters by crystal system
+       :header-rows: 1
+       :widths: 20 50
+
+       * - System
+         - Minimum parameters required
+       * - Cubic
+         - ``a``
+       * - Tetragonal
+         - ``a``, ``c``
+       * - Hexagonal
+         - ``a``, ``c``, ``gamma=120`` *(must be explicit)*
+       * - Trigonal
+         - ``a``, ``alpha`` *(alpha ≠ 90)*
+       * - Orthorhombic
+         - ``a``, ``b``, ``c``
+       * - Monoclinic
+         - ``a``, ``b``, ``c``, ``beta``
+       * - Triclinic
+         - ``a``, ``b``, ``c``, ``alpha``, ``beta``, ``gamma``
 
     All parameters are validated on construction and on every change:
       - Lengths (a, b, c) must be strictly positive.

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -9,19 +9,19 @@ first-class concern of the geometry description.
 
 Classes
 -------
-DiffractionMode
+:class:`DiffractionMode`
     Abstract base class for all modes.  Declares which stages are
     constrained (frozen) and which remain free, plus optional cut-points
     for branch selection.
 
-FixedAngleMode
+:class:`FixedAngleMode`
     Constrains one named stage to a fixed angle value.
 
-BisectingMode
+:class:`BisectingMode`
     Bisecting geometry: omega = ttheta/2 (half the detector angle).
     For psic-family geometries this means eta = delta/2.
 
-ModeDict
+:class:`ModeDict`
     An ordered, guarded dict of named modes.  Validates that all entries
     are DiffractionMode instances; prevents inserting non-Mode values.
 
@@ -40,7 +40,6 @@ References
 Busing & Levy, Acta Cryst. 22, 457-464 (1967).
 You, J. Appl. Cryst. 32, 614-623 (1999).
 Walko, Ref. Module Mater. Sci. Mater. Eng. (2016), section 3.3.
-SPEC #G0, #G4 lines — references/2020-12-13-fourcc-alignment-7-id-c/spec_G_lines.md
 """
 
 from __future__ import annotations

--- a/src/ad_hoc_diffractometer/radiation.py
+++ b/src/ad_hoc_diffractometer/radiation.py
@@ -28,7 +28,8 @@ HC_KEV_ANGSTROM : float
     hc = 12.398 419 843 320 026 keV·Å.  Exact (NIST CODATA 2022).
 
 HC_KEV_ANGSTROM_UNCERTAINTY : float
-    0.0 — exact constant.
+    0.0 — exactly zero.  The 2019 SI redefinition fixed both *h* and *c*
+    exactly, so *hc* has no uncertainty by definition.
 
 NEUTRON_MEV_ANGSTROM2 : float
     h²/(2 m_n) = 81.804 210 235 2 meV·Å² (NIST CODATA 2022).
@@ -101,7 +102,11 @@ import math
 HC_KEV_ANGSTROM: float = 12.398419843320026
 
 #: Uncertainty of :data:`HC_KEV_ANGSTROM` in keV·Å.
-#: Zero — this constant is exact.
+#: Exactly **0.0** — not a placeholder.  The 2019 redefinition of the SI
+#: fixed the numerical values of Planck's constant *h* and the speed of light
+#: *c* exactly; their product *hc* therefore has zero uncertainty by
+#: definition.  Reference: BIPM SI Brochure, 9th edition (2019);
+#: NIST CODATA 2022.
 HC_KEV_ANGSTROM_UNCERTAINTY: float = 0.0
 
 #: h²/(2 m_n) = 81.804 210 235 2 meV·Å².

--- a/src/ad_hoc_diffractometer/sample.py
+++ b/src/ad_hoc_diffractometer/sample.py
@@ -170,9 +170,8 @@ class Sample:
 
     Notes
     -----
-    U and UB are set by the U/UB computation routines (Priority 2 items
-    #5 and #6).  They are stored here so that each sample carries its
-    own orientation independently.
+    U and UB are set by the U/UB computation routines.  They are stored
+    here so that each sample carries its own orientation independently.
     """
 
     def __init__(

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -5,18 +5,18 @@ scan.py — Reciprocal-space trajectory computation.
 
 Functions
 ---------
-``hkl_trajectory(geometry, trajectory, n_points, solution_key=NEAREST_ANGLES)``
+:func:`hkl_trajectory` ``(geometry, trajectory, n_points, solution_key=NEAREST_ANGLES)``
     Compute motor-angle sequences along a specified reciprocal-space path.
 
-``psi_trajectory(geometry, h, k, l, psi_values, solution_key=NEAREST_ANGLES)``
+:func:`psi_trajectory` ``(geometry, h, k, l, psi_values, solution_key=NEAREST_ANGLES)``
     Compute motor-angle sequences for ψ (psi) rotation about the scattering
     vector Q while keeping the Bragg condition satisfied.
 
-``trajectory_plan(geometry, hkl_start, hkl_end, n_points, space="hkl", solution_key=NEAREST_ANGLES)``
+:func:`trajectory_plan` ``(geometry, hkl_start, hkl_end, n_points, space="hkl", solution_key=NEAREST_ANGLES)``
     Plan a motor-angle path between two reciprocal-space points, flagging
     limit violations and inaccessible regions.
 
-``NEAREST_ANGLES``
+:data:`NEAREST_ANGLES`
     Built-in solution-key callable: selects the candidate solution whose
     motor angles are closest (in least-squares sense) to the previous point.
     Suppresses branch-flip discontinuities across a trajectory.
@@ -27,9 +27,9 @@ These functions *compute* trajectories; they do not move motors or
 communicate with hardware.  A future execution layer (not yet planned)
 will consume these outputs to drive real diffractometers.
 
-The ordering instability of ``geometry.forward()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``forward()`` returns multiple solutions in seed-discovery order, which is
+The ordering instability of :meth:`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.forward`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:meth:`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.forward` returns multiple solutions in seed-discovery order, which is
 not reproducible and can switch between the positive-chi and negative-chi
 branches at adjacent trajectory points.  All three trajectory functions
 accept a ``solution_key`` parameter — a callable that scores each candidate


### PR DESCRIPTION
- closes #100
- closes #101
- closes #103
- closes #105
- closes #107
- closes #109
- closes #110
- closes #112
- closes #113

## Summary

| Issue | Change |
|---|---|
| #100 | `#:` doccomments on XHAT/YHAT/ZHAT (constants.py); BASIS_YOU/BASIS_BL (factories.py); expanded HC_KEV_ANGSTROM_UNCERTAINTY (radiation.py) |
| #101 | `_strip_module_header()` Jinja2 filter strips `<file>.py — <title>` from module docstrings; applied in module.rst template |
| #103 | Remove "Priority 2 items #5 and #6" from sample.py Notes |
| #105 | scan.py: `:func:` / `:data:` links in Functions section; `:meth:` link on `forward()` in ordering-instability heading and prose |
| #107 | axes.py: axis-notation block → bullet list; `:data:` cross-refs to XHAT/YHAT/ZHAT |
| #109 | constants.py: `Convention follows You (1999): ...` indented block → bullet list |
| #110 | lattice.py: `list-table` of minimum parameters by crystal system added to `Lattice` class docstring |
| #112 | mode.py: plain class names in Classes section → `:class:` cross-refs; remove private file path from References |
| #113 | radiation.py: explain why HC_KEV_ANGSTROM_UNCERTAINTY is exactly 0.0 (2019 SI redefinition); cite BIPM SI Brochure 9th ed and NIST CODATA 2022 |

All 1195 tests pass at 100% coverage. Zero doc build warnings.

Contributed by: OpenCode (argo/claudesonnet46)