### PR TITLE
docs: add Quick Start guide and restructure User Guide along Diátaxis lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,19 @@ libraries are required.
 ```python
 import ad_hoc_diffractometer as ahd
 
-# Create a six-circle psic geometry and set the wavelength
-g = ahd.psic()
-g.wavelength = 1.0  # Å
+# Four-circle geometry (Busing & Levy 1967, vertical scattering plane)
+g = ahd.fourcv()
+g.wavelength = 1.5406          # Å (Cu Kα)
+g.sample.lattice = ahd.Lattice(a=5.431)  # cubic silicon
 
-# Define the sample lattice (cubic silicon)
-g.sample.lattice = ahd.Lattice(a=5.431)
-
-# Show a summary of the geometry
 print(g.summary())
 ```
+
+See the
+[Quick Start guide](https://prjemian.github.io/ad_hoc_diffractometer/latest/quick_start.html)
+for a step-by-step walkthrough that builds the same geometry without the
+factory function — choosing a coordinate basis, stacking stages, defining
+diffraction modes, and running a forward calculation.
 
 ## Install
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,10 +5,15 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-.PHONY: help Makefile
+.PHONY: help realclean Makefile
 
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+realclean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	rm -rf "$(BUILDDIR)/.jupyter_cache"
+	rm -rf "$(SOURCEDIR)/autoapi"
 
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,8 +1,8 @@
 .. _api:
 
-=============
-API Reference
-=============
+===
+API
+===
 
 The complete public API is auto-generated from docstrings by
 `sphinx-autoapi <https://sphinx-autoapi.readthedocs.io/>`_.

--- a/docs/source/geometries/index.rst
+++ b/docs/source/geometries/index.rst
@@ -1,7 +1,7 @@
 .. _geometries:
 
-Geometry Reference
-==================
+Prebuilt Geometries
+===================
 
 Each factory function returns a fully configured
 :class:`~ad_hoc_diffractometer.geometry.AdHocDiffractometer` instance.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,11 +46,6 @@ It provides:
    user_guide
    api
    changes
-   references
-   glossary
-   direct-lattice
-   problem1
-   problem2
 
 .. icons: https://fonts.google.com/icons
 
@@ -104,26 +99,30 @@ It provides:
    # Show a summary of the geometry
    print(g.summary())
 
+See the :doc:`Quick Start guide <quick_start>` to build a four-circle
+geometry step by step — choosing a basis, stacking stages, defining modes,
+and running a forward calculation — without using a factory function.
+
 Background
 ----------
 
 .. grid:: 3
 
    .. grid-item-card:: :material-outlined:`functions;3em` Direct Lattice
-      :link: direct-lattice
-      :link-type: doc
+      :link: direct-lattice.html
+      :link-type: url
 
       Vector mathematics and lattice vector conventions in crystallography.
 
    .. grid-item-card:: :material-outlined:`science;3em` Case Study
-      :link: problem1
-      :link-type: doc
+      :link: problem1.html
+      :link-type: url
 
       The diffractometer problem that started this project.
 
    .. grid-item-card:: :material-outlined:`calculate;3em` You (1999) Geometry
-      :link: problem2
-      :link-type: doc
+      :link: problem2.html
+      :link-type: url
 
       Coordinate conventions and B/U/UB matrix derivation following
       You (1999) and Busing & Levy (1967).

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -1,0 +1,192 @@
+(quick-start)=
+# Quick Start
+
+This guide walks through the steps to build a four-circle diffractometer
+geometry by hand — without using the pre-built factory function.  Building
+it step by step makes the design choices explicit and shows how every
+geometry in the package is constructed.
+
+The concise factory-function equivalent appears at the end.
+
+---
+
+## 1. Choose a coordinate basis
+
+The package supports two standard coordinate conventions.  Each maps the
+physical directions of the instrument to Cartesian unit vectors:
+
+| Basis | vertical | longitudinal | lateral | Used by |
+|---|---|---|---|---|
+| `BASIS_YOU` | +x | +y | +z | psic, sixc, kappa6c, zaxis, s2d2, fivec |
+| `BASIS_BL` | +z | +y | +x | fourcv, fourch, kappa4cv, kappa4ch |
+
+For a standard four-circle diffractometer (Busing & Levy 1967) choose
+`BASIS_BL`:
+
+```python
+import numpy as np
+import ad_hoc_diffractometer as ahd
+
+BASIS = ahd.BASIS_BL
+LATERAL      = BASIS["lateral"]       # +x
+LONGITUDINAL = BASIS["longitudinal"]  # +y
+VERTICAL     = BASIS["vertical"]      # +z
+```
+
+---
+
+## 2. Define the stage stack
+
+A four-circle diffractometer has three sample stages and one detector stage.
+Each {class}`~ad_hoc_diffractometer.Stage` is described by:
+
+- **name** — motor name used in angle dictionaries and `forward()` results
+- **axis** — rotation axis vector; a leading `−` means left-handed rotation
+- **parent** — the stage this one sits on (`None` = directly on the floor)
+- **role** — `"sample"` or `"detector"`
+
+The fourcv (vertical scattering plane, synchrotron) stack is:
+
+```python
+stages = [
+    # Sample stack — base stage first
+    ahd.Stage("omega",  -LATERAL,      parent=None,    role="sample"),
+    ahd.Stage("chi",    +LONGITUDINAL, parent="omega", role="sample"),
+    ahd.Stage("phi",    -LATERAL,      parent="chi",   role="sample"),
+    # Detector — independent of the sample stack
+    ahd.Stage("ttheta", -LATERAL,      parent=None,    role="detector"),
+]
+```
+
+`omega` and `ttheta` both rotate about the lateral axis, so their scattering
+plane is **vertical** (the synchrotron convention).  For the laboratory
+(horizontal scattering plane) convention swap every `LATERAL` for `VERTICAL`
+and every `LONGITUDINAL` for `LATERAL` — that is the `fourch` geometry.
+
+---
+
+## 3. Define diffraction modes
+
+A {class}`~ad_hoc_diffractometer.DiffractionMode` specifies which degrees of
+freedom are constrained during a forward (hkl → motor angles) calculation.
+
+Two built-in mode types cover most cases:
+
+- {class}`~ad_hoc_diffractometer.BisectingMode` — ties a sample stage to
+  half the detector angle, placing the sample symmetrically in the beam.
+- {class}`~ad_hoc_diffractometer.FixedAngleMode` — holds one stage at a
+  preset angle.
+
+```python
+modes = {
+    "bisecting": ahd.BisectingMode(
+        sample_stage="omega",
+        detector_stage="ttheta",
+    ),
+    "fixed_chi": ahd.FixedAngleMode(stage="chi", value=90.0),
+    "fixed_phi": ahd.FixedAngleMode(stage="phi", value=0.0),
+}
+```
+
+---
+
+## 4. Assemble the geometry
+
+Pass the stage list, basis, and modes to
+{class}`~ad_hoc_diffractometer.AdHocDiffractometer`:
+
+```python
+g = ahd.AdHocDiffractometer(
+    name="my_fourcv",
+    stages=stages,
+    basis=BASIS,
+    description="Four-circle Eulerian, vertical scattering plane",
+    modes=modes,
+    default_mode="bisecting",
+)
+```
+
+---
+
+## 5. Set the wavelength and sample lattice
+
+```python
+g.wavelength = 1.5406          # Å (Cu Kα)
+g.sample.lattice = ahd.Lattice(a=5.431)  # cubic silicon
+```
+
+---
+
+## 6. Inspect the geometry
+
+```python
+print(g.summary())
+```
+
+Example output:
+
+```
+Geometry: my_fourcv
+  Four-circle Eulerian, vertical scattering plane
+  Wavelength: 1.5406 Å   Energy: 8.0478 keV
+  Mode: bisecting
+
+  Sample stages:
+    omega   axis=-lateral    angle=  0.000°  limits=(-180.0, 180.0)
+    chi     axis=+longitudinal  angle=  0.000°  limits=(-180.0, 180.0)
+    phi     axis=-lateral    angle=  0.000°  limits=(-180.0, 180.0)
+
+  Detector stages:
+    ttheta  axis=-lateral    angle=  0.000°  limits=(-180.0, 180.0)
+```
+
+---
+
+## 7. Solve the forward problem
+
+Given a reflection (hkl), find the motor angles that satisfy Bragg's law.
+First orient the crystal (see {doc}`howto/orient`), then call `forward()`:
+
+```python
+# Minimal orientation: identity U matrix (crystal axes || diffractometer axes)
+ahd.ub_identity(g.sample)
+
+# Solve for the (0, 0, 4) reflection
+solutions = g.forward(0, 0, 4)
+for sol in solutions:
+    print(sol)
+```
+
+---
+
+## Concise form — the factory function
+
+The code above is exactly what the built-in `fourcv()` factory does.
+If you do not need to customise anything, use it directly:
+
+```python
+import ad_hoc_diffractometer as ahd
+
+g = ahd.fourcv()               # Busing & Levy (1967) four-circle, vertical plane
+g.wavelength = 1.5406          # Å
+g.sample.lattice = ahd.Lattice(a=5.431)
+print(g.summary())
+```
+
+See {doc}`geometries/fourcv` for the full geometry reference, or
+{doc}`geometries/fourch` for the horizontal-plane (laboratory) variant.
+
+---
+
+## See also
+
+- {class}`~ad_hoc_diffractometer.AdHocDiffractometer`
+- {class}`~ad_hoc_diffractometer.Stage`
+- {class}`~ad_hoc_diffractometer.BisectingMode`
+- {class}`~ad_hoc_diffractometer.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.Lattice`
+- {doc}`howto/lattice`
+- {doc}`howto/orient`
+- {doc}`howto/forward`
+- {doc}`geometries/fourcv`
+- {doc}`geometries/fourch`

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -6,14 +6,94 @@ User Guide
 
 .. toctree::
    :hidden:
+   :caption: Tutorials
+
+   quick_start
+
+.. toctree::
+   :hidden:
+   :caption: How-to Guides
+
+   howto/index
+
+.. toctree::
+   :hidden:
+   :caption: Reference
+
+   geometries/index
+   glossary
+   references
+
+.. toctree::
+   :hidden:
+   :caption: Explanation
 
    concepts
-   howto/index
-   geometries/index
-   references
-   glossary
+   direct-lattice
+   problem1
+   problem2
 
 .. icons: https://fonts.google.com/icons
+
+Tutorials
+---------
+
+.. grid:: 2
+
+   .. grid-item-card:: :material-outlined:`rocket_launch;3em` Quick Start
+      :link: quick_start
+      :link-type: doc
+
+      Build a four-circle diffractometer step by step — without a factory
+      function — and run your first forward calculation.
+
+How-to Guides
+-------------
+
+.. grid:: 2
+
+   .. grid-item-card:: :material-outlined:`directions_run;3em` How-to Guides
+      :link: howto/index
+      :link-type: doc
+
+      Step-by-step guides: set wavelength, define a lattice, orient a
+      crystal, solve the forward problem, switch modes, plan trajectories,
+      and align a crystal end-to-end.
+
+Reference
+---------
+
+.. grid:: 2
+
+   .. grid-item-card:: :material-outlined:`format_list_bulleted;3em` Prebuilt Geometries
+      :link: geometries/index
+      :link-type: doc
+
+      Eulerian (4, 5, and 6 circle) · Kappa (4 and 6 circle) ·
+      Surface and special-purpose
+
+   .. grid-item-card:: :material-regular:`menu_book;3em` API Reference
+      :link: api
+      :link-type: doc
+
+      Complete auto-generated reference for every public class,
+      function, and constant.
+
+   .. grid-item-card:: :material-outlined:`abc;3em` Glossary
+      :link: glossary
+      :link-type: doc
+
+      Alphabetised definitions of key terms.
+
+   .. grid-item-card:: :material-outlined:`library_books;3em` References
+      :link: references
+      :link-type: doc
+
+      All literature citations — geometry papers, physical constants,
+      and numerical methods.
+
+Explanation
+-----------
 
 .. grid:: 2
 
@@ -24,37 +104,21 @@ User Guide
       Coordinate conventions, axis sign convention, B/U/UB matrices,
       diffraction modes, and the ψ angle.
 
-   .. grid-item-card:: :material-outlined:`directions_run;3em` How-to Guides
-      :link: howto/index
+   .. grid-item-card:: :material-outlined:`functions;3em` Direct Lattice
+      :link: direct-lattice
       :link-type: doc
 
-      Step-by-step guides: set wavelength, define a lattice, orient a
-      crystal, solve the forward problem, switch modes, plan trajectories,
-      and align a crystal end-to-end.
+      Vector mathematics and lattice vector conventions in crystallography.
 
-   .. grid-item-card:: :material-outlined:`format_list_bulleted;3em` Geometry Reference
-      :link: geometries/index
+   .. grid-item-card:: :material-outlined:`science;3em` Case Study
+      :link: problem1
       :link-type: doc
 
-      Eulerian (4, 5, and 6 circle) · Kappa (4 and 6 circle) ·
-      Surface and special-purpose
+      The diffractometer problem that started this project.
 
-   .. grid-item-card:: :material-outlined:`library_books;3em` References
-      :link: references
+   .. grid-item-card:: :material-outlined:`calculate;3em` You (1999) Geometry
+      :link: problem2
       :link-type: doc
 
-      All literature citations — geometry papers, physical constants,
-      and numerical methods.
-
-   .. grid-item-card:: :material-outlined:`abc;3em` Glossary
-      :link: glossary
-      :link-type: doc
-
-      Alphabetised definitions of key terms.
-
-   .. grid-item-card:: :material-regular:`menu_book;3em` API Reference
-      :link: api
-      :link-type: doc
-
-      Complete auto-generated reference for every public class,
-      function, and constant.
+      Coordinate conventions and B/U/UB matrix derivation following
+      You (1999) and Busing & Levy (1967).


### PR DESCRIPTION
## Summary

- Adds `docs/source/quick_start.md`: a step-by-step tutorial that builds a four-circle diffractometer without a factory function (basis choice → stage stack → modes → assembly → forward calculation), ending with the concise factory-function equivalent
- Restructures the User Guide into four Diátaxis sections (Tutorials, How-to Guides, Reference, Explanation) with captioned toctrees and matching card grids
- Tightens the top navbar to four entries: Installation · User Guide · API · Change History
- Renames "Geometry Reference" → "Prebuilt Geometries" throughout
- Adds a `realclean` target to `docs/Makefile` (removes build/, jupyter cache, autoapi)
- Updates README.md Quick start snippet

- closes #146

Contributed by: OpenCode (argo/claudesonnet46)