### PR TITLE
docs: enrich geometry pages — modes, factory source link, consistent titles

### DIFF
--- a/docs/source/geometries/fivec.md
+++ b/docs/source/geometries/fivec.md
@@ -1,5 +1,5 @@
 (geometry-fivec)=
-# fivec — Five-Circle (Vlieg et al. 1987)
+# fivec — Eulerian Five-Circle (Vlieg et al. 1987)
 
 Five-circle diffractometer: a standard fourcv (Eulerian four-circle) mounted on a vertical mu base stage. Sample and detector are coupled through mu.
 
@@ -16,6 +16,12 @@ g = ahd.fivec()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.fivec` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L974) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -38,12 +44,16 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: *(none defined)*
+*(No modes defined for this geometry.  All stages are free during*
+*`forward()` — the solver explores the full solution space.)*
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.fivec`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -1,5 +1,5 @@
 (geometry-fourch)=
-# fourch — Four-Circle Eulerian (Laboratory)
+# fourch — Eulerian Four-Circle (Laboratory)
 
 Busing & Levy (1967) four-circle Eulerian diffractometer, horizontal scattering plane. ω and 2θ rotate about the vertical axis. Standard laboratory convention.
 
@@ -16,6 +16,12 @@ g = ahd.fourch()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.fourch` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L556) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -35,12 +41,34 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_chi`, `fixed_phi`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+
+### `fixed_chi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `chi` fixed at 90.0° during `forward()`. All other free stages are computed by the solver.
+
+### `fixed_phi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `phi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.fourch`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -1,5 +1,5 @@
 (geometry-fourcv)=
-# fourcv — Four-Circle Eulerian (Synchrotron)
+# fourcv — Eulerian Four-Circle (Synchrotron)
 
 Busing & Levy (1967) four-circle Eulerian diffractometer, vertical scattering plane. ω and 2θ rotate about the lateral axis. Standard synchrotron convention.
 
@@ -16,6 +16,12 @@ g = ahd.fourcv()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.fourcv` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L502) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -35,12 +41,34 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_chi`, `fixed_phi`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+
+### `fixed_chi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `chi` fixed at 90.0° during `forward()`. All other free stages are computed by the solver.
+
+### `fixed_phi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `phi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.fourcv`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/index.rst
+++ b/docs/source/geometries/index.rst
@@ -12,9 +12,9 @@ Geometries are grouped below by their chi-circle mechanism.
 
    fourcv
    fourch
+   fivec
    psic
    sixc
-   fivec
    kappa4cv
    kappa4ch
    kappa6c
@@ -43,13 +43,20 @@ rotation axis.
 
       Horizontal scattering plane — ω and 2θ rotate about the vertical axis.
 
-Eulerian six-circle
--------------------
+Eulerian five- and six-circle
+-----------------------------
 
-A four-circle Eulerian sample stack with an additional base stage and a
-two-axis detector arm.
+A four-circle Eulerian sample stack extended with one or two additional
+base or detector stages.
 
 .. grid:: 3
+
+   .. grid-item-card:: :material-outlined:`rotate_right;3em` Five-circle (fivec)
+      :link: fivec
+      :link-type: doc
+
+      fourcv on a vertical mu base; sample and detector
+      coupled through mu. Vlieg et al. (1987).
 
    .. grid-item-card:: :material-outlined:`rotate_right;3em` 4S+2D (psic)
       :link: psic
@@ -64,13 +71,6 @@ two-axis detector arm.
 
       Sample and detector share a common alpha base stage.
       Lohmeier & Vlieg (1993).
-
-   .. grid-item-card:: :material-outlined:`rotate_right;3em` Five-circle
-      :link: fivec
-      :link-type: doc
-
-      Four-circle (fourcv) on a vertical mu base; sample and detector
-      coupled through mu. Vlieg et al. (1987).
 
 Kappa
 -----

--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -17,6 +17,12 @@ g.wavelength = 1.0  # Å
 print(g.summary())
 ```
 
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa4ch` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L733) for the complete stage
+and mode configuration.
+
 ## Stage layout
 
 **Sample stages (base first):**
@@ -35,12 +41,28 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_kphi`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+
+### `fixed_kphi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `kphi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.kappa4ch`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -17,6 +17,12 @@ g.wavelength = 1.0  # Å
 print(g.summary())
 ```
 
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa4cv` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L668) for the complete stage
+and mode configuration.
+
 ## Stage layout
 
 **Sample stages (base first):**
@@ -35,12 +41,28 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_kphi`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+
+### `fixed_kphi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `kphi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.kappa4cv`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -1,5 +1,5 @@
 (geometry-kappa6c)=
-# kappa6c — Six-Circle Kappa (Synchrotron)
+# kappa6c — Kappa Six-Circle
 
 Six-circle kappa diffractometer with psic-style outer axes (mu, nu). The inner sample axes (komega, kappa, and kphi) replace the Eulerian chi circle. Lateral detector, vertical scattering plane.
 
@@ -14,6 +14,12 @@ g = ahd.kappa6c()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa6c` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L794) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -35,12 +41,35 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_kphi`, `fixed_mu`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+Additional frozen stages: `mu` = 0.0°, `nu` = 0.0°.
+
+### `fixed_kphi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `kphi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
+### `fixed_mu`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `mu` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.kappa6c`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -1,5 +1,5 @@
 (geometry-psic)=
-# psic — Six-Circle 4S+2D (You 1999)
+# psic — Eulerian Six-Circle, 4S+2D (You 1999)
 
 You (1999) 4S+2D six-circle diffractometer. Four sample stages (mu, eta, chi, and phi) and two detector stages (nu, delta). Lateral detector, vertical scattering plane. Standard synchrotron six-circle.
 
@@ -14,6 +14,12 @@ g = ahd.psic()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.psic` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L439) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -35,12 +41,41 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: `bisecting`, `fixed_chi`, `fixed_phi`, `fixed_mu`
+Set the active mode with `g.mode_name = "<mode>"`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+
+### `bisecting`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L215))
+
+The bisecting condition: the sample stage angle equals half the detector angle, placing the sample symmetrically between the incident and diffracted beams.
+Additional frozen stages: `mu` = 0.0°, `nu` = 0.0°.
+
+### `fixed_chi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `chi` fixed at 90.0° during `forward()`. All other free stages are computed by the solver.
+
+### `fixed_phi`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `phi` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
+### `fixed_mu`
+
+**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+
+Holds `mu` fixed at 0.0° during `forward()`. All other free stages are computed by the solver.
+
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.psic`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -17,6 +17,12 @@ g.wavelength = 1.0  # Å
 print(g.summary())
 ```
 
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.s2d2` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L921) for the complete stage
+and mode configuration.
+
 ## Stage layout
 
 **Sample stages (base first):**
@@ -35,12 +41,16 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: *(none defined)*
+*(No modes defined for this geometry.  All stages are free during*
+*`forward()` — the solver explores the full solution space.)*
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.s2d2`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -1,5 +1,5 @@
 (geometry-sixc)=
-# sixc — Six-Circle Surface (Lohmeier & Vlieg 1993)
+# sixc — Eulerian Six-Circle, Surface (Lohmeier & Vlieg 1993)
 
 Six-circle surface diffractometer. Sample and detector share a common alpha (rotary table) base stage. Designed for surface diffraction.
 
@@ -16,6 +16,12 @@ g = ahd.sixc()
 g.wavelength = 1.0  # Å
 print(g.summary())
 ```
+
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.sixc` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L609) for the complete stage
+and mode configuration.
 
 ## Stage layout
 
@@ -39,12 +45,16 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: *(none defined)*
+*(No modes defined for this geometry.  All stages are free during*
+*`forward()` — the solver explores the full solution space.)*
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.sixc`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 

--- a/docs/source/geometries/zaxis.md
+++ b/docs/source/geometries/zaxis.md
@@ -17,6 +17,12 @@ g.wavelength = 1.0  # Å
 print(g.summary())
 ```
 
+## Pre-built geometry definition
+
+This geometry is defined by the {func}`~ad_hoc_diffractometer.zaxis` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L872) for the complete stage
+and mode configuration.
+
 ## Stage layout
 
 **Sample stages (base first):**
@@ -37,12 +43,16 @@ print(g.summary())
 
 ## Diffraction modes
 
-Available modes: *(none defined)*
+*(No modes defined for this geometry.  All stages are free during*
+*`forward()` — the solver explores the full solution space.)*
 
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.zaxis`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
+- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
+- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
 
 ## References
 


### PR DESCRIPTION
## Changes

**All 10 geometry pages** (`docs/source/geometries/*.md`):

- **Modes section**: each mode now has its class name (AutoAPI link),
  a GitHub source link to the mode definition, and a plain-language
  description of what it constrains (bisecting condition, fixed stage and value)
- **Pre-built geometry definition** section: GitHub source link to the
  factory function line in `factories.py`
- **API reference** extended with `DiffractionMode`, `BisectingMode`,
  `FixedAngleMode` class links

**Consistent title pattern:**
- Eulerian Four-Circle (Synchrotron / Laboratory)
- Eulerian Five-Circle
- Eulerian Six-Circle, 4S+2D (psic) / Surface (sixc)
- Kappa Four-Circle (Synchrotron / Laboratory)
- Kappa Six-Circle
- Z-Axis / S2D2 unchanged

**`geometries/index.rst`:**
- Toctree order: fourcv → fourch → fivec → psic → sixc → kappas → surface
- Section renamed to "Eulerian five- and six-circle"
- `fivec` card moved before `psic` (five-circle sits between four and six)

Zero doc build warnings. 1206 tests, 100% coverage.

Contributed by: OpenCode (argo/claudesonnet46)