### PR TITLE
fix: geometry pages — replace reST list-table with pipe tables

### DIFF
--- a/docs/source/geometries/fivec.md
+++ b/docs/source/geometries/fivec.md
@@ -1,11 +1,11 @@
 (geometry-fivec)=
 # fivec — Five-Circle (Vlieg et al. 1987)
 
-Five-circle diffractometer: a standard fourcv (Eulerian four-circle) mounted on a vertical mu base stage. Sample and detector are coupled through mu, providing access to wider regions of reciprocal space.
+Five-circle diffractometer: a standard fourcv (Eulerian four-circle) mounted on a vertical mu base stage. Sample and detector are coupled through mu.
 
 **Walko (2016) designation:** (S3D1)1
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,40 +19,20 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed, shared base |
+| ``omega`` | −lateral (−z) | left-handed |
+| ``chi`` | +longitudinal (+y) | right-handed |
+| ``phi`` | −lateral (−z) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``mu``
-     - +vertical (+x)
-     - right-handed, shared base
-   * - ``omega``
-     - −lateral (−z)
-     - left-handed
-   * - ``chi``
-     - +longitudinal (+y)
-     - right-handed
-   * - ``phi``
-     - −lateral (−z)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``ttheta``
-     - −lateral (−z)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``ttheta`` | −lateral (−z) | left-handed |
 
 **Shared stage:** mu (base stage shared between sample and detector stacks)
 
@@ -67,6 +47,5 @@ Available modes: *(none defined)*
 
 ## References
 
-- Vlieg et al., *J. Appl. Cryst.* **20**, 330–337 (1987). DOI: `10.1107/S0021889887087266 <https://doi.org/10.1107/S0021889887087266>`_
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- Vlieg et al., *J. Appl. Cryst.* **20**, 330–337 (1987). DOI: [10.1107/S0021889887087266](https://doi.org/10.1107/S0021889887087266)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -5,7 +5,7 @@ Busing & Levy (1967) four-circle Eulerian diffractometer, horizontal scattering 
 
 **Walko (2016) designation:** S3D1
 
-**Coordinate basis:** Busing & Levy (``BASIS_BL``): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,41 +19,23 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``omega`` | −vertical (−z BL) | left-handed |
+| ``chi`` | +longitudinal (+y BL) | right-handed |
+| ``phi`` | −vertical (−z BL) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``omega``
-     - −vertical (−z BL)
-     - left-handed
-   * - ``chi``
-     - +longitudinal (+y BL)
-     - right-handed
-   * - ``phi``
-     - −vertical (−z BL)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``ttheta``
-     - −vertical (−z BL)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``ttheta`` | −vertical (−z BL) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``
+Available modes: `bisecting`, `fixed_chi`, `fixed_phi`
 
 ## API reference
 
@@ -62,5 +44,5 @@ Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``
 
 ## References
 
-- Busing & Levy, *Acta Cryst.* **22**, 457–464 (1967). DOI: `10.1107/S0365110X67000970 <https://doi.org/10.1107/S0365110X67000970>`_
+- Busing & Levy, *Acta Cryst.* **22**, 457–464 (1967). DOI: [10.1107/S0365110X67000970](https://doi.org/10.1107/S0365110X67000970)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -5,7 +5,7 @@ Busing & Levy (1967) four-circle Eulerian diffractometer, vertical scattering pl
 
 **Walko (2016) designation:** S3D1
 
-**Coordinate basis:** Busing & Levy (``BASIS_BL``): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,41 +19,23 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``omega`` | −lateral (−x BL) | left-handed |
+| ``chi`` | +longitudinal (+y BL) | right-handed |
+| ``phi`` | −lateral (−x BL) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``omega``
-     - −lateral (−x BL)
-     - left-handed
-   * - ``chi``
-     - +longitudinal (+y BL)
-     - right-handed
-   * - ``phi``
-     - −lateral (−x BL)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``ttheta``
-     - −lateral (−x BL)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``ttheta`` | −lateral (−x BL) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``
+Available modes: `bisecting`, `fixed_chi`, `fixed_phi`
 
 ## API reference
 
@@ -62,5 +44,5 @@ Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``
 
 ## References
 
-- Busing & Levy, *Acta Cryst.* **22**, 457–464 (1967). DOI: `10.1107/S0365110X67000970 <https://doi.org/10.1107/S0365110X67000970>`_
+- Busing & Levy, *Acta Cryst.* **22**, 457–464 (1967). DOI: [10.1107/S0365110X67000970](https://doi.org/10.1107/S0365110X67000970)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -5,7 +5,7 @@ Four-circle kappa diffractometer, horizontal scattering plane. Kappa axis tilted
 
 **Walko (2016) designation:** S3D1 (kappa)
 
-**Coordinate basis:** Busing & Levy (``BASIS_BL``): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,41 +19,23 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``komega`` | −vertical (−z BL) | left-handed |
+| ``kappa`` | tilted axis, α=50° | right-handed |
+| ``kphi`` | −vertical (−z BL) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``komega``
-     - −vertical (−z BL)
-     - left-handed
-   * - ``kappa``
-     - tilted axis, α=50°
-     - right-handed
-   * - ``kphi``
-     - −vertical (−z BL)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``ttheta``
-     - −vertical (−z BL)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``ttheta`` | −vertical (−z BL) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_kphi``
+Available modes: `bisecting`, `fixed_kphi`
 
 ## API reference
 
@@ -62,6 +44,5 @@ Available modes: ``bisecting``, ``fixed_kphi``
 
 ## References
 
-- ITC Vol. C §2.2.6 (2006). DOI: `10.1107/97809553602060000577 <https://doi.org/10.1107/97809553602060000577>`_
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -1,11 +1,11 @@
 (geometry-kappa4cv)=
 # kappa4cv — Kappa Four-Circle (Synchrotron)
 
-Four-circle kappa diffractometer, vertical scattering plane. The chi circle is replaced by a kappa axis tilted at α = 50° from the vertical toward the lateral axis (Walko 2016; ITC Vol. C §2.2.6).
+Four-circle kappa diffractometer, vertical scattering plane. The chi circle is replaced by a kappa axis tilted at α = 50° from the vertical toward the lateral axis.
 
 **Walko (2016) designation:** S3D1 (kappa)
 
-**Coordinate basis:** Busing & Levy (``BASIS_BL``): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,41 +19,23 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``komega`` | −lateral (−x BL) | left-handed |
+| ``kappa`` | tilted axis, α=50° | right-handed |
+| ``kphi`` | −lateral (−x BL) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``komega``
-     - −lateral (−x BL)
-     - left-handed
-   * - ``kappa``
-     - tilted axis, α=50°
-     - right-handed
-   * - ``kphi``
-     - −lateral (−x BL)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``ttheta``
-     - −lateral (−x BL)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``ttheta`` | −lateral (−x BL) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_kphi``
+Available modes: `bisecting`, `fixed_kphi`
 
 ## API reference
 
@@ -62,6 +44,5 @@ Available modes: ``bisecting``, ``fixed_kphi``
 
 ## References
 
-- ITC Vol. C §2.2.6 (2006). DOI: `10.1107/97809553602060000577 <https://doi.org/10.1107/97809553602060000577>`_
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -3,7 +3,7 @@
 
 Six-circle kappa diffractometer with psic-style outer axes (mu, nu). The inner sample axes (komega, kappa, and kphi) replace the Eulerian chi circle. Lateral detector, vertical scattering plane.
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -17,47 +17,25 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed |
+| ``komega`` | −lateral (−z) | left-handed |
+| ``kappa`` | tilted axis, α=50° | right-handed |
+| ``kphi`` | −lateral (−z) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``mu``
-     - +vertical (+x)
-     - right-handed
-   * - ``komega``
-     - −lateral (−z)
-     - left-handed
-   * - ``kappa``
-     - tilted axis, α=50°
-     - right-handed
-   * - ``kphi``
-     - −lateral (−z)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``nu``
-     - +vertical (+x)
-     - right-handed
-   * - ``delta``
-     - −lateral (−z)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed |
+| ``delta`` | −lateral (−z) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_kphi``, ``fixed_mu``
+Available modes: `bisecting`, `fixed_kphi`, `fixed_mu`
 
 ## API reference
 
@@ -66,5 +44,5 @@ Available modes: ``bisecting``, ``fixed_kphi``, ``fixed_mu``
 
 ## References
 
-- ITC Vol. C §2.2.6 (2006). DOI: `10.1107/97809553602060000577 <https://doi.org/10.1107/97809553602060000577>`_
+- ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -3,7 +3,7 @@
 
 You (1999) 4S+2D six-circle diffractometer. Four sample stages (mu, eta, chi, and phi) and two detector stages (nu, delta). Lateral detector, vertical scattering plane. Standard synchrotron six-circle.
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -17,47 +17,25 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed |
+| ``eta`` | −lateral (−z) | left-handed |
+| ``chi`` | +longitudinal (+y) | right-handed |
+| ``phi`` | −lateral (−z) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``mu``
-     - +vertical (+x)
-     - right-handed
-   * - ``eta``
-     - −lateral (−z)
-     - left-handed
-   * - ``chi``
-     - +longitudinal (+y)
-     - right-handed
-   * - ``phi``
-     - −lateral (−z)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``nu``
-     - +vertical (+x)
-     - right-handed
-   * - ``delta``
-     - −lateral (−z)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed |
+| ``delta`` | −lateral (−z) | left-handed |
 
 ## Diffraction modes
 
-Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``, ``fixed_mu``
+Available modes: `bisecting`, `fixed_chi`, `fixed_phi`, `fixed_mu`
 
 ## API reference
 
@@ -66,5 +44,5 @@ Available modes: ``bisecting``, ``fixed_chi``, ``fixed_phi``, ``fixed_mu``
 
 ## References
 
-- You, *J. Appl. Cryst.* **32**, 614–623 (1999). DOI: `10.1107/S0021889899001223 <https://doi.org/10.1107/S0021889899001223>`_
+- You, *J. Appl. Cryst.* **32**, 614–623 (1999). DOI: [10.1107/S0021889899001223](https://doi.org/10.1107/S0021889899001223)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -1,11 +1,11 @@
 (geometry-s2d2)=
 # s2d2 — S2D2 General-Inclination Four-Circle
 
-S2D2 geometry with two independent sample axes (mu, Z) and two independent detector axes (nu, delta), all mechanically decoupled. The angle of incidence equals mu; the surface normal is parallel to Z.
+S2D2 geometry with two independent sample axes (mu, Z) and two independent detector axes (nu, delta), all mechanically decoupled.
 
 **Walko (2016) designation:** S2D2
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,37 +19,19 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed |
+| ``Z`` | +longitudinal (+y) | right-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``mu``
-     - +vertical (+x)
-     - right-handed
-   * - ``Z``
-     - +longitudinal (+y)
-     - right-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``nu``
-     - +vertical (+x)
-     - right-handed
-   * - ``delta``
-     - −lateral (−z)
-     - left-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed |
+| ``delta`` | −lateral (−z) | left-handed |
 
 ## Diffraction modes
 
@@ -62,6 +44,5 @@ Available modes: *(none defined)*
 
 ## References
 
-- Evans-Lutterodt & Tang, *J. Appl. Cryst.* **28**, 318–326 (1995). DOI: `10.1107/S0021889895001063 <https://doi.org/10.1107/S0021889895001063>`_
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- Evans-Lutterodt & Tang, *J. Appl. Cryst.* **28**, 318–326 (1995). DOI: [10.1107/S0021889895001063](https://doi.org/10.1107/S0021889895001063)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -1,11 +1,11 @@
 (geometry-sixc)=
 # sixc — Six-Circle Surface (Lohmeier & Vlieg 1993)
 
-Six-circle surface diffractometer. Sample and detector share a common alpha (rotary table) base stage. Designed for surface diffraction. Also known as the IUCr six-circle geometry.
+Six-circle surface diffractometer. Sample and detector share a common alpha (rotary table) base stage. Designed for surface diffraction.
 
 **Walko (2016) designation:** (S3D2)1
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,43 +19,21 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``alpha`` | +vertical (+x) | right-handed, shared base |
+| ``omega`` | −lateral (−z) | left-handed |
+| ``chi`` | +longitudinal (+y) | right-handed |
+| ``phi`` | −lateral (−z) | left-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``alpha``
-     - +vertical (+x)
-     - right-handed, shared base
-   * - ``omega``
-     - −lateral (−z)
-     - left-handed
-   * - ``chi``
-     - +longitudinal (+y)
-     - right-handed
-   * - ``phi``
-     - −lateral (−z)
-     - left-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``delta``
-     - −lateral (−z)
-     - left-handed
-   * - ``gamma``
-     - +vertical (+x)
-     - right-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``delta`` | −lateral (−z) | left-handed |
+| ``gamma`` | +vertical (+x) | right-handed |
 
 **Shared stage:** alpha (base stage shared between sample and detector stacks)
 
@@ -70,5 +48,5 @@ Available modes: *(none defined)*
 
 ## References
 
-- Lohmeier & Vlieg, *J. Appl. Cryst.* **26**, 706–716 (1993). DOI: `10.1107/S0021889893006198 <https://doi.org/10.1107/S0021889893006198>`_
+- Lohmeier & Vlieg, *J. Appl. Cryst.* **26**, 706–716 (1993). DOI: [10.1107/S0021889893006198](https://doi.org/10.1107/S0021889893006198)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/docs/source/geometries/zaxis.md
+++ b/docs/source/geometries/zaxis.md
@@ -1,11 +1,11 @@
 (geometry-zaxis)=
 # zaxis — Z-Axis Four-Circle (Surface)
 
-Z-axis four-circle diffractometer for surface diffraction. The sample surface normal is parallel to the Z-axis. Sample and detector share an alpha base stage. Designed for grazing-incidence work.
+Z-axis four-circle diffractometer for surface diffraction. The sample surface normal is parallel to the Z-axis. Sample and detector share an alpha base stage.
 
 **Walko (2016) designation:** (S1D2)1
 
-**Coordinate basis:** You (1999) (``BASIS_YOU``): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,37 +19,19 @@ print(g.summary())
 
 ## Stage layout
 
-**Sample stages** (floor first):
+**Sample stages (base first):**
 
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``alpha`` | +vertical (+x) | right-handed, shared base |
+| ``Z`` | +longitudinal (+y) | right-handed |
 
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``alpha``
-     - +vertical (+x)
-     - right-handed, shared base
-   * - ``Z``
-     - +longitudinal (+y)
-     - right-handed
+**Detector stages (base first):**
 
-**Detector stages** (floor first):
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 40 20
-
-   * - Stage
-     - Axis
-     - Handedness
-   * - ``delta``
-     - −lateral (−z)
-     - left-handed
-   * - ``gamma``
-     - +vertical (+x)
-     - right-handed
+| Stage | Axis | Handedness |
+|---|---|---|
+| ``delta`` | −lateral (−z) | left-handed |
+| ``gamma`` | +vertical (+x) | right-handed |
 
 **Shared stage:** alpha (base stage shared between sample and detector stacks)
 
@@ -64,6 +46,5 @@ Available modes: *(none defined)*
 
 ## References
 
-- Bloch, *J. Appl. Cryst.* **18**, 33–36 (1985). DOI: `10.1107/S0021889885009858 <https://doi.org/10.1107/S0021889885009858>`_
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- Bloch, *J. Appl. Cryst.* **18**, 33–36 (1985). DOI: [10.1107/S0021889885009858](https://doi.org/10.1107/S0021889885009858)
 - Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).

--- a/roadmap.md
+++ b/roadmap.md
@@ -14,6 +14,23 @@ as they are completed.
 
 ---
 
+## v1.0 criteria
+
+The following must be resolved before a v1.0 tag is applied:
+
+- [~] **#122** — Review and expand diffraction modes for psic, sixc, fivec,
+  and kappa6c (horizontal scattering plane variants, fixed_nu, grazing
+  incidence, azimuthal ψ scan mode).
+  [Issue #122](https://github.com/prjemian/ad_hoc_diffractometer/issues/122)
+
+The following are **not** required for v1.0:
+
+- **#114** — Sphere of confusion (SoC): more involved; deferred to a later
+  release.
+  [Issue #114](https://github.com/prjemian/ad_hoc_diffractometer/issues/114)
+
+---
+
 ## Already implemented
 
 - [x] Rotation axis description: signed basis vector notation (+x, -z, etc.)


### PR DESCRIPTION
## Problem

All 10 geometry reference pages used reST `.. list-table::` directives
inside MyST Markdown files — the directive source leaked into rendered HTML.

## Fix

Regenerated all 10 pages using MyST-native pipe tables.  Also:
- "floor first" → "base first" in stage-layout headings (#128 consistency)
- `roadmap.md`: v1.0 criteria section (#122 required, #114 deferred)

Zero doc build warnings.

Contributed by: OpenCode (argo/claudesonnet46)