### PR TITLE
api: expose wh() and pa() as public top-level functions

### DIFF
--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -48,6 +48,8 @@ from .factories import sixc
 from .factories import zaxis
 from .forward import compute_forward
 from .geometry import AdHocDiffractometer
+from .geometry import pa
+from .geometry import wh
 from .lattice import CRYSTAL_SYSTEMS
 from .lattice import Lattice
 from .lattice import b_matrix
@@ -120,6 +122,8 @@ __all__ = [
     "Stage",
     # geometry
     "AdHocDiffractometer",
+    "pa",
+    "wh",
     "Reflection",
     "ReflectionList",
     "Sample",

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -2088,3 +2088,90 @@ class AdHocDiffractometer:
                 del geom.samples._data[n]
 
         return geom
+
+
+# ---------------------------------------------------------------------------
+# Public top-level convenience functions (SPEC-familiar status commands)
+# ---------------------------------------------------------------------------
+
+
+def wh(geometry: AdHocDiffractometer, print: bool = True) -> str:
+    """
+    Terse one-screen status for a diffractometer (the SPEC ``wh`` command).
+
+    Shows the current reciprocal-space position (H K L), azimuthal angle ψ,
+    wavelength, and a motor-angle table with SPEC-style column names.
+    Graceful fallback text is shown for any field that cannot be computed
+    (e.g. no UB matrix or no wavelength set).
+
+    Equivalent to ``geometry.wh(print=print)``.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        The diffractometer to report on.
+    print : bool, optional
+        If ``True`` (default), the string is printed to stdout before
+        being returned.  Pass ``print=False`` to suppress output and
+        capture the string instead.
+
+    Returns
+    -------
+    str
+        Multi-line status string.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> g.wavelength = 1.5406
+    >>> out = ahd.wh(g, print=False)
+    >>> "Lambda" in out
+    True
+
+    See Also
+    --------
+    :func:`pa` : Verbose parameter listing.
+    :meth:`AdHocDiffractometer.wh` : Equivalent method on the geometry object.
+    """
+    return geometry.wh(print=print)
+
+
+def pa(geometry: AdHocDiffractometer, print: bool = True) -> str:
+    """
+    Verbose parameter listing for a diffractometer (the SPEC ``pa`` command).
+
+    Shows the geometry name, the two designated orienting reflections (if
+    set), lattice constants in real and reciprocal space, the azimuthal
+    reference vector, and the wavelength.
+
+    Equivalent to ``geometry.pa(print=print)``.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        The diffractometer to report on.
+    print : bool, optional
+        If ``True`` (default), the string is printed to stdout before
+        being returned.  Pass ``print=False`` to suppress output and
+        capture the string instead.
+
+    Returns
+    -------
+    str
+        Multi-line parameter string.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.fourcv()
+    >>> out = ahd.pa(g, print=False)
+    >>> "Geometry" in out
+    True
+
+    See Also
+    --------
+    :func:`wh` : Terse one-screen status.
+    :meth:`AdHocDiffractometer.pa` : Equivalent method on the geometry object.
+    """
+    return geometry.pa(print=print)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1183,6 +1183,64 @@ class TestPaMethod:
         assert "psic" in g.pa(print=False)
 
 
+class TestWhPaTopLevel:
+    """Tests for top-level ahd.wh() and ahd.pa() convenience functions."""
+
+    def test_wh_is_exported(self):
+        import ad_hoc_diffractometer as ahd
+
+        assert callable(ahd.wh)
+
+    def test_pa_is_exported(self):
+        import ad_hoc_diffractometer as ahd
+
+        assert callable(ahd.pa)
+
+    def test_wh_function_matches_method(self):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        assert ahd.wh(g, print=False) == g.wh(print=False)
+
+    def test_pa_function_matches_method(self):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        assert ahd.pa(g, print=False) == g.pa(print=False)
+
+    def test_wh_function_returns_str(self):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        assert isinstance(ahd.wh(g, print=False), str)
+
+    def test_pa_function_returns_str(self):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        assert isinstance(ahd.pa(g, print=False), str)
+
+    def test_wh_function_prints(self, capsys):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        ahd.wh(g)
+        assert "Lambda" in capsys.readouterr().out
+
+    def test_pa_function_prints(self, capsys):
+        import ad_hoc_diffractometer as ahd
+
+        g = ahd.fourcv()
+        g.wavelength = 1.5406
+        ahd.pa(g)
+        assert "Geometry" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # Geometry — additional branch coverage
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- closes #131

Add standalone \`wh(geometry)\` and \`pa(geometry)\` wrapper functions exported from \`ad_hoc_diffractometer\`:

\`\`\`python
import ad_hoc_diffractometer as ahd
g = ahd.fourcv()
g.wavelength = 1.5406
ahd.wh(g)   # terse: H K L, psi, wavelength, motor table
ahd.pa(g)   # verbose: geometry, lattice, reflections, UB
\`\`\`

Both functions delegate to the existing \`AdHocDiffractometer.wh()\` / \`.pa()\` methods. Docstrings reference SPEC equivalents. 8 new tests in \`TestWhPaTopLevel\`; 1203 tests total, 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)