### PR TITLE
docs: add serialization how-to guide (JSON + YAML)

### DIFF
--- a/docs/source/concepts.md
+++ b/docs/source/concepts.md
@@ -179,3 +179,15 @@ Two definitions of ψ appear in the literature:
   See {func}`~ad_hoc_diffractometer.psi_trajectory`.
 
 See {doc}`howto/trajectory`.
+
+---
+
+## Serialization
+
+The complete diffractometer state — geometry, wavelength, lattice, reflections,
+UB matrix, and all parameters — can be saved and restored via
+`to_dict()` / `from_dict()` on {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`.
+The dict contains only JSON-compatible types; save to JSON (stdlib) or YAML
+(`pyyaml`) without loss.
+
+See {doc}`howto/serialize`.

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -83,10 +83,17 @@ Stage
    and optional motor limits.
    See {class}`~ad_hoc_diffractometer.stage.Stage`.
 
+Serialization
+   The process of converting the complete diffractometer state to a Python
+   dict (via `to_dict()`) and restoring it (via `from_dict()`).  The dict
+   contains only JSON-compatible types and can be saved to JSON (stdlib) or
+   YAML (`pyyaml`).  All major classes support this round-trip.
+   See {doc}`howto/serialize`.
+
 Stack
    An ordered chain of stages in which each stage sits mechanically on the
    one below it (its parent).  The combined rotation matrix is the ordered
-   product of individual stage matrices, from the floor-mounted (outermost)
+   product of individual stage matrices, from the base-mounted (outermost)
    stage to the innermost.
 
 Two-theta

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -17,6 +17,7 @@ installed the package and are familiar with the
    modes
    trajectory
    refine_lattice
+   serialize
    fourcv_alignment_howto
 
 .. icons: https://fonts.google.com/icons
@@ -72,6 +73,13 @@ installed the package and are familiar with the
       Refine unit-cell parameters from measured Bragg peak positions using
       Busing & Levy (1967) least-squares or the Nelder-Mead simplex method,
       with and without crystal-system constraints.
+
+   .. grid-item-card:: :material-outlined:`save;3em` Save and Restore Configuration
+      :link: serialize
+      :link-type: doc
+
+      Save the complete diffractometer state to JSON or YAML and restore
+      it in a later session.
 
    .. grid-item-card:: :material-outlined:`align_horizontal_center;3em` Align a Crystal
       :link: fourcv_alignment_howto

--- a/docs/source/howto/serialize.md
+++ b/docs/source/howto/serialize.md
@@ -1,0 +1,157 @@
+(howto-serialize)=
+# Save and Restore a Diffractometer Configuration
+
+This guide shows how to save the complete state of a diffractometer to a
+file and restore it later.  The state includes the geometry, wavelength,
+sample lattice, orienting reflections, UB matrix, and all other parameters.
+
+## What is serialized
+
+`to_dict()` captures the full diffractometer state:
+
+- Geometry name, description, and basis
+- Wavelength, source type
+- All motor stage names and angles
+- Active diffraction mode and cut points
+- All samples: lattice parameters, reflections (with angles and wavelength),
+  orienting reflection designations (or0/or1), and UB matrix
+- Azimuthal reference, surface normal, inclination matrix
+- Detector geometry parameters (distance, tilt, offset)
+
+The resulting dict contains only JSON-compatible types (str, float, int,
+list, dict, None) — it can be round-tripped through JSON or YAML without
+loss.
+
+## Basic round-trip
+
+```python
+import ad_hoc_diffractometer as ahd
+
+# Set up a geometry
+g = ahd.fourcv()
+g.wavelength = 1.5406                       # Å  (Cu Kα)
+g.sample.lattice = ahd.Lattice(a=5.431)     # cubic silicon
+ahd.ub_identity(g.sample)
+
+g.sample.reflections.add(
+    "r1",
+    hkl=(0, 0, 4),
+    angles={"omega": 34.56, "chi": 90.0, "phi": 0.0, "ttheta": 69.13},
+)
+g.sample.reflections.setor0("r1")
+
+# Serialize to a dict
+d = g.to_dict()
+
+# Restore from the dict
+g2 = ahd.AdHocDiffractometer.from_dict(d)
+print(g2.name)          # fourcv
+print(g2.wavelength)    # 1.5406
+print(g2.sample.lattice.a)  # 5.431
+```
+
+## Save to a JSON file
+
+JSON is the simplest option — it requires only the Python standard library:
+
+```python
+import json
+
+# Save
+with open("diffractometer.json", "w") as f:
+    json.dump(g.to_dict(), f, indent=2)
+
+# Restore
+with open("diffractometer.json") as f:
+    g2 = ahd.AdHocDiffractometer.from_dict(json.load(f))
+```
+
+## Save to a YAML file
+
+YAML produces a more human-readable file.  It requires `pyyaml`
+(not installed automatically — run `pip install pyyaml`):
+
+```python
+try:
+    import yaml
+except ImportError:
+    raise ImportError("Install pyyaml: pip install pyyaml")
+
+# Save
+with open("diffractometer.yaml", "w") as f:
+    yaml.dump(g.to_dict(), f, default_flow_style=False, sort_keys=False)
+
+# Restore
+with open("diffractometer.yaml") as f:
+    g2 = ahd.AdHocDiffractometer.from_dict(yaml.safe_load(f))
+```
+
+## Verify a round-trip
+
+Check that the restored geometry matches the original:
+
+```python
+import numpy as np
+
+assert g2.name == g.name
+assert g2.wavelength == g.wavelength
+assert np.isclose(g2.sample.lattice.a, g.sample.lattice.a)
+assert list(g2.sample.reflections.keys()) == list(g.sample.reflections.keys())
+assert np.allclose(g2.sample.UB, g.sample.UB)
+print("Round-trip verified.")
+```
+
+## Serialize individual objects
+
+All major classes support `to_dict()` / `from_dict()` independently:
+
+```python
+from ad_hoc_diffractometer import Lattice, Sample
+
+# Lattice
+lat_dict = g.sample.lattice.to_dict()
+lat2 = Lattice.from_dict(lat_dict)
+
+# Sample (including reflections and UB)
+sample_dict = g.sample.to_dict()
+# sample2 = Sample.from_dict(sample_dict, parent=g)  # requires parent geometry
+```
+
+## Typical workflow
+
+A common pattern is to save the configuration after alignment and restore
+it at the start of the next session:
+
+```python
+import json
+import ad_hoc_diffractometer as ahd
+
+SESSION_FILE = "session_config.json"
+
+def save_session(geometry):
+    with open(SESSION_FILE, "w") as f:
+        json.dump(geometry.to_dict(), f, indent=2)
+    print(f"Session saved to {SESSION_FILE}")
+
+def restore_session():
+    with open(SESSION_FILE) as f:
+        return ahd.AdHocDiffractometer.from_dict(json.load(f))
+
+# End of session: save
+g = ahd.fourcv()
+# ... do alignment ...
+save_session(g)
+
+# Start of next session: restore
+g = restore_session()
+ahd.pa(g)   # verify the restored configuration
+```
+
+## See also
+
+- {meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.to_dict`
+- {meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.from_dict`
+- {class}`~ad_hoc_diffractometer.lattice.Lattice`
+- {class}`~ad_hoc_diffractometer.sample.Sample`
+- {func}`~ad_hoc_diffractometer.pa`
+- {doc}`orient`


### PR DESCRIPTION
- closes #132

## New how-to guide: Save and Restore a Diffractometer Configuration

`docs/source/howto/serialize.md` covers:

- **What is serialized** — complete state inventory (geometry, wavelength, lattice, reflections, UB, motor stages, modes, detector params, …)
- **Basic round-trip** — `to_dict()` / `from_dict()`
- **JSON file** (stdlib `json` — no extra dependency)
- **YAML file** (`pyyaml` — optional, with try/import pattern)
- **Round-trip verification** using `np.allclose` on UB matrix
- **Per-object serialization** — `Lattice`, `Sample` independently
- **Typical session workflow** — save at end of session, restore at start

Also:
- `concepts.md`: Serialization section added
- `glossary.md`: Serialization entry added; Stack entry: "floor-mounted" → "base-mounted"
- `howto/index.rst`: card and toctree entry added

Contributed by: OpenCode (argo/claudesonnet46)