### PR TITLE
feat: fourcv and fourch diffraction modes (#149)

### DIFF
--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -161,9 +161,11 @@ from .constants import XHAT
 from .constants import YHAT
 from .constants import ZHAT
 from .geometry import AdHocDiffractometer
+from .mode import REQUIRED
 from .mode import BisectConstraint
 from .mode import ConstraintSet
 from .mode import DetectorConstraint
+from .mode import ReferenceConstraint
 from .mode import SampleConstraint
 from .stage import Stage
 
@@ -566,7 +568,6 @@ def fourcv(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         Stage("ttheta", -LATERAL, parent=None, role="detector"),
     ]
     # fourcv: 4 DOF, N-3=1 constraint needed per mode.
-    # fourcv: 4 DOF, N-3=1 constraint needed per mode.
     modes = {
         "bisecting": ConstraintSet(
             [BisectConstraint("omega", "ttheta")],
@@ -579,6 +580,20 @@ def fourcv(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         "fixed_phi": ConstraintSet(
             [SampleConstraint("phi", 0.0)],
             computed=["omega", "chi", "ttheta"],
+        ),
+        "constant_omega": ConstraintSet(
+            [SampleConstraint("omega", 0.0)],
+            computed=["chi", "phi", "ttheta"],
+        ),
+        "psi_constant": ConstraintSet(
+            [ReferenceConstraint("psi", 0.0)],
+            computed=["omega", "chi", "phi", "ttheta"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "double_diffraction": ConstraintSet(
+            [BisectConstraint("omega", "ttheta")],
+            computed=["omega", "chi", "phi", "ttheta"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
     }
     return AdHocDiffractometer(
@@ -629,7 +644,6 @@ def fourch(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         Stage("ttheta", -VERTICAL, parent=None, role="detector"),
     ]
     # fourch: 4 DOF, N-3=1 constraint needed per mode.
-    # fourch: 4 DOF, N-3=1 constraint needed per mode.
     modes = {
         "bisecting": ConstraintSet(
             [BisectConstraint("omega", "ttheta")],
@@ -642,6 +656,20 @@ def fourch(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
         "fixed_phi": ConstraintSet(
             [SampleConstraint("phi", 0.0)],
             computed=["omega", "chi", "ttheta"],
+        ),
+        "constant_omega": ConstraintSet(
+            [SampleConstraint("omega", 0.0)],
+            computed=["chi", "phi", "ttheta"],
+        ),
+        "psi_constant": ConstraintSet(
+            [ReferenceConstraint("psi", 0.0)],
+            computed=["omega", "chi", "phi", "ttheta"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "double_diffraction": ConstraintSet(
+            [BisectConstraint("omega", "ttheta")],
+            computed=["omega", "chi", "phi", "ttheta"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
     }
     return AdHocDiffractometer(

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -175,29 +175,25 @@ def _unsupported_mode():
 
 
 # ---------------------------------------------------------------------------
-# BisectingMode — fourcv (bisecting, omega = ttheta/2)
+# BisectingMode — fourcv and fourch round-trips
 # ---------------------------------------------------------------------------
 
 
-def test_fourcv_bisecting_round_trip_100():
-    g = _setup_cubic(fourcv, a=5.0)
+@pytest.mark.parametrize(
+    "factory, a, h, k, l",
+    [
+        pytest.param(fourcv, 5.0, 1, 0, 0, id="fourcv-100"),
+        pytest.param(fourcv, 5.0, 0, 1, 0, id="fourcv-010"),
+        pytest.param(fourcv, 5.0, 0, 0, 1, id="fourcv-001"),
+        pytest.param(fourcv, 4.0, 1, 1, 1, id="fourcv-111"),
+        pytest.param(fourch, 4.0, 1, 0, 0, id="fourch-100"),
+    ],
+)
+def test_bisecting_round_trip(factory, a, h, k, l):  # noqa: E741
+    """Bisecting mode round-trip: inverse(forward(hkl)) == hkl."""
+    g = _setup_cubic(factory, a=a)
     assert g.mode_name == "bisecting"
-    assert _round_trip_ok(g, 1, 0, 0)
-
-
-def test_fourcv_bisecting_round_trip_010():
-    g = _setup_cubic(fourcv, a=5.0)
-    assert _round_trip_ok(g, 0, 1, 0)
-
-
-def test_fourcv_bisecting_round_trip_001():
-    g = _setup_cubic(fourcv, a=5.0)
-    assert _round_trip_ok(g, 0, 0, 1)
-
-
-def test_fourcv_bisecting_round_trip_111():
-    g = _setup_cubic(fourcv, a=4.0)
-    assert _round_trip_ok(g, 1, 1, 1)
+    assert _round_trip_ok(g, h, k, l)
 
 
 def test_fourcv_bisecting_two_solutions():
@@ -239,30 +235,22 @@ def test_fourcv_bisecting_ttheta_from_bragg():
 
 
 # ---------------------------------------------------------------------------
-# BisectingMode — fourch (omega = ttheta/2, vertical axis)
-# ---------------------------------------------------------------------------
-
-
-def test_fourch_bisecting_round_trip():
-    g = _setup_cubic(fourch, a=4.0)
-    assert g.mode_name == "bisecting"
-    assert _round_trip_ok(g, 1, 0, 0)
-
-
-# ---------------------------------------------------------------------------
 # BisectingMode — psic (eta = delta/2, mu = nu = 0)
 # ---------------------------------------------------------------------------
 
 
-def test_psic_bisecting_round_trip_100():
-    g = _setup_cubic(psic, a=5.0)
+@pytest.mark.parametrize(
+    "a, h, k, l",
+    [
+        pytest.param(5.0, 1, 0, 0, id="psic-100"),
+        pytest.param(4.0, 1, 1, 1, id="psic-111"),
+    ],
+)
+def test_psic_bisecting_round_trip(a, h, k, l):  # noqa: E741
+    """psic bisecting round-trip: inverse(forward(hkl)) == hkl."""
+    g = _setup_cubic(psic, a=a)
     assert g.mode_name == "bisecting"
-    assert _round_trip_ok(g, 1, 0, 0)
-
-
-def test_psic_bisecting_round_trip_111():
-    g = _setup_cubic(psic, a=4.0)
-    assert _round_trip_ok(g, 1, 1, 1)
+    assert _round_trip_ok(g, h, k, l)
 
 
 def test_psic_bisecting_frozen_mu_nu():
@@ -327,6 +315,211 @@ def test_fourcv_fixed_chi_value_respected():
     assert len(solutions) > 0
     for sol in solutions:
         assert sol["chi"] == pytest.approx(90.0, abs=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Issue #149 — fourcv and fourch: all modes present, stubs not implemented
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_has_all_six_modes(factory):
+    """fourcv and fourch both expose all 6 declared modes as ConstraintSet."""
+    g = factory()
+    expected = {
+        "bisecting",
+        "fixed_chi",
+        "fixed_phi",
+        "constant_omega",
+        "psi_constant",
+        "double_diffraction",
+    }
+    assert set(g.modes.keys()) == expected
+    for name, mode in g.modes.items():
+        assert isinstance(mode, ConstraintSet), f"{name} is not a ConstraintSet"
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(fourcv, "psi_constant", id="fourcv-psi_constant"),
+        pytest.param(fourch, "psi_constant", id="fourch-psi_constant"),
+    ],
+)
+def test_four_circle_stub_not_implemented(factory, mode_name):
+    """psi_constant requires reference infrastructure (Issue J) — not yet implemented."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    assert not g.modes[mode_name].is_implemented(g)
+    with pytest.raises(NotImplementedError):
+        g.forward(1, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "factory, h, k, l",
+    [
+        pytest.param(fourcv, 1, 0, 0, id="fourcv-100"),
+        pytest.param(fourcv, 0, 1, 0, id="fourcv-010"),
+        pytest.param(fourcv, 1, 1, 1, id="fourcv-111"),
+        pytest.param(fourch, 1, 0, 0, id="fourch-100"),
+        pytest.param(fourch, 1, 1, 1, id="fourch-111"),
+    ],
+)
+def test_four_circle_constant_omega_round_trip(factory, h, k, l):  # noqa: E741
+    """constant_omega (omega=0) is implemented by the generic solver; round-trips correctly."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = "constant_omega"
+    assert g.modes["constant_omega"].is_implemented(g)
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_constant_omega_value_in_solution(factory):
+    """constant_omega: omega=0 in all returned solutions."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = "constant_omega"
+    solutions = g.forward(1, 0, 0)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol["omega"] == pytest.approx(0.0, abs=1e-8)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        pytest.param(fourcv, "fixed_phi", 0, 1, 0, id="fourcv-fixed_phi-010"),
+        pytest.param(fourcv, "fixed_phi", 1, 1, 1, id="fourcv-fixed_phi-111"),
+        pytest.param(fourch, "fixed_chi", 1, 0, 0, id="fourch-fixed_chi-100"),
+        pytest.param(fourch, "fixed_chi", 1, 1, 0, id="fourch-fixed_chi-110"),
+        pytest.param(fourch, "fixed_phi", 0, 1, 0, id="fourch-fixed_phi-010"),
+        pytest.param(fourch, "fixed_phi", 1, 1, 1, id="fourch-fixed_phi-111"),
+    ],
+)
+def test_four_circle_fixed_angle_round_trip(factory, mode_name, h, k, l):  # noqa: E741
+    """fixed_chi and fixed_phi round-trips on both fourcv and fourch."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_fixed_stage, expected_value, h, k, l",
+    [
+        pytest.param(
+            fourcv, "fixed_phi", "phi", 0.0, 0, 1, 0, id="fourcv-fixed_phi-value"
+        ),
+        pytest.param(
+            fourch, "fixed_chi", "chi", 90.0, 1, 0, 0, id="fourch-fixed_chi-value"
+        ),
+        pytest.param(
+            fourch, "fixed_phi", "phi", 0.0, 0, 1, 0, id="fourch-fixed_phi-value"
+        ),
+    ],
+)
+def test_four_circle_fixed_angle_constraint_value_in_solution(
+    factory,
+    mode_name,
+    expected_fixed_stage,
+    expected_value,
+    h,
+    k,
+    l,  # noqa: E741
+):
+    """The fixed stage appears at its declared constraint value in all solutions."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol[expected_fixed_stage] == pytest.approx(expected_value, abs=1e-8), (
+            f"{expected_fixed_stage} not at {expected_value} in {sol}"
+        )
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, extras_key, expected_value",
+    [
+        pytest.param(
+            fourcv,
+            "double_diffraction",
+            "h2",
+            "REQUIRED",
+            id="fourcv-double_diffraction-h2",
+        ),
+        pytest.param(
+            fourcv,
+            "double_diffraction",
+            "k2",
+            "REQUIRED",
+            id="fourcv-double_diffraction-k2",
+        ),
+        pytest.param(
+            fourcv,
+            "double_diffraction",
+            "l2",
+            "REQUIRED",
+            id="fourcv-double_diffraction-l2",
+        ),
+        pytest.param(
+            fourch,
+            "double_diffraction",
+            "h2",
+            "REQUIRED",
+            id="fourch-double_diffraction-h2",
+        ),
+        pytest.param(
+            fourch,
+            "double_diffraction",
+            "k2",
+            "REQUIRED",
+            id="fourch-double_diffraction-k2",
+        ),
+        pytest.param(
+            fourch,
+            "double_diffraction",
+            "l2",
+            "REQUIRED",
+            id="fourch-double_diffraction-l2",
+        ),
+        pytest.param(
+            fourcv, "psi_constant", "n_hat", "REQUIRED", id="fourcv-psi_constant-n_hat"
+        ),
+        pytest.param(
+            fourcv, "psi_constant", "psi", None, id="fourcv-psi_constant-psi-output"
+        ),
+        pytest.param(
+            fourch, "psi_constant", "n_hat", "REQUIRED", id="fourch-psi_constant-n_hat"
+        ),
+        pytest.param(
+            fourch, "psi_constant", "psi", None, id="fourch-psi_constant-psi-output"
+        ),
+    ],
+)
+def test_four_circle_mode_extras_declared(
+    factory, mode_name, extras_key, expected_value
+):
+    """Mode extras carry the expected sentinel or output placeholder."""
+    from ad_hoc_diffractometer import REQUIRED
+
+    g = factory()
+    mode = g.modes[mode_name]
+    actual = mode.extras.get(extras_key)
+    if expected_value == "REQUIRED":
+        assert actual is REQUIRED
+    else:
+        assert actual is expected_value
 
 
 # ---------------------------------------------------------------------------
@@ -554,55 +747,76 @@ def test_compute_forward_same_as_method():
 # ---------------------------------------------------------------------------
 
 
-def test_check_limits_all_ok():
-    g = _setup_cubic(fourcv, a=4.0)
-    angles = {s.name: 0.0 for s in g.sample_stages + g.detector_stages}
-    assert _check_limits(g, angles) is True
+@pytest.mark.parametrize(
+    "angles, expected, context",
+    [
+        pytest.param(
+            {s: 0.0 for s in ("omega", "chi", "phi", "ttheta")},
+            True,
+            does_not_raise(),
+            id="all-within-limits",
+        ),
+        pytest.param(
+            {"omega": 0.0, "chi": 200.0, "phi": 0.0, "ttheta": 0.0},
+            False,
+            does_not_raise(),
+            id="chi-out-of-limits",
+        ),
+        pytest.param(
+            {"omega": 0.0, "nonexistent": 999.0},
+            True,
+            does_not_raise(),
+            id="unknown-stage-ignored",
+        ),
+    ],
+)
+def test_check_limits(angles, expected, context):
+    with context:
+        g = _setup_cubic(fourcv, a=4.0)
+        assert _check_limits(g, angles) is expected
 
 
-def test_check_limits_one_fails():
-    g = _setup_cubic(fourcv, a=4.0)
-    angles = {"omega": 0.0, "chi": 200.0, "phi": 0.0, "ttheta": 0.0}
-    assert _check_limits(g, angles) is False
-
-
-def test_check_limits_unknown_stage_ignored():
-    g = _setup_cubic(fourcv, a=4.0)
-    angles = {"omega": 0.0, "nonexistent": 999.0}
-    assert _check_limits(g, angles) is True
-
-
-def test_apply_cut_points_mode_priority():
-    """Mode cut-point takes priority over geometry-level cut-point."""
-    g = _setup_cubic(fourcv, a=4.0)
-    mode = ConstraintSet(
-        [BisectConstraint("omega", "ttheta")],
-        cut_points={"phi": 0.0},  # phi in [0, 360)
-    )
-    g.cut_points["phi"] = -180.0  # would put phi in [-180, 180) if used
-    angles = {"phi": -10.0}
-    _apply_cut_points(angles, mode, g)
-    # Mode cut-point (0°) wins: -10° → 350°
-    assert angles["phi"] == pytest.approx(350.0, abs=1e-10)
-
-
-def test_apply_cut_points_geometry_fallback():
-    """Geometry-level cut-point used when no mode cut-point set for that stage."""
-    g = _setup_cubic(fourcv, a=4.0)
-    mode = ConstraintSet([BisectConstraint("omega", "ttheta")])
-    g.cut_points["phi"] = 0.0  # phi in [0, 360)
-    angles = {"phi": -10.0}
-    _apply_cut_points(angles, mode, g)
-    assert angles["phi"] == pytest.approx(350.0, abs=1e-10)
-
-
-def test_apply_cut_points_no_cut_unchanged():
-    """Angles without any cut-point are unchanged."""
-    g = _setup_cubic(fourcv, a=4.0)
-    mode = ConstraintSet([BisectConstraint("omega", "ttheta")])
-    angles = {"phi": -10.0}
-    _apply_cut_points(angles, mode, g)
-    assert angles["phi"] == pytest.approx(-10.0, abs=1e-10)
+@pytest.mark.parametrize(
+    "mode_cut_points, geom_cut_points, angle_in, expected_out, context",
+    [
+        pytest.param(
+            {"phi": 0.0},
+            {"phi": -180.0},
+            -10.0,
+            350.0,
+            does_not_raise(),
+            id="mode-cut-takes-priority",
+        ),
+        pytest.param(
+            {},
+            {"phi": 0.0},
+            -10.0,
+            350.0,
+            does_not_raise(),
+            id="geometry-cut-fallback",
+        ),
+        pytest.param(
+            {},
+            {},
+            -10.0,
+            -10.0,
+            does_not_raise(),
+            id="no-cut-unchanged",
+        ),
+    ],
+)
+def test_apply_cut_points(
+    mode_cut_points, geom_cut_points, angle_in, expected_out, context
+):
+    with context:
+        g = _setup_cubic(fourcv, a=4.0)
+        mode = ConstraintSet(
+            [BisectConstraint("omega", "ttheta")], cut_points=mode_cut_points
+        )
+        g.cut_points.update(geom_cut_points)
+        angles = {"phi": angle_in}
+        _apply_cut_points(angles, mode, g)
+        assert angles["phi"] == pytest.approx(expected_out, abs=1e-10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -45,6 +45,7 @@ from ad_hoc_diffractometer import ModeDict
 from ad_hoc_diffractometer import ReferenceConstraint
 from ad_hoc_diffractometer import SampleConstraint
 from ad_hoc_diffractometer import Stage
+from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer.constants import XHAT
 from ad_hoc_diffractometer.constants import YHAT
@@ -109,19 +110,18 @@ def _psic_like(**kwargs):
 
 
 @pytest.mark.parametrize(
-    "name, value, context",
+    "name, value",
     [
-        pytest.param("chi", 90.0, does_not_raise(), id="fixed-chi-90"),
-        pytest.param("phi", 0.0, does_not_raise(), id="fixed-phi-0"),
-        pytest.param("mu", -45.0, does_not_raise(), id="fixed-mu-neg45"),
+        pytest.param("chi", 90.0, id="fixed-chi-90"),
+        pytest.param("phi", 0.0, id="fixed-phi-0"),
+        pytest.param("mu", -45.0, id="fixed-mu-neg45"),
     ],
 )
-def test_sample_constraint_construction(name, value, context):
-    with context:
-        sc = SampleConstraint(name, value)
-        assert sc.name == name
-        assert sc.is_bisect is False
-        assert sc.category == "sample"
+def test_sample_constraint_construction(name, value):
+    sc = SampleConstraint(name, value)
+    assert sc.name == name
+    assert sc.is_bisect is False
+    assert sc.category == "sample"
 
 
 def test_sample_constraint_value_coerced_to_float():
@@ -138,20 +138,91 @@ def test_sample_constraint_repr_fixed():
     assert "90.0" in r
 
 
-def test_sample_constraint_eq_same():
-    assert SampleConstraint("chi", 90.0) == SampleConstraint("chi", 90.0)
-
-
-def test_sample_constraint_eq_different_name():
-    assert SampleConstraint("chi", 90.0) != SampleConstraint("phi", 90.0)
-
-
-def test_sample_constraint_eq_different_value():
-    assert SampleConstraint("chi", 90.0) != SampleConstraint("chi", 0.0)
-
-
-def test_sample_constraint_eq_different_type():
-    assert SampleConstraint("chi", 90.0) != DetectorConstraint("chi", 90.0)
+@pytest.mark.parametrize(
+    "lhs, rhs, expected",
+    [
+        pytest.param(
+            SampleConstraint("chi", 90.0),
+            SampleConstraint("chi", 90.0),
+            True,
+            id="sample-eq-same",
+        ),
+        pytest.param(
+            SampleConstraint("chi", 90.0),
+            SampleConstraint("phi", 90.0),
+            False,
+            id="sample-eq-different-name",
+        ),
+        pytest.param(
+            SampleConstraint("chi", 90.0),
+            SampleConstraint("chi", 0.0),
+            False,
+            id="sample-eq-different-value",
+        ),
+        pytest.param(
+            SampleConstraint("chi", 90.0),
+            DetectorConstraint("chi", 90.0),
+            False,
+            id="sample-eq-different-type",
+        ),
+        pytest.param(
+            BisectConstraint("omega", "ttheta"),
+            BisectConstraint("omega", "ttheta"),
+            True,
+            id="bisect-eq-same",
+        ),
+        pytest.param(
+            BisectConstraint("omega", "ttheta"),
+            BisectConstraint("eta", "delta"),
+            False,
+            id="bisect-eq-different",
+        ),
+        pytest.param(
+            BisectConstraint("omega", "ttheta"),
+            SampleConstraint("omega", 0.0),
+            False,
+            id="bisect-eq-different-type",
+        ),
+        pytest.param(
+            DetectorConstraint("nu", 0.0),
+            DetectorConstraint("nu", 0.0),
+            True,
+            id="detector-eq-same",
+        ),
+        pytest.param(
+            DetectorConstraint("nu", 0.0),
+            DetectorConstraint("delta", 0.0),
+            False,
+            id="detector-eq-different",
+        ),
+        pytest.param(
+            DetectorConstraint("nu", 0.0),
+            SampleConstraint("nu", 0.0),
+            False,
+            id="detector-eq-different-type",
+        ),
+        pytest.param(
+            ReferenceConstraint("psi", 90.0),
+            ReferenceConstraint("psi", 90.0),
+            True,
+            id="reference-eq-same",
+        ),
+        pytest.param(
+            ReferenceConstraint("psi", 90.0),
+            ReferenceConstraint("psi", 0.0),
+            False,
+            id="reference-eq-different",
+        ),
+        pytest.param(
+            ReferenceConstraint("psi", 90.0),
+            SampleConstraint("psi", 90.0),
+            False,
+            id="reference-eq-different-type",
+        ),
+    ],
+)
+def test_constraint_eq(lhs, rhs, expected):
+    assert (lhs == rhs) is expected
 
 
 def test_sample_constraint_to_dict_from_dict_fixed():
@@ -174,67 +245,210 @@ def test_bisect_constraint_to_dict_from_dict():
     assert bc2 == bc
 
 
-def test_sample_constraint_is_implemented_real_stage():
+@pytest.mark.parametrize(
+    "constraint_factory, args, geometry_factory, expected",
+    [
+        pytest.param(
+            SampleConstraint,
+            ("chi", 90.0),
+            _fourcv_like,
+            True,
+            id="sample-real-stage-chi",
+        ),
+        pytest.param(
+            SampleConstraint,
+            ("phi", 0.0),
+            _fourcv_like,
+            True,
+            id="sample-real-stage-phi",
+        ),
+        pytest.param(
+            SampleConstraint,
+            ("mu", 0.0),
+            _fourcv_like,
+            False,
+            id="sample-missing-stage-mu",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "ttheta"),
+            _fourcv_like,
+            True,
+            id="bisect-both-stages-exist-fourcv",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("eta", "delta"),
+            _psic_like,
+            True,
+            id="bisect-both-stages-exist-psic",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("eta", "ttheta"),
+            _fourcv_like,
+            False,
+            id="bisect-sample-stage-missing",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "delta"),
+            _fourcv_like,
+            False,
+            id="bisect-detector-stage-missing",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("nu", 0.0),
+            _psic_like,
+            True,
+            id="detector-real-stage-nu",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("delta", 0.0),
+            _psic_like,
+            True,
+            id="detector-real-stage-delta",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("gamma", 0.0),
+            _psic_like,
+            False,
+            id="detector-missing-stage-gamma",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("qaz", 90.0),
+            _psic_like,
+            False,
+            id="detector-qaz-not-implemented",
+        ),
+    ],
+)
+def test_constraint_is_implemented(
+    constraint_factory, args, geometry_factory, expected
+):
+    g = geometry_factory()
+    assert constraint_factory(*args).is_implemented(g) is expected
+
+
+_ANGLES_FOURCV = {"omega": 10.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
+_ANGLES_PSIC = {
+    "mu": 0.0,
+    "eta": 10.0,
+    "chi": 90.0,
+    "phi": 0.0,
+    "nu": 0.0,
+    "delta": 20.0,
+}
+
+
+@pytest.mark.parametrize(
+    "constraint_factory, args, angles, expected_residual",
+    [
+        pytest.param(
+            SampleConstraint,
+            ("chi", 90.0),
+            _ANGLES_FOURCV,
+            0.0,
+            id="sample-chi-satisfied",
+        ),
+        pytest.param(
+            SampleConstraint,
+            ("chi", 45.0),
+            _ANGLES_FOURCV,
+            45.0,
+            id="sample-chi-not-satisfied",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "ttheta"),
+            _ANGLES_FOURCV,
+            0.0,
+            id="bisect-satisfied",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "ttheta"),
+            {**_ANGLES_FOURCV, "omega": 5.0},
+            -5.0,
+            id="bisect-not-satisfied",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("nu", 0.0),
+            _ANGLES_PSIC,
+            0.0,
+            id="detector-nu-satisfied",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("nu", 5.0),
+            _ANGLES_PSIC,
+            -5.0,
+            id="detector-nu-not-satisfied",
+        ),
+    ],
+)
+def test_constraint_evaluate(constraint_factory, args, angles, expected_residual):
     g = _fourcv_like()
-    assert SampleConstraint("chi", 90.0).is_implemented(g) is True
-    assert SampleConstraint("phi", 0.0).is_implemented(g) is True
+    assert constraint_factory(*args).evaluate(angles, g) == pytest.approx(
+        expected_residual
+    )
 
 
-def test_sample_constraint_is_implemented_missing_stage():
+@pytest.mark.parametrize(
+    "constraint_factory, args, angles, expected_satisfied",
+    [
+        pytest.param(
+            SampleConstraint,
+            ("chi", 90.0),
+            _ANGLES_FOURCV,
+            True,
+            id="sample-chi-satisfied",
+        ),
+        pytest.param(
+            SampleConstraint,
+            ("chi", 45.0),
+            _ANGLES_FOURCV,
+            False,
+            id="sample-chi-not-satisfied",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "ttheta"),
+            _ANGLES_FOURCV,
+            True,
+            id="bisect-satisfied",
+        ),
+        pytest.param(
+            BisectConstraint,
+            ("omega", "ttheta"),
+            {**_ANGLES_FOURCV, "omega": 5.0},
+            False,
+            id="bisect-not-satisfied",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("nu", 0.0),
+            _ANGLES_PSIC,
+            True,
+            id="detector-nu-satisfied",
+        ),
+        pytest.param(
+            DetectorConstraint,
+            ("nu", 5.0),
+            _ANGLES_PSIC,
+            False,
+            id="detector-nu-not-satisfied",
+        ),
+    ],
+)
+def test_constraint_is_satisfied(constraint_factory, args, angles, expected_satisfied):
     g = _fourcv_like()
-    assert SampleConstraint("mu", 0.0).is_implemented(g) is False
-
-
-def test_bisect_constraint_is_implemented_both_stages_exist():
-    g = _fourcv_like()
-    assert BisectConstraint("omega", "ttheta").is_implemented(g) is True
-
-
-def test_bisect_constraint_is_implemented_sample_stage_missing():
-    g = _fourcv_like()
-    assert BisectConstraint("eta", "ttheta").is_implemented(g) is False
-
-
-def test_bisect_constraint_is_implemented_detector_stage_missing():
-    g = _fourcv_like()
-    assert BisectConstraint("omega", "delta").is_implemented(g) is False
-
-
-def test_bisect_constraint_is_implemented_psic():
-    g = _psic_like()
-    assert BisectConstraint("eta", "delta").is_implemented(g) is True
-
-
-def test_sample_constraint_evaluate_fixed(tmp_path):
-    g = _fourcv_like()
-    angles = {"omega": 10.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
-    sc = SampleConstraint("chi", 90.0)
-    assert sc.evaluate(angles, g) == pytest.approx(0.0)
-    sc2 = SampleConstraint("chi", 45.0)
-    assert sc2.evaluate(angles, g) == pytest.approx(45.0)
-
-
-def test_bisect_constraint_evaluate_satisfied():
-    g = _fourcv_like()
-    angles = {"omega": 10.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
-    bc = BisectConstraint("omega", "ttheta")
-    # residual = omega - ttheta/2 = 10 - 10 = 0
-    assert bc.evaluate(angles, g) == pytest.approx(0.0)
-
-
-def test_bisect_constraint_evaluate_not_satisfied():
-    g = _fourcv_like()
-    angles = {"omega": 5.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
-    bc = BisectConstraint("omega", "ttheta")
-    assert bc.evaluate(angles, g) == pytest.approx(-5.0)
-
-
-def test_bisect_constraint_is_satisfied():
-    g = _fourcv_like()
-    angles = {"omega": 10.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
-    assert BisectConstraint("omega", "ttheta").is_satisfied(angles, g)
-    angles2 = dict(angles, omega=5.0)
-    assert not BisectConstraint("omega", "ttheta").is_satisfied(angles2, g)
+    assert constraint_factory(*args).is_satisfied(angles, g) is expected_satisfied
 
 
 def test_bisect_constraint_repr():
@@ -245,23 +459,34 @@ def test_bisect_constraint_repr():
     assert "delta" in r
 
 
-def test_bisect_constraint_eq_same():
-    assert BisectConstraint("omega", "ttheta") == BisectConstraint("omega", "ttheta")
-
-
-def test_bisect_constraint_eq_different():
-    assert BisectConstraint("omega", "ttheta") != BisectConstraint("eta", "delta")
-
-
-def test_bisect_constraint_eq_different_type():
-    assert BisectConstraint("omega", "ttheta") != SampleConstraint("omega", 0.0)
-
-
-def test_bisect_constraint_hash():
-    bc1 = BisectConstraint("omega", "ttheta")
-    bc2 = BisectConstraint("omega", "ttheta")
-    assert hash(bc1) == hash(bc2)
-    assert len({bc1, bc2}) == 1
+@pytest.mark.parametrize(
+    "c1, c2",
+    [
+        pytest.param(
+            BisectConstraint("omega", "ttheta"),
+            BisectConstraint("omega", "ttheta"),
+            id="bisect-hash",
+        ),
+        pytest.param(
+            SampleConstraint("chi", 90.0),
+            SampleConstraint("chi", 90.0),
+            id="sample-hash",
+        ),
+        pytest.param(
+            DetectorConstraint("nu", 0.0),
+            DetectorConstraint("nu", 0.0),
+            id="detector-hash",
+        ),
+        pytest.param(
+            ReferenceConstraint("psi", 90.0),
+            ReferenceConstraint("psi", 90.0),
+            id="reference-hash",
+        ),
+    ],
+)
+def test_constraint_hash(c1, c2):
+    assert hash(c1) == hash(c2)
+    assert len({c1, c2}) == 1
 
 
 def test_bisect_constraint_category():
@@ -276,34 +501,26 @@ def test_bisect_constraint_name():
     assert BisectConstraint("omega", "ttheta").name == "bisect"
 
 
-def test_sample_constraint_is_satisfied():
-    g = _fourcv_like()
-    angles = {"omega": 10.0, "chi": 90.0, "phi": 0.0, "ttheta": 20.0}
-    assert SampleConstraint("chi", 90.0).is_satisfied(angles, g)
-    assert not SampleConstraint("chi", 45.0).is_satisfied(angles, g)
-
-
 # ---------------------------------------------------------------------------
 # DetectorConstraint
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "name, value, expected_is_qaz, context",
+    "name, value, expected_is_qaz",
     [
-        pytest.param("delta", 0.0, False, does_not_raise(), id="fixed-delta"),
-        pytest.param("nu", 0.0, False, does_not_raise(), id="fixed-nu"),
-        pytest.param("ttheta", 20.0, False, does_not_raise(), id="fixed-ttheta"),
-        pytest.param("qaz", 90.0, True, does_not_raise(), id="qaz-pseudo"),
+        pytest.param("delta", 0.0, False, id="fixed-delta"),
+        pytest.param("nu", 0.0, False, id="fixed-nu"),
+        pytest.param("ttheta", 20.0, False, id="fixed-ttheta"),
+        pytest.param("qaz", 90.0, True, id="qaz-pseudo"),
     ],
 )
-def test_detector_constraint_construction(name, value, expected_is_qaz, context):
-    with context:
-        dc = DetectorConstraint(name, value)
-        assert dc.name == name
-        assert dc.value == value
-        assert dc.is_qaz == expected_is_qaz
-        assert dc.category == "detector"
+def test_detector_constraint_construction(name, value, expected_is_qaz):
+    dc = DetectorConstraint(name, value)
+    assert dc.name == name
+    assert dc.value == value
+    assert dc.is_qaz == expected_is_qaz
+    assert dc.category == "detector"
 
 
 def test_detector_constraint_repr():
@@ -313,49 +530,12 @@ def test_detector_constraint_repr():
     assert "nu" in r
 
 
-def test_detector_constraint_eq_same():
-    assert DetectorConstraint("nu", 0.0) == DetectorConstraint("nu", 0.0)
-
-
-def test_detector_constraint_eq_different():
-    assert DetectorConstraint("nu", 0.0) != DetectorConstraint("delta", 0.0)
-
-
-def test_detector_constraint_eq_different_type():
-    assert DetectorConstraint("nu", 0.0) != SampleConstraint("nu", 0.0)
-
-
 def test_detector_constraint_to_dict_from_dict():
     dc = DetectorConstraint("nu", 0.0)
     d = dc.to_dict()
     assert d == {"type": "DetectorConstraint", "name": "nu", "value": 0.0}
     dc2 = DetectorConstraint.from_dict(d)
     assert dc2 == dc
-
-
-def test_detector_constraint_is_implemented_real_stage():
-    g = _psic_like()
-    assert DetectorConstraint("nu", 0.0).is_implemented(g) is True
-    assert DetectorConstraint("delta", 0.0).is_implemented(g) is True
-
-
-def test_detector_constraint_is_implemented_missing():
-    g = _psic_like()
-    assert DetectorConstraint("gamma", 0.0).is_implemented(g) is False
-
-
-def test_detector_constraint_is_implemented_qaz_not_implemented():
-    g = _psic_like()
-    assert DetectorConstraint("qaz", 90.0).is_implemented(g) is False
-
-
-def test_detector_constraint_evaluate_fixed():
-    g = _psic_like()
-    angles = {"mu": 0.0, "eta": 10.0, "chi": 90.0, "phi": 0.0, "nu": 0.0, "delta": 20.0}
-    dc = DetectorConstraint("nu", 0.0)
-    assert dc.evaluate(angles, g) == pytest.approx(0.0)
-    dc2 = DetectorConstraint("nu", 5.0)
-    assert dc2.evaluate(angles, g) == pytest.approx(-5.0)
 
 
 def test_detector_constraint_evaluate_qaz_raises():
@@ -416,18 +596,6 @@ def test_reference_constraint_repr():
     r = repr(rc)
     assert "ReferenceConstraint" in r
     assert "psi" in r
-
-
-def test_reference_constraint_eq_same():
-    assert ReferenceConstraint("psi", 90.0) == ReferenceConstraint("psi", 90.0)
-
-
-def test_reference_constraint_eq_different():
-    assert ReferenceConstraint("psi", 90.0) != ReferenceConstraint("psi", 0.0)
-
-
-def test_reference_constraint_eq_different_type():
-    assert ReferenceConstraint("psi", 90.0) != SampleConstraint("psi", 90.0)
 
 
 def test_reference_constraint_to_dict_from_dict():
@@ -681,60 +849,52 @@ def test_constraint_set_constrained_stages_det_name_present():
 # ---------------------------------------------------------------------------
 
 
-def test_constant_stages_bisect_only():
-    """constant_stages includes the bisect sample stage."""
-    cs = ConstraintSet([BisectConstraint("omega", "ttheta")])
-    assert cs.constant_stages == ["omega"]
-
-
-def test_constant_stages_psic_bisecting():
-    """constant_stages for psic bisecting includes eta, mu, nu."""
-    cs = ConstraintSet(
-        [
-            BisectConstraint("eta", "delta"),
-            SampleConstraint("mu", 0.0),
-            DetectorConstraint("nu", 0.0),
-        ]
-    )
-    assert cs.constant_stages == ["eta", "mu", "nu"]
-
-
-def test_constant_stages_no_bisect():
-    """constant_stages with only fixed sample and detector."""
-    cs = ConstraintSet(
-        [
-            SampleConstraint("chi", 90.0),
-            DetectorConstraint("nu", 0.0),
-        ]
-    )
-    assert "chi" in cs.constant_stages
-    assert "nu" in cs.constant_stages
-
-
-def test_constant_stages_reference_excluded():
-    """ReferenceConstraint does not contribute to constant_stages."""
-    cs = ConstraintSet(
-        [
-            BisectConstraint("omega", "ttheta"),
-            ReferenceConstraint("psi", 90.0),
-        ]
-    )
+@pytest.mark.parametrize(
+    "constraints, expected_in, expected_not_in",
+    [
+        pytest.param(
+            [BisectConstraint("omega", "ttheta")],
+            ["omega"],
+            [],
+            id="bisect-only",
+        ),
+        pytest.param(
+            [
+                BisectConstraint("eta", "delta"),
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+            ],
+            ["eta", "mu", "nu"],
+            [],
+            id="psic-bisecting",
+        ),
+        pytest.param(
+            [SampleConstraint("chi", 90.0), DetectorConstraint("nu", 0.0)],
+            ["chi", "nu"],
+            [],
+            id="fixed-sample-and-detector",
+        ),
+        pytest.param(
+            [BisectConstraint("omega", "ttheta"), ReferenceConstraint("psi", 90.0)],
+            ["omega"],
+            ["psi"],
+            id="reference-excluded",
+        ),
+        pytest.param(
+            [SampleConstraint("chi", 90.0), DetectorConstraint("qaz", 90.0)],
+            ["chi"],
+            ["qaz"],
+            id="qaz-excluded",
+        ),
+    ],
+)
+def test_constant_stages(constraints, expected_in, expected_not_in):
+    cs = ConstraintSet(constraints)
     stages = cs.constant_stages
-    assert "psi" not in stages
-    assert "omega" in stages
-
-
-def test_constant_stages_qaz_excluded():
-    """DetectorConstraint qaz does not contribute to constant_stages."""
-    cs = ConstraintSet(
-        [
-            SampleConstraint("chi", 90.0),
-            DetectorConstraint("qaz", 90.0),
-        ]
-    )
-    stages = cs.constant_stages
-    assert "qaz" not in stages
-    assert "chi" in stages
+    for name in expected_in:
+        assert name in stages
+    for name in expected_not_in:
+        assert name not in stages
 
 
 # ---------------------------------------------------------------------------
@@ -851,27 +1011,6 @@ def test_validate_solutions_sampleconstraint_violation_message():
 # ---------------------------------------------------------------------------
 
 
-def test_sample_constraint_hash_used_in_set():
-    sc1 = SampleConstraint("chi", 90.0)
-    sc2 = SampleConstraint("chi", 90.0)
-    assert len({sc1, sc2}) == 1
-
-
-def test_detector_constraint_is_satisfied():
-    g = _psic_like()
-    angles = {"mu": 0.0, "eta": 10.0, "chi": 90.0, "phi": 0.0, "nu": 0.0, "delta": 20.0}
-    dc = DetectorConstraint("nu", 0.0)
-    assert dc.is_satisfied(angles, g) is True
-    dc2 = DetectorConstraint("nu", 5.0)
-    assert dc2.is_satisfied(angles, g) is False
-
-
-def test_detector_constraint_hash_used_in_set():
-    dc1 = DetectorConstraint("nu", 0.0)
-    dc2 = DetectorConstraint("nu", 0.0)
-    assert len({dc1, dc2}) == 1
-
-
 def test_constraint_set_bisect_constraint_property_none():
     """bisect_constraint returns None when no BisectConstraint present."""
     cs = ConstraintSet([SampleConstraint("chi", 90.0)])
@@ -974,21 +1113,37 @@ def test_constraint_set_repr_contains_bisect():
     assert "delta" in r
 
 
-def test_constraint_set_eq_different_cutpoints():
-    cs1 = ConstraintSet([SampleConstraint("chi", 90.0)], cut_points={"chi": 0.0})
-    cs2 = ConstraintSet([SampleConstraint("chi", 90.0)])
-    assert cs1 != cs2
-
-
-def test_constraint_set_eq_different_type():
-    cs = ConstraintSet([SampleConstraint("chi", 90.0)])
-    assert cs != "not a constraint set"
-
-
-def test_constraint_set_eq_different_constraints():
-    cs1 = ConstraintSet([SampleConstraint("chi", 90.0)])
-    cs2 = ConstraintSet([SampleConstraint("phi", 0.0)])
-    assert cs1 != cs2
+@pytest.mark.parametrize(
+    "lhs, rhs, expected",
+    [
+        pytest.param(
+            ConstraintSet([SampleConstraint("chi", 90.0)]),
+            ConstraintSet([SampleConstraint("chi", 90.0)]),
+            True,
+            id="cs-eq-same",
+        ),
+        pytest.param(
+            ConstraintSet([SampleConstraint("chi", 90.0)], cut_points={"chi": 0.0}),
+            ConstraintSet([SampleConstraint("chi", 90.0)]),
+            False,
+            id="cs-eq-different-cutpoints",
+        ),
+        pytest.param(
+            ConstraintSet([SampleConstraint("chi", 90.0)]),
+            "not a constraint set",
+            False,
+            id="cs-eq-different-type",
+        ),
+        pytest.param(
+            ConstraintSet([SampleConstraint("chi", 90.0)]),
+            ConstraintSet([SampleConstraint("phi", 0.0)]),
+            False,
+            id="cs-eq-different-constraints",
+        ),
+    ],
+)
+def test_constraint_set_eq(lhs, rhs, expected):
+    assert (lhs == rhs) is expected
 
 
 def test_mode_dict_setitem_invalid_raises():
@@ -1087,3 +1242,237 @@ def test_geometry_from_dict_old_bisecting_mode_raises():
     d["mode_name"] = "bisecting"
     with pytest.raises(ValueError, match=re.escape("BisectingMode")):
         AdHocDiffractometer.from_dict(d)
+
+
+# ---------------------------------------------------------------------------
+# Issue #149 — fourcv and fourch mode structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, expected_modes",
+    [
+        pytest.param(
+            fourcv,
+            {
+                "bisecting",
+                "fixed_chi",
+                "fixed_phi",
+                "constant_omega",
+                "psi_constant",
+                "double_diffraction",
+            },
+            id="fourcv-six-modes",
+        ),
+        pytest.param(
+            fourch,
+            {
+                "bisecting",
+                "fixed_chi",
+                "fixed_phi",
+                "constant_omega",
+                "psi_constant",
+                "double_diffraction",
+            },
+            id="fourch-six-modes",
+        ),
+    ],
+)
+def test_four_circle_factory_mode_names(factory, expected_modes):
+    """Both fourcv and fourch expose exactly the 6 declared mode names."""
+    g = factory()
+    assert set(g.modes.keys()) == expected_modes
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_type, expected_has_bisect",
+    [
+        pytest.param(
+            fourcv, "bisecting", BisectConstraint, True, id="fourcv-bisecting"
+        ),
+        pytest.param(
+            fourcv, "fixed_chi", SampleConstraint, False, id="fourcv-fixed_chi"
+        ),
+        pytest.param(
+            fourcv, "fixed_phi", SampleConstraint, False, id="fourcv-fixed_phi"
+        ),
+        pytest.param(
+            fourcv,
+            "constant_omega",
+            SampleConstraint,
+            False,
+            id="fourcv-constant_omega",
+        ),
+        pytest.param(
+            fourcv, "psi_constant", ReferenceConstraint, False, id="fourcv-psi_constant"
+        ),
+        pytest.param(
+            fourcv,
+            "double_diffraction",
+            BisectConstraint,
+            True,
+            id="fourcv-double_diffraction",
+        ),
+        pytest.param(
+            fourch, "bisecting", BisectConstraint, True, id="fourch-bisecting"
+        ),
+        pytest.param(
+            fourch, "fixed_chi", SampleConstraint, False, id="fourch-fixed_chi"
+        ),
+        pytest.param(
+            fourch, "fixed_phi", SampleConstraint, False, id="fourch-fixed_phi"
+        ),
+        pytest.param(
+            fourch,
+            "constant_omega",
+            SampleConstraint,
+            False,
+            id="fourch-constant_omega",
+        ),
+        pytest.param(
+            fourch, "psi_constant", ReferenceConstraint, False, id="fourch-psi_constant"
+        ),
+        pytest.param(
+            fourch,
+            "double_diffraction",
+            BisectConstraint,
+            True,
+            id="fourch-double_diffraction",
+        ),
+    ],
+)
+def test_four_circle_mode_constraint_type(
+    factory, mode_name, expected_type, expected_has_bisect
+):
+    """Each mode's leading constraint is of the expected type."""
+    g = factory()
+    cs = g.modes[mode_name]
+    assert isinstance(cs, ConstraintSet)
+    assert cs.has_bisect == expected_has_bisect
+    assert any(isinstance(c, expected_type) for c in cs.constraints)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_implemented",
+    [
+        pytest.param(fourcv, "bisecting", True, id="fourcv-bisecting-implemented"),
+        pytest.param(fourcv, "fixed_chi", True, id="fourcv-fixed_chi-implemented"),
+        pytest.param(fourcv, "fixed_phi", True, id="fourcv-fixed_phi-implemented"),
+        pytest.param(
+            fourcv, "constant_omega", True, id="fourcv-constant_omega-implemented"
+        ),
+        pytest.param(fourcv, "psi_constant", False, id="fourcv-psi_constant-stub"),
+        pytest.param(
+            fourcv,
+            "double_diffraction",
+            True,
+            id="fourcv-double_diffraction-implemented",
+        ),
+        pytest.param(fourch, "bisecting", True, id="fourch-bisecting-implemented"),
+        pytest.param(fourch, "fixed_chi", True, id="fourch-fixed_chi-implemented"),
+        pytest.param(fourch, "fixed_phi", True, id="fourch-fixed_phi-implemented"),
+        pytest.param(
+            fourch, "constant_omega", True, id="fourch-constant_omega-implemented"
+        ),
+        pytest.param(fourch, "psi_constant", False, id="fourch-psi_constant-stub"),
+        pytest.param(
+            fourch,
+            "double_diffraction",
+            True,
+            id="fourch-double_diffraction-implemented",
+        ),
+    ],
+)
+def test_four_circle_mode_is_implemented(factory, mode_name, expected_implemented):
+    """Implemented modes return True; stubs return False from is_implemented()."""
+    g = factory()
+    assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_default_mode_is_bisecting(factory):
+    """Default mode for both four-circle geometries is 'bisecting'."""
+    g = factory()
+    assert g.mode_name == "bisecting"
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_computed",
+    [
+        pytest.param(
+            fourcv,
+            "bisecting",
+            ["omega", "chi", "phi", "ttheta"],
+            id="fourcv-bisecting-computed",
+        ),
+        pytest.param(
+            fourcv,
+            "fixed_chi",
+            ["omega", "phi", "ttheta"],
+            id="fourcv-fixed_chi-computed",
+        ),
+        pytest.param(
+            fourcv,
+            "fixed_phi",
+            ["omega", "chi", "ttheta"],
+            id="fourcv-fixed_phi-computed",
+        ),
+        pytest.param(
+            fourcv,
+            "constant_omega",
+            ["chi", "phi", "ttheta"],
+            id="fourcv-constant_omega-computed",
+        ),
+    ],
+)
+def test_four_circle_computed_stages_declared(factory, mode_name, expected_computed):
+    """computed field lists the correct stage names for each mode."""
+    g = factory()
+    cs = g.modes[mode_name]
+    assert cs.computed == expected_computed
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_free_dof(factory):
+    """Four-circle geometries have free_dof_after_bragg == 1."""
+    g = factory()
+    assert g.free_dof_after_bragg == 1
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_modes_round_trip_serialisation(factory):
+    """Full to_dict / from_dict round-trip preserves all 6 modes."""
+    import json
+
+    g = factory()
+    d = g.to_dict()
+    assert json.dumps(d)  # must be JSON-serialisable
+    assert set(d["modes"].keys()) == {
+        "bisecting",
+        "fixed_chi",
+        "fixed_phi",
+        "constant_omega",
+        "psi_constant",
+        "double_diffraction",
+    }
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == set(g.modes.keys())
+    assert g2.mode_name == "bisecting"


### PR DESCRIPTION
## Summary

- Adds `constant_omega`, `psi_constant`, and `double_diffraction` modes to `fourcv` and `fourch`, completing the 6-mode set declared in issue #149
- `constant_omega` (omega=0) is immediately solvable via the existing generic fixed-sample solver — discovered during implementation to be already working, not a stub
- `psi_constant` is a stub (`is_implemented=False`); requires reference vector infrastructure (Issue J / #157)
- `double_diffraction` carries `REQUIRED` extras for h₂, k₂, l₂; bisecting solver runs but h₂k₂l₂ logic is future work
- Refactors `test_mode.py` and `test_forward.py` throughout: parametrized tests folded by constraint class, `context` stripped from all-`does_not_raise()` sets, round-trip and helper tests consolidated

- closes #149

Contributed by: OpenCode (argo/claudesonnet46)