### PR TITLE
api: convert trajectory functions to generators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@ for the full issue tracker.
   `setor1()` to match the SPEC convention (primary = or0, secondary = or1).
   Update all call sites: `setor1("x")` → `setor0("x")`;
   `setor2("x")` → `setor1("x")`. (#120)
+- `hkl_trajectory()`, `psi_trajectory()`, and `trajectory_plan()` are now
+  **generators** (they `yield` one point dict at a time instead of returning a
+  list).  Callers that iterate with `for pt in result:` are unaffected.
+  Callers that index the result directly (e.g. `result[0]`) must wrap the
+  call: `list(hkl_trajectory(...))`. (#115)
 
 ### Added
 

--- a/docs/source/howto/trajectory.md
+++ b/docs/source/howto/trajectory.md
@@ -4,6 +4,10 @@
 This guide shows how to compute motor-angle sequences along paths through
 reciprocal space and for ψ scans.
 
+All three trajectory functions are **generators** — they yield one point dict
+at a time and compute each point lazily.  Use a `for` loop to process points
+one by one, or `list(func(...))` to collect all points at once.
+
 ## Prerequisites
 
 - A geometry with wavelength and UB matrix set (see {doc}`orient`)

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -6,15 +6,15 @@ scan.py — Reciprocal-space trajectory computation.
 Functions
 ---------
 :func:`hkl_trajectory` ``(geometry, trajectory, n_points, solution_key=NEAREST_ANGLES)``
-    Compute motor-angle sequences along a specified reciprocal-space path.
+    **Generator.** Yield motor-angle dicts along a reciprocal-space path.
+    Use ``list(hkl_trajectory(...))`` to collect all points at once.
 
 :func:`psi_trajectory` ``(geometry, h, k, l, psi_values, solution_key=NEAREST_ANGLES)``
-    Compute motor-angle sequences for ψ (psi) rotation about the scattering
-    vector Q while keeping the Bragg condition satisfied.
+    **Generator.** Yield motor-angle dicts for ψ (psi) rotation about Q.
 
 :func:`trajectory_plan` ``(geometry, hkl_start, hkl_end, n_points, space="hkl", solution_key=NEAREST_ANGLES)``
-    Plan a motor-angle path between two reciprocal-space points, flagging
-    limit violations and inaccessible regions.
+    **Generator.** Yield motor-angle dicts between two reciprocal-space points,
+    flagging limit violations and inaccessible regions.
 
 :data:`NEAREST_ANGLES`
     Built-in solution-key callable: selects the candidate solution whose
@@ -118,6 +118,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -593,14 +594,18 @@ def hkl_trajectory(
     n_points: int,
     *,
     solution_key=NEAREST_ANGLES,
-) -> list[dict]:
+) -> Iterator[dict]:
     """
-    Compute motor-angle sequences along a reciprocal-space trajectory.
+    Yield motor-angle dicts along a reciprocal-space trajectory.
 
     For each of the ``n_points`` equally-spaced hkl positions along the
     trajectory, calls ``geometry.forward()`` to find all valid motor-angle
     solutions, then uses ``solution_key`` to select one.  Points with no
-    valid solution are included with ``angles=None``.
+    valid solution are yielded with ``angles=None``.
+
+    This function is a **generator**: it yields one dict per trajectory point
+    and computes each point on demand.  To get all points at once use
+    ``list(hkl_trajectory(...))``.
 
     The ``NEAREST_ANGLES`` solution key (the default) prevents branch-flip
     discontinuities: at each point it selects the candidate whose motor
@@ -620,9 +625,9 @@ def hkl_trajectory(
         Default: ``NEAREST_ANGLES``.  Pass ``None`` to use ``forward()``'s
         raw ordering.
 
-    Returns
-    -------
-    list of dict
+    Yields
+    ------
+    dict
         One entry per trajectory point with keys:
 
         ``"hkl"`` : tuple of float
@@ -650,16 +655,14 @@ def hkl_trajectory(
     >>> g.sample.lattice = ahd.Lattice(a=4.0)
     >>> ahd.ub_identity(g.sample)
     >>> g.mode_name = "bisecting"
-    >>> result = ahd.hkl_trajectory(
+    >>> for pt in ahd.hkl_trajectory(
     ...     g,
     ...     {"type": "line", "start": (1, 0, 0), "end": (3, 0, 0)},
     ...     n_points=5,
-    ... )
-    >>> for pt in result:
+    ... ):
     ...     print(pt["hkl"], pt["angles"])
     """
     points = _hkl_points(trajectory, n_points)
-    results: list[dict] = []
     previous: dict[str, float] | None = None
 
     for hkl in points:
@@ -667,24 +670,20 @@ def hkl_trajectory(
         try:
             solutions = geometry.forward(h, k, l)
         except (ValueError, NotImplementedError) as exc:
-            results.append({"hkl": hkl, "angles": None, "warning": str(exc)})
+            yield {"hkl": hkl, "angles": None, "warning": str(exc)}
             continue
 
         if not solutions:
-            results.append(
-                {
-                    "hkl": hkl,
-                    "angles": None,
-                    "warning": "no valid motor solution (all candidates outside limits)",
-                }
-            )
+            yield {
+                "hkl": hkl,
+                "angles": None,
+                "warning": "no valid motor solution (all candidates outside limits)",
+            }
             continue
 
         chosen = _pick_solution(solutions, previous, solution_key)
-        results.append({"hkl": hkl, "angles": chosen, "warning": None})
+        yield {"hkl": hkl, "angles": chosen, "warning": None}
         previous = chosen
-
-    return results
 
 
 def psi_trajectory(
@@ -695,9 +694,9 @@ def psi_trajectory(
     psi_values,
     *,
     solution_key=NEAREST_ANGLES,
-) -> list[dict]:
+) -> Iterator[dict]:
     """
-    Compute motor-angle sequences for ψ rotation about the scattering vector Q.
+    Yield motor-angle dicts for ψ rotation about the scattering vector Q.
 
     For the fixed reflection (h, k, l) and each target ψ in ``psi_values``,
     finds motor angles that simultaneously satisfy the Bragg condition and
@@ -728,9 +727,9 @@ def psi_trajectory(
         Scoring function ``(candidate, previous) -> float``; lower wins.
         Default: ``NEAREST_ANGLES``.
 
-    Returns
-    -------
-    list of dict
+    Yields
+    ------
+    dict
         One entry per ψ value with keys:
 
         ``"psi_target"`` : float
@@ -769,8 +768,7 @@ def psi_trajectory(
     >>> g.sample.lattice = ahd.Lattice(a=4.0)
     >>> ahd.ub_identity(g.sample)
     >>> g.mode_name = "bisecting"
-    >>> result = ahd.psi_trajectory(g, 1, 1, 0, range(-90, 91, 30))
-    >>> for pt in result:
+    >>> for pt in ahd.psi_trajectory(g, 1, 1, 0, range(-90, 91, 30)):
     ...     print(pt["psi_target"], pt["psi_actual"])
     """
 
@@ -783,15 +781,14 @@ def psi_trajectory(
             "no valid Bragg solution for this reflection "
             "(all candidates outside limits)"
         )
-        return [
-            {
+        for p in psi_values:
+            yield {
                 "psi_target": float(p),
                 "psi_actual": None,
                 "angles": None,
                 "warning": no_bragg_msg,
             }
-            for p in psi_values
-        ]
+        return
 
     # Pick the base solution (used to compute Z0 and as the psi=0 reference)
     base = base_solutions[0]
@@ -822,7 +819,6 @@ def psi_trajectory(
     y_perp_0 = y_phi_0 - np.dot(y_phi_0, q_hat_phi) * q_hat_phi
     ref_dir = y_perp_0 / np.linalg.norm(y_perp_0)
 
-    results: list[dict] = []
     previous: dict[str, float] | None = None
 
     for psi_target in psi_values:
@@ -831,17 +827,15 @@ def psi_trajectory(
         candidates = _psi_candidates(geometry, Z0, Q_lab_hat, y_eff, psi_target, base)
 
         if not candidates:
-            results.append(
-                {
-                    "psi_target": psi_target,
-                    "psi_actual": None,
-                    "angles": None,
-                    "warning": (
-                        f"no motor solution achieves psi = {psi_target:.4g}° "
-                        "within stage limits"
-                    ),
-                }
-            )
+            yield {
+                "psi_target": psi_target,
+                "psi_actual": None,
+                "angles": None,
+                "warning": (
+                    f"no motor solution achieves psi = {psi_target:.4g}° "
+                    "within stage limits"
+                ),
+            }
             continue
 
         chosen = _pick_solution(candidates, previous, solution_key)
@@ -849,17 +843,13 @@ def psi_trajectory(
             geometry, chosen, Q_lab_hat, y_eff, q_hat_phi, ref_dir
         )
 
-        results.append(
-            {
-                "psi_target": psi_target,
-                "psi_actual": psi_actual,
-                "angles": chosen,
-                "warning": None,
-            }
-        )
+        yield {
+            "psi_target": psi_target,
+            "psi_actual": psi_actual,
+            "angles": chosen,
+            "warning": None,
+        }
         previous = chosen
-
-    return results
 
 
 def trajectory_plan(
@@ -870,9 +860,9 @@ def trajectory_plan(
     *,
     space: str = "hkl",
     solution_key=NEAREST_ANGLES,
-) -> list[dict]:
+) -> Iterator[dict]:
     r"""
-    Plan a motor-angle path between two reciprocal-space points.
+    Yield motor-angle dicts for a planned path between two reciprocal-space points.
 
     Interpolates between ``hkl_start`` and ``hkl_end`` in ``n_points``
     equally-spaced steps, calls ``geometry.forward()`` at each point, and
@@ -905,9 +895,9 @@ def trajectory_plan(
         Scoring function ``(candidate, previous) -> float``; lower wins.
         Default: ``NEAREST_ANGLES``.
 
-    Returns
-    -------
-    list of dict
+    Yields
+    ------
+    dict
         One entry per trajectory point with keys:
 
         ``"hkl"`` : tuple of float
@@ -940,7 +930,7 @@ def trajectory_plan(
     >>> g.sample.lattice = ahd.Lattice(a=4.0)
     >>> ahd.ub_identity(g.sample)
     >>> g.mode_name = "bisecting"
-    >>> plan = ahd.trajectory_plan(g, (1, 0, 0), (3, 0, 0), n_points=11)
+    >>> plan = list(ahd.trajectory_plan(g, (1, 0, 0), (3, 0, 0), n_points=11))
     >>> accessible = [pt for pt in plan if pt["accessible"]]
     >>> print(f"{len(accessible)}/{len(plan)} points accessible")
     """
@@ -980,7 +970,6 @@ def trajectory_plan(
         hkl_points[0] = tuple(float(v) for v in hkl_start_arr)
         hkl_points[-1] = tuple(float(v) for v in hkl_end_arr)
 
-    results: list[dict] = []
     previous: dict[str, float] | None = None
 
     for hkl in hkl_points:
@@ -990,27 +979,21 @@ def trajectory_plan(
         try:
             solutions = geometry.forward(h, k, l)
         except (ValueError, NotImplementedError) as exc:
-            results.append(
-                {
-                    "hkl": hkl,
-                    "angles": None,
-                    "accessible": False,
-                    "warnings": [str(exc)],
-                }
-            )
+            yield {
+                "hkl": hkl,
+                "angles": None,
+                "accessible": False,
+                "warnings": [str(exc)],
+            }
             continue
 
         if not solutions:
-            results.append(
-                {
-                    "hkl": hkl,
-                    "angles": None,
-                    "accessible": False,
-                    "warnings": [
-                        "no valid motor solution (all candidates outside limits)"
-                    ],
-                }
-            )
+            yield {
+                "hkl": hkl,
+                "angles": None,
+                "accessible": False,
+                "warnings": ["no valid motor solution (all candidates outside limits)"],
+            }
             continue
 
         chosen = _pick_solution(solutions, previous, solution_key)
@@ -1020,15 +1003,11 @@ def trajectory_plan(
         except ValueError as exc:
             warnings_list.append(str(exc))
 
-        results.append(
-            {
-                "hkl": hkl,
-                "angles": chosen,
-                "accessible": len(warnings_list) == 0,
-                "warnings": warnings_list,
-            }
-        )
+        yield {
+            "hkl": hkl,
+            "angles": chosen,
+            "accessible": len(warnings_list) == 0,
+            "warnings": warnings_list,
+        }
         if not warnings_list:
             previous = chosen
-
-    return results

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -354,10 +354,12 @@ class TestHklTrajectory:
     def test_line_round_trip(self):
         """Every accessible point satisfies inverse(angles) ≈ hkl."""
         g = _setup(fourcv)
-        result = hkl_trajectory(
-            g,
-            {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
-            n_points=5,
+        result = list(
+            hkl_trajectory(
+                g,
+                {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
+                n_points=5,
+            )
         )
         assert len(result) == 5
         for pt in result:
@@ -368,15 +370,17 @@ class TestHklTrajectory:
     def test_radial_trajectory_endpoints(self):
         """Radial trajectory: endpoints match expected hkl."""
         g = _setup(fourcv)
-        result = hkl_trajectory(
-            g,
-            {
-                "type": "radial",
-                "center": (1, 0, 0),
-                "direction": (1, 0, 0),
-                "extent": 0.5,
-            },
-            n_points=3,
+        result = list(
+            hkl_trajectory(
+                g,
+                {
+                    "type": "radial",
+                    "center": (1, 0, 0),
+                    "direction": (1, 0, 0),
+                    "extent": 0.5,
+                },
+                n_points=3,
+            )
         )
         assert len(result) == 3
         assert np.allclose(result[0]["hkl"], (0.5, 0.0, 0.0), atol=1e-12)
@@ -385,15 +389,17 @@ class TestHklTrajectory:
     def test_transverse_perpendicular(self):
         """Transverse points lie perpendicular to Q_ref from center."""
         g = _setup(fourcv)
-        result = hkl_trajectory(
-            g,
-            {
-                "type": "transverse",
-                "center": (1, 0, 0),
-                "Q_ref": (1, 0, 0),
-                "extent": 0.1,
-            },
-            n_points=5,
+        result = list(
+            hkl_trajectory(
+                g,
+                {
+                    "type": "transverse",
+                    "center": (1, 0, 0),
+                    "Q_ref": (1, 0, 0),
+                    "extent": 0.1,
+                },
+                n_points=5,
+            )
         )
         center = np.array([1.0, 0.0, 0.0])
         q_ref = np.array([1.0, 0.0, 0.0])
@@ -404,10 +410,12 @@ class TestHklTrajectory:
     def test_inaccessible_gives_none_and_warning(self):
         """When Q exceeds Ewald sphere, angles=None and warning is non-empty."""
         g = _setup(fourcv, a=0.1)  # tiny lattice → very large |Q|
-        result = hkl_trajectory(
-            g,
-            {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
-            n_points=3,
+        result = list(
+            hkl_trajectory(
+                g,
+                {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)},
+                n_points=3,
+            )
         )
         inaccessible = [pt for pt in result if pt["angles"] is None]
         assert len(inaccessible) > 0
@@ -417,11 +425,13 @@ class TestHklTrajectory:
     def test_nearest_angles_prevents_branch_flip(self):
         """chi values stay on the same branch (no sign flip) with NEAREST_ANGLES."""
         g = _setup(fourcv)
-        result = hkl_trajectory(
-            g,
-            {"type": "line", "start": (0.5, 0, 0), "end": (1.5, 0, 0)},
-            n_points=7,
-            solution_key=NEAREST_ANGLES,
+        result = list(
+            hkl_trajectory(
+                g,
+                {"type": "line", "start": (0.5, 0, 0), "end": (1.5, 0, 0)},
+                n_points=7,
+                solution_key=NEAREST_ANGLES,
+            )
         )
         chi_values = [pt["angles"]["chi"] for pt in result if pt["angles"] is not None]
         assert len(chi_values) >= 2
@@ -433,11 +443,13 @@ class TestHklTrajectory:
         g = _setup(fourcv)
         # Always pick the solution with the largest (most positive) chi
         max_chi_key = lambda c, p: -c.get("chi", 0.0)  # noqa: E731
-        result = hkl_trajectory(
-            g,
-            {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
-            n_points=2,
-            solution_key=max_chi_key,
+        result = list(
+            hkl_trajectory(
+                g,
+                {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
+                n_points=2,
+                solution_key=max_chi_key,
+            )
         )
         for pt in result:
             if pt["angles"] is not None:
@@ -446,11 +458,13 @@ class TestHklTrajectory:
     def test_none_solution_key_returns_result(self):
         """solution_key=None runs and returns angles dicts."""
         g = _setup(fourcv)
-        result = hkl_trajectory(
-            g,
-            {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
-            n_points=2,
-            solution_key=None,
+        result = list(
+            hkl_trajectory(
+                g,
+                {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)},
+                n_points=2,
+                solution_key=None,
+            )
         )
         assert all("angles" in pt for pt in result)
 
@@ -476,7 +490,7 @@ class TestHklTrajectory:
     def test_hkl_trajectory_raises(self, trajectory, n_points, context):
         g = _setup(fourcv)
         with context:
-            hkl_trajectory(g, trajectory, n_points)
+            list(hkl_trajectory(g, trajectory, n_points))
 
     def test_no_wavelength_gives_warnings(self):
         """When wavelength is not set all points have warnings and angles=None."""
@@ -484,8 +498,10 @@ class TestHklTrajectory:
         g.sample.lattice = Lattice(a=4.0)
         ub_identity(g.sample)
         g.mode_name = "bisecting"
-        result = hkl_trajectory(
-            g, {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)}, n_points=3
+        result = list(
+            hkl_trajectory(
+                g, {"type": "line", "start": (1, 0, 0), "end": (2, 0, 0)}, n_points=3
+            )
         )
         assert all(pt["angles"] is None for pt in result)
         assert all(pt["warning"] is not None for pt in result)
@@ -515,7 +531,7 @@ class TestPsiTrajectory:
         """Assert psi_actual ≈ psi_target (mod 360) for all accessible points."""
         if targets is None:
             targets = self.PSI_TARGETS
-        result = psi_trajectory(geometry, *hkl, targets)
+        result = list(psi_trajectory(geometry, *hkl, targets))
         assert len(result) == len(targets)
         accessible = [pt for pt in result if pt["angles"] is not None]
         assert len(accessible) >= len(targets) // 2, (
@@ -548,14 +564,16 @@ class TestPsiTrajectory:
     def test_psi_zero_at_base(self):
         """psi_actual = 0 when psi_target = 0 (base forward() solution)."""
         g = _setup(fourcv)
-        result = psi_trajectory(g, *HKL_TEST, [0.0])
+        result = list(psi_trajectory(g, *HKL_TEST, [0.0]))
         assert result[0]["psi_actual"] == pytest.approx(0.0, abs=1e-6)
 
     def test_psi_smooth_motion_nearest_angles(self):
         """phi values vary smoothly across a dense ψ sweep (no large jumps)."""
         g = _setup(fourcv)
         targets = list(range(-60, 61, 10))
-        result = psi_trajectory(g, *HKL_TEST, targets, solution_key=NEAREST_ANGLES)
+        result = list(
+            psi_trajectory(g, *HKL_TEST, targets, solution_key=NEAREST_ANGLES)
+        )
         phi_values = [pt["angles"]["phi"] for pt in result if pt["angles"] is not None]
         assert len(phi_values) >= 2
         for i in range(1, len(phi_values)):
@@ -569,7 +587,7 @@ class TestPsiTrajectory:
         """When reflection is inaccessible all psi points have warning."""
         g = _setup(fourcv)
         g.stage("ttheta").limits = (0.0, 1.0)  # block the detector
-        result = psi_trajectory(g, *HKL_TEST, [0.0, 30.0])
+        result = list(psi_trajectory(g, *HKL_TEST, [0.0, 30.0]))
         for pt in result:
             assert pt["angles"] is None
             assert pt["warning"] is not None
@@ -581,7 +599,7 @@ class TestPsiTrajectory:
         ub_identity(g.sample)
         g.mode_name = "bisecting"
         with pytest.raises(ValueError, match=re.escape("wavelength")):
-            psi_trajectory(g, *HKL_TEST, [0.0])
+            list(psi_trajectory(g, *HKL_TEST, [0.0]))
 
     def test_psi_no_ub_raises(self):
         """Raises ValueError when UB is not set."""
@@ -589,18 +607,18 @@ class TestPsiTrajectory:
         g.wavelength = WAVELENGTH
         g.mode_name = "bisecting"
         with pytest.raises(ValueError, match=re.escape("UB")):
-            psi_trajectory(g, *HKL_TEST, [0.0])
+            list(psi_trajectory(g, *HKL_TEST, [0.0]))
 
     def test_psi_zero_hkl_raises(self):
         """Raises ValueError for hkl = (0,0,0)."""
         g = _setup(fourcv)
         with pytest.raises(ValueError, match=re.escape("(0, 0, 0)")):
-            psi_trajectory(g, 0, 0, 0, [0.0])
+            list(psi_trajectory(g, 0, 0, 0, [0.0]))
 
     def test_psi_result_keys(self):
         """Every result entry has exactly the expected keys."""
         g = _setup(fourcv)
-        result = psi_trajectory(g, *HKL_TEST, [0.0])
+        result = list(psi_trajectory(g, *HKL_TEST, [0.0]))
         assert set(result[0].keys()) == {
             "psi_target",
             "psi_actual",
@@ -611,7 +629,7 @@ class TestPsiTrajectory:
     def test_psi_none_solution_key(self):
         """solution_key=None runs without error."""
         g = _setup(fourcv)
-        result = psi_trajectory(g, *HKL_TEST, [0.0], solution_key=None)
+        result = list(psi_trajectory(g, *HKL_TEST, [0.0], solution_key=None))
         assert len(result) == 1
 
 
@@ -624,7 +642,7 @@ class TestTrajectoryPlan:
     def test_hkl_space_endpoints(self):
         """Start and end hkl are exactly the requested values."""
         g = _setup(fourcv)
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5)
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5))
         assert len(plan) == 5
         assert np.allclose(plan[0]["hkl"], (1, 0, 0), atol=1e-12)
         assert np.allclose(plan[-1]["hkl"], (2, 0, 0), atol=1e-12)
@@ -632,7 +650,7 @@ class TestTrajectoryPlan:
     def test_hkl_space_round_trip(self):
         """All accessible points satisfy inverse(angles) ≈ hkl."""
         g = _setup(fourcv)
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5)
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5))
         for pt in plan:
             if pt["accessible"]:
                 assert _round_trip_ok(g, pt["angles"], pt["hkl"])
@@ -641,7 +659,7 @@ class TestTrajectoryPlan:
     def test_q_space_endpoints_exact(self):
         """space='Q': endpoints are exact despite Q interpolation."""
         g = _setup(fourcv)
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5, space="Q")
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=5, space="Q"))
         assert np.allclose(plan[0]["hkl"], (1, 0, 0), atol=1e-12)
         assert np.allclose(plan[-1]["hkl"], (2, 0, 0), atol=1e-12)
 
@@ -653,7 +671,7 @@ class TestTrajectoryPlan:
         ub_identity(g.sample)
 
         n = 5
-        plan_q = trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="Q")
+        plan_q = list(trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="Q"))
 
         # Compute Q vectors at each trajectory point
         Q_vecs = [g.sample.UB @ np.array(pt["hkl"]) for pt in plan_q]
@@ -664,7 +682,9 @@ class TestTrajectoryPlan:
         assert np.std(dQ_mags) < 1e-10, f"Q step sizes not equal: {dQ_mags}"
 
         # Verify both plans share the same exact endpoints regardless of space.
-        plan_hkl = trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="hkl")
+        plan_hkl = list(
+            trajectory_plan(g, (1, 0, 0), (0, 0, 2), n_points=n, space="hkl")
+        )
         assert np.allclose(plan_q[0]["hkl"], (1, 0, 0), atol=1e-12)
         assert np.allclose(plan_q[-1]["hkl"], (0, 0, 2), atol=1e-12)
         assert np.allclose(plan_hkl[0]["hkl"], (1, 0, 0), atol=1e-12)
@@ -673,7 +693,7 @@ class TestTrajectoryPlan:
     def test_inaccessible_points_flagged(self):
         """Points with no valid solution are accessible=False."""
         g = _setup(fourcv, a=0.1)
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3))
         inaccessible = [pt for pt in plan if not pt["accessible"]]
         assert len(inaccessible) > 0
         for pt in inaccessible:
@@ -683,7 +703,7 @@ class TestTrajectoryPlan:
     def test_nearest_angles_no_branch_flip(self):
         """chi values stay on the same branch across the plan."""
         g = _setup(fourcv)
-        plan = trajectory_plan(g, (0.5, 0, 0), (1.5, 0, 0), n_points=9)
+        plan = list(trajectory_plan(g, (0.5, 0, 0), (1.5, 0, 0), n_points=9))
         chi_values = [pt["angles"]["chi"] for pt in plan if pt["accessible"]]
         assert len(chi_values) >= 2
         signs = {1 if v >= 0 else -1 for v in chi_values}
@@ -692,36 +712,36 @@ class TestTrajectoryPlan:
     def test_n_points_too_small_raises(self):
         g = _setup(fourcv)
         with pytest.raises(ValueError, match=re.escape("n_points must be at least 2")):
-            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=1)
+            list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=1))
 
     def test_invalid_space_raises(self):
         g = _setup(fourcv)
         with pytest.raises(ValueError, match=re.escape("space must be 'hkl' or 'Q'")):
-            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="crystal")
+            list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="crystal"))
 
     def test_q_space_no_ub_raises(self):
         g = fourcv()
         g.wavelength = WAVELENGTH
         g.mode_name = "bisecting"
         with pytest.raises(ValueError, match=re.escape("UB")):
-            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q")
+            list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q"))
 
     def test_result_keys(self):
         g = _setup(fourcv)
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3))
         for pt in plan:
             assert set(pt.keys()) == {"hkl", "angles", "accessible", "warnings"}
 
     def test_n_points_respected(self):
         g = _setup(fourcv)
         for n in [2, 5, 11]:
-            plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=n)
+            plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=n))
             assert len(plan) == n
 
     def test_psic_accessible(self):
         """psic geometry: most points on a simple trajectory should be accessible."""
         g = _setup(psic)
-        plan = trajectory_plan(g, (0, 0, 1), (0, 0, 2), n_points=5)
+        plan = list(trajectory_plan(g, (0, 0, 1), (0, 0, 2), n_points=5))
         assert sum(pt["accessible"] for pt in plan) >= 3
 
     def test_no_wavelength_gives_inaccessible(self):
@@ -730,7 +750,7 @@ class TestTrajectoryPlan:
         g.sample.lattice = Lattice(a=4.0)
         ub_identity(g.sample)
         g.mode_name = "bisecting"
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3)
+        plan = list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3))
         assert all(not pt["accessible"] for pt in plan)
         assert all(len(pt["warnings"]) > 0 for pt in plan)
 
@@ -828,7 +848,7 @@ def test_psi_trajectory_beam_parallel_to_Q():
     # (0,1,0) with UB=B in BL basis: Q_phi = B@[0,1,0] = (0, 2π/a, 0)
     # The BL longitudinal (beam) direction is also [0,1,0], so beam ∥ Q.
     g = _setup(fourcv)
-    result = psi_trajectory(g, 0, 1, 0, [0.0])
+    result = list(psi_trajectory(g, 0, 1, 0, [0.0]))
     # Either no solution found (limits) or the beam-parallel warning fires
     # — in any case the degenerate path must not raise
     assert len(result) == 1
@@ -865,7 +885,7 @@ def test_psi_trajectory_fewer_than_3_sample_stages():
     g.sample.lattice = ahd.Lattice(a=4.0)
     ahd.ub_identity(g.sample)
 
-    result = psi_trajectory(g, 1, 0, 0, [0.0, 30.0])
+    result = list(psi_trajectory(g, 1, 0, 0, [0.0, 30.0]))
     # _psi_candidates returns [] for < 3 sample stages → warning entries
     for pt in result:
         assert pt["angles"] is None
@@ -877,8 +897,10 @@ def test_hkl_trajectory_all_candidates_outside_limits():
     g = _setup(fourcv)
     # Lock chi to a range that excludes all forward() solutions for (1,0,0)
     g.stage("chi").limits = (0.1, 0.2)
-    result = hkl_trajectory(
-        g, {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)}, n_points=2
+    result = list(
+        hkl_trajectory(
+            g, {"type": "line", "start": (1, 0, 0), "end": (1, 0, 0)}, n_points=2
+        )
     )
     for pt in result:
         assert pt["angles"] is None
@@ -889,7 +911,7 @@ def test_trajectory_plan_all_candidates_outside_limits():
     """trajectory_plan marks points inaccessible when all solutions fail limits."""
     g = _setup(fourcv)
     g.stage("chi").limits = (0.1, 0.2)
-    plan = trajectory_plan(g, (1, 0, 0), (1, 0, 0), n_points=2)
+    plan = list(trajectory_plan(g, (1, 0, 0), (1, 0, 0), n_points=2))
     for pt in plan:
         assert not pt["accessible"]
         assert len(pt["warnings"]) > 0
@@ -901,7 +923,7 @@ def test_trajectory_plan_singular_ub_raises():
     # Replace UB with a singular matrix
     g.sample.UB = np.zeros((3, 3))
     with pytest.raises(ValueError, match=re.escape("singular")):
-        trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q")
+        list(trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, space="Q"))
 
 
 def test_trajectory_plan_check_limits_warning_when_violated():
@@ -914,7 +936,9 @@ def test_trajectory_plan_check_limits_warning_when_violated():
     g = _setup(fourcv)
     exc = ValueError("The following stages have angles outside their limits:\n  chi")
     with mock.patch.object(g, "check_limits", side_effect=exc):
-        plan = trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, solution_key=None)
+        plan = list(
+            trajectory_plan(g, (1, 0, 0), (2, 0, 0), n_points=3, solution_key=None)
+        )
 
     for pt in plan:
         if pt["angles"] is not None:
@@ -973,7 +997,7 @@ def test_psi_trajectory_on_longitudinal_reflection():
     and psi_actual is a well-defined float.
     """
     g = _setup(fourcv)
-    result = psi_trajectory(g, 0, 1, 0, [0.0, 30.0])
+    result = list(psi_trajectory(g, 0, 1, 0, [0.0, 30.0]))
     # Should find solutions (or gracefully report limits issues)
     assert len(result) == 2
     for pt in result:


### PR DESCRIPTION
- closes #115

## Breaking change

`hkl_trajectory()`, `psi_trajectory()`, and `trajectory_plan()` are now **generators**.

| Pattern | Status |
|---|---|
| `for pt in hkl_trajectory(...):` | **unchanged — works as before** |
| `result = hkl_trajectory(...)` then `result[0]` | **must add `list()`**: `result = list(hkl_trajectory(...))` |

## Benefits

- **Lazy evaluation** — each point is computed only when consumed
- **Early termination** — `break` after first limit violation without computing the rest
- **Composability** — works with `itertools`, `zip`, `islice`, etc.
- **Natural fit** for streaming / live-scanning use cases

## Changes

- `scan.py`: `yield` replaces accumulate-then-return; `-> Iterator[dict]` type hints; docstrings updated (Returns → Yields)
- `tests/test_scan.py`: bare calls wrapped with `list()`; `pytest.raises` blocks updated to consume the generator
- `CHANGES.md`: breaking change documented
- `howto/trajectory.md`: generator note added

1206 tests, 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)