### PR TITLE
feat: sixc diffraction modes; constraint framework doc overhaul (#155)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -180,9 +180,10 @@ Modules are grouped by layer.
        orientation -> reflection
        orientation -> rotation
        orientation -> stage
-       forward     -> geometry  [style=dashed]
-       forward     -> mode
-       forward     -> orientation
+        forward     -> display    [style=dashed]
+        forward     -> geometry  [style=dashed]
+        forward     -> mode
+        forward     -> orientation
         conversions -> sample
        surface     -> geometry  [style=dashed]
        scan        -> geometry  [style=dashed]

--- a/docs/source/geometries/fivec.md
+++ b/docs/source/geometries/fivec.md
@@ -1,11 +1,11 @@
 (geometry-fivec)=
 # fivec — Eulerian Five-Circle (Vlieg et al. 1987)
 
-Five-circle diffractometer: a standard fourcv (Eulerian four-circle) mounted on a vertical mu base stage. Sample and detector are coupled through mu.
+Five-circle diffractometer: a standard {func}`~ad_hoc_diffractometer.factories.fourcv` (Eulerian four-circle) mounted on a vertical mu base stage. Sample and detector are coupled through mu.
 
 **Walko (2016) designation:** (S3D1)1
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.fivec` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L974) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.fivec` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L1147) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -44,16 +44,84 @@ and mode configuration.
 
 ## Diffraction modes
 
-*(No modes defined for this geometry.  All stages are free during*
-*`forward()` — the solver explores the full solution space.)*
+Set the active mode with `g.mode_name = "<mode>"`.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 2 constraints
+(N − 3 = 2 for N = 5 DOF).
+With mu = 0, {func}`~ad_hoc_diffractometer.factories.fivec` reduces identically to {func}`~ad_hoc_diffractometer.factories.fourcv`.
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
+
+### `bisecting_4c` *(default)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`mu = 0`, `omega = ttheta / 2`.
+Reduces to standard four-circle bisecting geometry.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, phi, ttheta |
+| **Constant during** `forward()` | mu = 0 |
+
+### `fixed_chi`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2:
+`mu = 0`.
+`chi` is held at the value declared in the constraint (factory default: 90°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
+persists until replaced — see {doc}`../howto/constraints`.
+
+| | |
+|---|---|
+| **Computed** | omega, phi, ttheta |
+| **Constant during** `forward()` | mu = 0, chi |
+
+### `fixed_phi`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2:
+`mu = 0`.
+`phi` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, ttheta |
+| **Constant during** `forward()` | mu = 0, phi |
+
+### `fixed_mu`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`omega = ttheta / 2`.
+`mu` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+Intended for non-zero mu once the tilted-plane solver is implemented.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, phi, ttheta |
+| **Constant during** `forward()` | mu |
+
+### `constant_omega_noncoplanar`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2:
+`mu = 0`.
+`omega` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, ttheta |
+| **Constant during** `forward()` | mu = 0, omega |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.fivec`
+- {func}`~ad_hoc_diffractometer.factories.fivec`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -5,7 +5,7 @@ Busing & Levy (1967) four-circle Eulerian diffractometer, horizontal scattering 
 
 **Walko (2016) designation:** S3D1
 
-**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy ({data}`~ad_hoc_diffractometer.factories.BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.fourch` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L556) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.fourch` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L613) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -41,34 +41,88 @@ and mode configuration.
 
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Set the active mode with `g.mode_name = "<mode>"`.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`omega = ttheta / 2`.
+Places the sample symmetrically between the incident and diffracted beams.
 
-`omega` is constrained to `ttheta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
+| | Stages |
+|---|---|
+| **Computed** | omega, chi, phi, ttheta |
+| **Constant during** `forward()` | — |
 
 ### `fixed_chi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`chi` is held at the value declared in the constraint (factory default: 90°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
+persists until replaced — see {doc}`../howto/constraints`.
 
-Holds `chi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("chi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | omega, phi, ttheta |
+| **Constant during** `forward()` | chi |
 
 ### `fixed_phi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`phi` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
-Holds `phi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("phi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | omega, chi, ttheta |
+| **Constant during** `forward()` | phi |
 
+### `constant_omega`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`omega` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+
+| | |
+|---|---|
+| **Computed** | chi, phi, ttheta |
+| **Constant during** `forward()` | omega |
+
+### `psi_constant` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Fix the azimuthal angle ψ of the reference vector about Q.
+Requires n̂ — not yet implemented (Issue J).
+
+| | |
+|---|---|
+| **Extras (input)** | n̂ (reference vector), ψ (target, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
+
+### `double_diffraction` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` with secondary reflection extras.
+Simultaneous diffraction condition — not yet implemented.
+
+| | |
+|---|---|
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.fourch`
+- {func}`~ad_hoc_diffractometer.factories.fourch`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -5,7 +5,7 @@ Busing & Levy (1967) four-circle Eulerian diffractometer, vertical scattering pl
 
 **Walko (2016) designation:** S3D1
 
-**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy ({data}`~ad_hoc_diffractometer.factories.BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.fourcv` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L502) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.fourcv` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L536) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -41,34 +41,88 @@ and mode configuration.
 
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Set the active mode with `g.mode_name = "<mode>"`.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`omega = ttheta / 2`.
+Places the sample symmetrically between the incident and diffracted beams.
 
-`omega` is constrained to `ttheta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
+| | Stages |
+|---|---|
+| **Computed** | omega, chi, phi, ttheta |
+| **Constant during** `forward()` | — |
 
 ### `fixed_chi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`chi` is held at the value declared in the constraint (factory default: 90°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
+persists until replaced — see {doc}`../howto/constraints`.
 
-Holds `chi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("chi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | omega, phi, ttheta |
+| **Constant during** `forward()` | chi |
 
 ### `fixed_phi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`phi` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
-Holds `phi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("phi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | omega, chi, ttheta |
+| **Constant during** `forward()` | phi |
 
+### `constant_omega`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`omega` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+
+| | |
+|---|---|
+| **Computed** | chi, phi, ttheta |
+| **Constant during** `forward()` | omega |
+
+### `psi_constant` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Fix the azimuthal angle ψ of the reference vector about Q.
+Requires n̂ — not yet implemented (Issue J).
+
+| | |
+|---|---|
+| **Extras (input)** | n̂ (reference vector), ψ (target, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
+
+### `double_diffraction` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` with secondary reflection extras.
+Simultaneous diffraction condition — not yet implemented.
+
+| | |
+|---|---|
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.fourcv`
+- {func}`~ad_hoc_diffractometer.factories.fourcv`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -3,7 +3,7 @@
 
 You (1999) 4S+2D six-circle diffractometer. Four sample stages (mu, eta, chi, and phi) and two detector stages (nu, delta). Lateral detector, vertical scattering plane. Standard synchrotron six-circle.
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -17,8 +17,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.psic` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L439) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.psic` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L454) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -41,42 +41,71 @@ and mode configuration.
 
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Set the active mode with `g.mode_name = "<mode>"`.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 3 constraints
+(N − 3 = 3 for N = 6 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`eta = delta / 2`, `mu = 0`, `nu = 0`.
+Vertical scattering plane bisecting condition (You 1999, §5.3).
 
-`eta` is constrained to `delta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
-
-Additional stages frozen at their current angles: `mu` = current angle, `nu` = current angle.
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
 
 ### `fixed_chi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`eta = delta / 2`, `mu = 0`, `nu = 0`.
+`chi` is held at the value declared in the constraint (factory default: 90°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
+persists until replaced — see {doc}`../howto/constraints`.
 
-Holds `chi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("chi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | eta, phi, delta |
+| **Constant during** `forward()` | chi, mu = 0, nu = 0 |
 
 ### `fixed_phi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`eta = delta / 2`, `mu = 0`, `nu = 0`.
+`phi` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
-Holds `phi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("phi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | eta, chi, delta |
+| **Constant during** `forward()` | phi, mu = 0, nu = 0 |
 
 ### `fixed_mu`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`eta = delta / 2`, `nu = 0`.
+`mu` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
-Holds `mu` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("mu", value)` before calling `forward()`.
-
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu, nu = 0 |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.psic`
+- {func}`~ad_hoc_diffractometer.factories.psic`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -1,11 +1,11 @@
 (geometry-sixc)=
 # sixc — Eulerian Six-Circle, Surface (Lohmeier & Vlieg 1993)
 
-Six-circle surface diffractometer. Sample and detector share a common alpha (rotary table) base stage. Designed for surface diffraction.
+Six-circle surface diffractometer. Sample and detector share a common alpha (rotary table) base stage. Supports both bulk crystallography (four-circle mode) and surface diffraction.
 
 **Walko (2016) designation:** (S3D2)1
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.sixc` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L609) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.sixc` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L689) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -41,20 +41,99 @@ and mode configuration.
 | ``delta`` | −lateral (−z) | left-handed |
 | ``gamma`` | +vertical (+x) | right-handed |
 
-**Shared stage:** alpha (base stage shared between sample and detector stacks)
+**Shared stage:** alpha (rotary table base shared between sample and detector stacks)
 
 ## Diffraction modes
 
-*(No modes defined for this geometry.  All stages are free during*
-*`forward()` — the solver explores the full solution space.)*
+Set the active mode with `g.mode_name = "<mode>"`.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 3 constraints
+(N − 3 = 3 for N = 6 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
+
+### `bisecting_4c` *(default)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`alpha = 0`, `gamma = 0`, `omega = delta / 2`.
+Reduces to standard four-circle bisecting geometry.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, phi, delta |
+| **Constant during** `forward()` | alpha = 0, gamma = 0 |
+
+### `fixed_gamma_5c`
+
+{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`alpha = 0`, `omega = delta / 2`.
+`gamma` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
+persists until replaced — see {doc}`../howto/constraints`.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, phi, delta, alpha |
+| **Constant during** `forward()` | gamma, alpha = 0 |
+
+### `fixed_alpha_5c`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`omega = delta / 2`, `gamma = 0`.
+`alpha` is held at the value declared in the constraint (factory default: 0°).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+
+| | |
+|---|---|
+| **Computed** | omega, chi, phi, delta, gamma |
+| **Constant during** `forward()` | alpha, gamma = 0 |
+
+### `zaxis_alpha_fixed` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Z-axis mode with fixed incidence angle. Requires n̂ — not yet implemented (Issue J).
+
+| | |
+|---|---|
+| **Computed** | omega, delta, gamma |
+| **Constant during** `forward()` | alpha (= β_in), chi, phi |
+| **Extras (input)** | n̂ (surface normal) |
+| **Extras (output)** | alpha_i (incidence angle), beta_out (exit angle) |
+
+### `zaxis_beta_fixed` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Z-axis mode with fixed exit angle. Requires n̂ — not yet implemented (Issue J).
+
+| | |
+|---|---|
+| **Computed** | omega, delta, alpha |
+| **Constant during** `forward()` | gamma (= β_out), chi |
+| **Extras (input)** | n̂ |
+| **Extras (output)** | alpha_i, beta_out |
+
+### `zaxis_alpha_eq_beta` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Z-axis mode, symmetric reflection (α = γ, β_in = β_out). Requires n̂ — not yet implemented (Issue J).
+
+| | |
+|---|---|
+| **Computed** | omega, delta, alpha, gamma |
+| **Constant during** `forward()` | chi, phi |
+| **Extras (input)** | n̂ |
+| **Extras (output)** | alpha_i, beta_out |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.sixc`
+- {func}`~ad_hoc_diffractometer.factories.sixc`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/howto/constraints.md
+++ b/docs/source/howto/constraints.md
@@ -1,0 +1,247 @@
+(howto-constraints)=
+# Work with Constraints and Diffraction Modes
+
+This guide explains the constraint system in detail: how modes are defined,
+how to customise constraint values, how to build entirely new modes, and how
+to work with the `extras` dict for advanced modes.
+
+## Background: degrees of freedom
+
+Specifying a reflection (h, k, l) provides exactly **3 equations** on the
+motor angles (the three components of the scattering vector Q).
+A geometry with N real motor axes therefore has **N − 3 free parameters**
+after the Bragg condition is satisfied.  Each free parameter must be resolved
+by exactly one constraint.
+
+| Geometry family | N | N − 3 |
+|---|---|---|
+| {func}`~ad_hoc_diffractometer.factories.fourcv`, {func}`~ad_hoc_diffractometer.factories.fourch`, {func}`~ad_hoc_diffractometer.factories.zaxis`, {func}`~ad_hoc_diffractometer.factories.s2d2` | 4 | 1 |
+| {func}`~ad_hoc_diffractometer.factories.fivec` | 5 | 2 |
+| {func}`~ad_hoc_diffractometer.factories.psic`, {func}`~ad_hoc_diffractometer.factories.kappa6c`, {func}`~ad_hoc_diffractometer.factories.sixc` | 6 | 3 |
+
+```python
+import ad_hoc_diffractometer as ahd
+
+print(ahd.fourcv().free_dof_after_bragg)   # 1
+print(ahd.psic().free_dof_after_bragg)     # 3
+```
+
+## Constraint categories
+
+Every constraint belongs to one of three categories:
+
+**Sample constraint** — fixes one sample stage at a declared value, or
+declares the bisecting relational condition:
+
+```python
+from ad_hoc_diffractometer import SampleConstraint, BisectConstraint
+
+SampleConstraint("chi", 90.0)          # chi fixed at 90°
+SampleConstraint("omega", 0.0)         # omega fixed at 0°
+BisectConstraint("omega", "ttheta")    # omega = ttheta / 2
+BisectConstraint("eta", "delta")       # eta = delta / 2  (psic)
+```
+
+**Detector constraint** — fixes one detector stage at a declared value:
+
+```python
+from ad_hoc_diffractometer import DetectorConstraint
+
+DetectorConstraint("nu", 0.0)     # nu fixed at 0°
+DetectorConstraint("gamma", 0.0)  # gamma fixed at 0°
+```
+
+**Reference constraint** — expresses a condition between Q and a reference
+vector n̂ (surface normal, polarisation axis, etc.).
+All reference constraints are stubs pending the reference-vector
+infrastructure (Issue J):
+
+```python
+from ad_hoc_diffractometer import ReferenceConstraint
+
+ReferenceConstraint("psi", 90.0)       # azimuthal angle of n̂ about Q
+ReferenceConstraint("alpha_i", 5.0)    # incidence angle
+ReferenceConstraint("a_eq_b", True)    # alpha_i = beta_out (symmetric)
+```
+
+**Rules:** at most one {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`,
+at most one {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`,
+remainder must be {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+or {class}`~ad_hoc_diffractometer.mode.BisectConstraint`.
+Total must equal N − 3.
+
+## Use a factory-defined mode
+
+```python
+g = ahd.fourcv()
+g.mode_name = "bisecting"   # 1 BisectConstraint (N-3=1)
+solutions = g.forward(1, 0, 0)
+```
+
+## Set a constraint value at run time
+
+A constraint value is **constant for the duration of a single
+{func}`~ad_hoc_diffractometer.forward.compute_forward` call**.
+The {class}`~ad_hoc_diffractometer.mode.ConstraintSet` object persists on the
+geometry until explicitly replaced — there is no need to reassign it if the
+value does not change between calls.
+
+```python
+from ad_hoc_diffractometer import ConstraintSet, SampleConstraint
+
+g = ahd.fourcv()
+
+# Set once — all subsequent forward() calls use chi = 45°
+g.modes["my_chi"] = ConstraintSet([SampleConstraint("chi", 45.0)])
+g.mode_name = "my_chi"
+
+sols_100 = g.forward(1, 0, 0)   # chi = 45°
+sols_010 = g.forward(0, 1, 0)   # chi = 45° (same constraint, no reassignment needed)
+sols_111 = g.forward(1, 1, 1)   # chi = 45°
+
+# Only reassign when the value changes
+g.modes["my_chi"] = ConstraintSet([SampleConstraint("chi", 60.0)])
+sols_new = g.forward(1, 0, 0)   # chi = 60° from here on
+```
+
+The factory mode `"fixed_chi"` has a default chi = 90°.
+Replacing the {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+in `g.modes["fixed_chi"]` changes the value for all subsequent calls
+until it is replaced again.
+
+The `computed` field on {class}`~ad_hoc_diffractometer.mode.ConstraintSet` is
+informational (documents which stages the solver computes) and does not
+affect the calculation.
+
+## Build a multi-constraint mode (six-circle)
+
+For psic (N − 3 = 3), three constraints are needed:
+
+```python
+from ad_hoc_diffractometer import (
+    ConstraintSet, BisectConstraint, SampleConstraint, DetectorConstraint
+)
+
+g = ahd.psic()
+
+# Custom bisecting mode with mu=5° (non-zero mu)
+g.modes["bisecting_mu5"] = ConstraintSet(
+    [
+        BisectConstraint("eta", "delta"),   # sample: eta = delta/2
+        SampleConstraint("mu", 5.0),        # sample: mu fixed at 5°
+        DetectorConstraint("nu", 0.0),      # detector: nu fixed at 0°
+    ],
+    computed=["eta", "chi", "phi", "delta"],
+)
+g.mode_name = "bisecting_mu5"
+```
+
+## Inspect a mode
+
+```python
+cs = g.modes["bisecting"]
+
+# All constraints in definition order
+print(cs.constraints)
+
+# Stage names held fixed (derived from constraints, not a separate dict)
+print(cs.constant_stages)    # e.g. ['eta', 'mu', 'nu']
+
+# Stage names computed by the solver
+print(cs.computed)           # e.g. ['eta', 'chi', 'phi', 'delta']
+
+# Bisect pair (sample stage, detector stage)
+print(cs.bisect_stages())    # e.g. ('eta', 'delta')
+
+# DOF check
+print(cs.is_fully_constrained(g))   # True if len(constraints) == N-3
+
+# Solver availability
+print(cs.is_implemented(g))         # True if all constraints have solvers
+```
+
+## The extras dict
+
+Some modes require additional input beyond (h, k, l), or compute additional
+output quantities alongside the motor angles.
+These are declared in the `extras` dict using {data}`~ad_hoc_diffractometer.mode.REQUIRED`
+and {data}`~ad_hoc_diffractometer.mode.OPTIONAL` sentinels:
+
+```python
+from ad_hoc_diffractometer import REQUIRED, OPTIONAL, ConstraintSet, ReferenceConstraint
+
+# psi_constant mode on fourcv: requires a reference vector n̂
+cs = g.modes["psi_constant"]
+print(cs.extras)
+# {'n_hat': <REQUIRED>, 'psi': None}
+# n_hat must be supplied; psi is an output populated by the solver
+```
+
+`REQUIRED` marks inputs that **must** be supplied before calling `forward()`.
+`None` marks output slots populated by the solver.
+`OPTIONAL` marks inputs with a sensible default.
+
+## Stub modes
+
+Modes whose constraint patterns do not yet have a solver implementation
+return `False` from `is_implemented()` and raise `NotImplementedError`
+when `forward()` is called:
+
+```python
+g = ahd.fourcv()
+g.mode_name = "psi_constant"
+
+print(g.modes["psi_constant"].is_implemented(g))  # False
+
+try:
+    g.forward(1, 0, 0)
+except NotImplementedError as e:
+    print(e)   # describes which infrastructure is missing
+```
+
+## Serialisation
+
+{class}`~ad_hoc_diffractometer.mode.ConstraintSet` round-trips through `to_dict()` / `from_dict()`:
+
+```python
+import json
+from ad_hoc_diffractometer import AdHocDiffractometer
+
+g = ahd.fourcv()
+d = g.to_dict()
+json.dumps(d)   # JSON-serialisable
+
+g2 = AdHocDiffractometer.from_dict(d)
+print(g2.modes.keys())    # same modes as g
+print(g2.mode_name)       # 'bisecting'
+```
+
+## Custom constraint protocol
+
+Any object satisfying the {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+interface can be added to a {class}`~ad_hoc_diffractometer.mode.ModeDict`.
+A minimal custom constraint must implement:
+
+- `name: str` — a unique identifier
+- `category: str` — `"sample"`, `"detector"`, or `"reference"`
+- `extras: dict` — input/output parameters
+- `evaluate(angles, geometry) -> float` — residual (0 = satisfied)
+- `is_satisfied(angles, geometry, tol) -> bool`
+- `is_implemented(geometry) -> bool`
+- `to_dict() / from_dict()` — serialisation
+
+The numeric fallback solver in `forward.py` handles any custom constraint
+that has `is_implemented()` returning `True`, even without an analytic solver.
+
+## See also
+
+- {doc}`modes` — everyday mode switching
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {data}`~ad_hoc_diffractometer.mode.REQUIRED`
+- {data}`~ad_hoc_diffractometer.mode.OPTIONAL`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -15,6 +15,7 @@ installed the package and are familiar with the
    orient
    forward
    modes
+   constraints
    trajectory
    refine_lattice
    serialize
@@ -58,6 +59,13 @@ installed the package and are familiar with the
 
       Choose which stages are free, fixed, or coupled during a
       forward calculation.
+
+   .. grid-item-card:: :material-outlined:`rule;3em` Work with Constraints
+      :link: constraints
+      :link-type: doc
+
+      Understand the constraint framework: DOF rule, constraint categories,
+      custom modes, and the extras dict for advanced modes.
 
    .. grid-item-card:: :material-outlined:`route;3em` Plan a Trajectory
       :link: trajectory

--- a/docs/source/howto/modes.md
+++ b/docs/source/howto/modes.md
@@ -1,9 +1,11 @@
 (howto-modes)=
 # Switch Diffraction Modes
 
-A **diffraction mode** describes how `forward()` will compute the motor
-angles and which ones remain constant.  See [Concepts](../concepts.md)
-for background.
+A **diffraction mode** is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+that describes which motor stages are free, which are held at declared values,
+and which are related to others (e.g. bisecting).
+See [Concepts](../concepts.md) for background, and
+{doc}`constraints` for the full constraint framework.
 
 ## List available modes
 
@@ -12,106 +14,126 @@ import ad_hoc_diffractometer as ahd
 
 g = ahd.fourcv()
 print(list(g.modes.keys()))
-# ['bisecting', 'fixed_chi', 'fixed_phi']
+# ['bisecting', 'fixed_chi', 'fixed_phi', 'constant_omega',
+#  'psi_constant', 'double_diffraction']
 ```
 
 ## Get and set the active mode
 
 ```python
-# No mode active by default
-print(g.mode_name)   # None
-
-# Set a mode
-g.mode_name = "bisecting"
+# The default mode is set by the factory
 print(g.mode_name)   # 'bisecting'
+
+# Switch to a different mode
+g.mode_name = "fixed_chi"
+print(g.mode_name)   # 'fixed_chi'
+
+# Clear the active mode (all stages free — forward() will raise)
+g.mode_name = None
 ```
 
 ## Mode reference
 
 ### Bisecting mode
 
-The sample stage angle is constrained to half the detector stage angle,
-placing the sample symmetrically between the incident and diffracted beams.
-Available on: fourcv (omega = ttheta/2), fourch (omega = ttheta/2),
-psic (eta = delta/2), and kappa geometries (komega = ttheta/2 or
-komega = delta/2).
+The bisecting {class}`~ad_hoc_diffractometer.mode.BisectConstraint` drives the
+co-axial sample stage to half the detector angle, placing the sample
+symmetrically between the incident and diffracted beams.
 
 ```python
 g.mode_name = "bisecting"
+solutions = g.forward(1, 0, 0)
+# omega = ttheta / 2 in every solution
 ```
 
-### Fixed chi / fixed phi / fixed kphi / fixed mu
+### Fixed-angle modes
 
-A fixed-angle mode holds one stage at its **current angle** during
-`forward()`.  The caller presets the stage angle with `g.set_angle()`
-before activating the mode:
+Fixed-angle modes hold one sample stage at its **declared constraint value**
+during a single `forward()` call.  The value is part of the {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+definition and is constant only for the duration of that call.
 
 ```python
-# Freeze chi at 90° (surface diffraction geometry)
-g.set_angle("chi", 90.0)
+# fixed_chi: factory default holds chi at 90°
 g.mode_name = "fixed_chi"
-solutions = g.forward(h, k, l)   # chi held at 90° throughout
-
-# Freeze chi at a different angle — same mode, new preset
-g.set_angle("chi", 45.0)
-solutions = g.forward(h, k, l)   # chi held at 45°
+solutions = g.forward(1, 0, 0)
+# sol["chi"] == 90.0 for every solution
 ```
 
-```python
-# Freeze phi at 0°
-g.set_angle("phi", 0.0)
-g.mode_name = "fixed_phi"
-```
+To use a **different value**, construct a new {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+and assign it. The constraint persists until replaced — only reassign when
+the value changes:
 
 ```python
-# Freeze mu at 0° on psic or kappa6c
-g = ahd.psic()
-g.set_angle("mu", 0.0)
-g.mode_name = "fixed_mu"
-```
+from ad_hoc_diffractometer import ConstraintSet, SampleConstraint
 
-### Custom fixed-angle mode
-
-To add a fixed-angle mode that is not pre-built into the geometry:
-
-```python
-from ad_hoc_diffractometer import FixedAngleMode
-
-g.modes["my_chi"] = FixedAngleMode(stage="chi", value=90.0)
-g.set_angle("chi", 90.0)   # preset the stage angle
+# Call 1: chi = 45°
+g.modes["my_chi"] = ConstraintSet([SampleConstraint("chi", 45.0)])
 g.mode_name = "my_chi"
+sols_45 = g.forward(1, 0, 0)   # chi = 45° this call
+
+# Call 2: chi = 60°
+g.modes["my_chi"] = ConstraintSet([SampleConstraint("chi", 60.0)])
+sols_60 = g.forward(1, 0, 0)   # chi = 60° this call
 ```
 
-The `value` argument to `FixedAngleMode` sets the **initial** stage angle
-as a convenience default.  The solver always reads the stage's current angle
-at call time, so a subsequent `g.set_angle()` overrides it.
+See {doc}`constraints` for the full run-time pattern.
 
-## Custom modes
+### constant_omega
 
-Subclass `DiffractionMode` to implement any constraint:
+Holds `omega` at 0° (any geometry where omega is a sample stage).
 
 ```python
-from ad_hoc_diffractometer import DiffractionMode
+g.mode_name = "constant_omega"
+solutions = g.forward(1, 0, 0)
+# sol["omega"] == 0.0 for every solution
+```
 
-class MyMode(DiffractionMode):
-    @property
-    def constrained_stages(self):
-        return ["phi"]
+## Inspect a mode's constraints
 
-    def solve(self, geometry, h, k, l):
-        ...  # return list of angle dicts
+```python
+g = ahd.fourcv()
+cs = g.modes["fixed_chi"]
+
+print(cs)
+# ConstraintSet([SampleConstraint('chi', 90.0)])
+
+print(cs.computed)
+# ['omega', 'phi', 'ttheta']
+
+print(cs.constant_stages)
+# ['chi']
+
+print(cs.is_fully_constrained(g))
+# True  (N - 3 = 1 constraint for N = 4 DOF)
+
+print(cs.is_implemented(g))
+# True
+```
+
+## Check if a mode is implemented
+
+Stub modes (e.g. `psi_constant`) have `is_implemented(g)` returning `False`
+and raise `NotImplementedError` when `forward()` is called:
+
+```python
+g.mode_name = "psi_constant"
+print(g.modes["psi_constant"].is_implemented(g))  # False
+
+# forward() raises NotImplementedError for unimplemented modes
 ```
 
 ## Clear the active mode
 
 ```python
-g.mode_name = None   # all stages free
+g.mode_name = None   # all stages free; forward() raises NotImplementedError
 ```
 
 ## See also
 
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {doc}`constraints` — full constraint framework: DOF rule, custom modes, extras
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
 - {class}`~ad_hoc_diffractometer.mode.ModeDict`
 - [Concepts — Diffraction modes](../concepts.md)

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -724,6 +724,63 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         Stage("delta", -LATERAL, parent="alpha", role="detector"),
         Stage("gamma", +VERTICAL, parent="delta", role="detector"),
     ]
+    # sixc: 6 DOF, N-3=3 constraints needed per mode.
+    # four_circle: alpha=0, gamma=0 frozen; bisect on omega/delta.
+    # Reduces to fourcv bisecting — the generic bisecting solver handles it.
+    # Surface modes (five_circle_*, zaxis_*) require reference infrastructure (Issue J).
+    modes = {
+        "bisecting_4c": ConstraintSet(
+            [
+                SampleConstraint("alpha", 0.0),
+                DetectorConstraint("gamma", 0.0),
+                BisectConstraint("omega", "delta"),
+            ],
+            computed=["omega", "chi", "phi", "delta"],
+        ),
+        "fixed_gamma_5c": ConstraintSet(
+            [
+                DetectorConstraint("gamma", 0.0),
+                SampleConstraint("alpha", 0.0),
+                BisectConstraint("omega", "delta"),
+            ],
+            computed=["omega", "chi", "phi", "delta", "alpha"],
+        ),
+        "fixed_alpha_5c": ConstraintSet(
+            [
+                SampleConstraint("alpha", 0.0),
+                BisectConstraint("omega", "delta"),
+                DetectorConstraint("gamma", 0.0),
+            ],
+            computed=["omega", "chi", "phi", "delta", "gamma"],
+        ),
+        "zaxis_alpha_fixed": ConstraintSet(
+            [
+                SampleConstraint("alpha", 0.0),
+                SampleConstraint("chi", 0.0),
+                ReferenceConstraint("alpha_i", 0.0),
+            ],
+            computed=["omega", "delta", "gamma"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+        "zaxis_beta_fixed": ConstraintSet(
+            [
+                DetectorConstraint("gamma", 0.0),
+                SampleConstraint("chi", 0.0),
+                ReferenceConstraint("beta_out", 0.0),
+            ],
+            computed=["omega", "delta", "alpha"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+        "zaxis_alpha_eq_beta": ConstraintSet(
+            [
+                SampleConstraint("chi", 0.0),
+                SampleConstraint("phi", 0.0),
+                ReferenceConstraint("a_eq_b", True),
+            ],
+            computed=["omega", "delta", "alpha", "gamma"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -733,6 +790,8 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "(IUCr six-circle; Walko S(3D2)1). "
             "Sample and detector share the alpha (rotary table) base stage."
         ),
+        modes=modes,
+        default_mode="bisecting_4c",
     )
 
 
@@ -1124,7 +1183,7 @@ def fivec(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
     # handles this case identically to fourcv bisecting.
     # Modes where mu != 0 require a tilted-plane solver (not yet implemented).
     modes = {
-        "bisecting": ConstraintSet(
+        "bisecting_4c": ConstraintSet(
             [
                 SampleConstraint("mu", 0.0),
                 BisectConstraint("omega", "ttheta"),
@@ -1170,5 +1229,5 @@ def fivec(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "Sample and detector coupled through mu."
         ),
         modes=modes,
-        default_mode="bisecting",
+        default_mode="bisecting_4c",
     )

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -47,7 +47,7 @@ ValueError
 ValueError
     If (h, k, l) = (0, 0, 0).
 EwaldSphereViolation
-    If the requested |Q| exceeds the Ewald sphere (wavelength too long).
+    If the requested ``|Q|`` exceeds the Ewald sphere (wavelength too long).
 ConstraintViolation
     If a returned solution violates a declared constraint beyond tolerance.
 
@@ -111,7 +111,7 @@ def compute_forward(
         If (h, k, l) == (0, 0, 0).
     EwaldSphereViolation
         If the scattering vector magnitude exceeds the Ewald sphere
-        (|Q| > 4π/λ, i.e. Bragg condition cannot be satisfied).
+        (``|Q|`` > 4π/λ, i.e. Bragg condition cannot be satisfied).
     ConstraintViolation
         If a solution returned by the solver violates a declared constraint
         beyond the display-precision tolerance.

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -114,7 +114,7 @@ class EwaldSphereViolation(ValueError):
     Ewald sphere (``|Q| > 4π/λ``), meaning the Bragg condition cannot be
     satisfied regardless of motor angles.
 
-    Attributes
+    Parameters
     ----------
     q_mag : float
         Requested scattering vector magnitude in Å⁻¹.
@@ -143,7 +143,7 @@ class ConstraintViolation(ValueError):
     constraint (e.g. a kappa Eulerian pseudoangle that has not yet been
     inverted).
 
-    Attributes
+    Parameters
     ----------
     solution_index : int
         Zero-based index of the violating solution in the returned list.

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -35,6 +35,7 @@ from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import kappa4cv
 from ad_hoc_diffractometer import psic
+from ad_hoc_diffractometer import sixc
 from ad_hoc_diffractometer import ub_identity
 from ad_hoc_diffractometer.constants import XHAT
 from ad_hoc_diffractometer.constants import YHAT
@@ -1077,9 +1078,9 @@ def test_fixed_sample_with_detector_constraint():
 @pytest.mark.parametrize(
     "mode_name, h, k, l",
     [
-        pytest.param("bisecting", 1, 0, 0, id="bisecting-100"),
-        pytest.param("bisecting", 0, 1, 0, id="bisecting-010"),
-        pytest.param("bisecting", 1, 1, 1, id="bisecting-111"),
+        pytest.param("bisecting_4c", 1, 0, 0, id="bisecting_4c-100"),
+        pytest.param("bisecting_4c", 0, 1, 0, id="bisecting_4c-010"),
+        pytest.param("bisecting_4c", 1, 1, 1, id="bisecting_4c-111"),
         pytest.param("fixed_chi", 1, 0, 0, id="fixed_chi-100"),
         pytest.param("fixed_chi", 0, 1, 0, id="fixed_chi-010"),
         pytest.param("fixed_phi", 0, 1, 0, id="fixed_phi-010"),
@@ -1104,7 +1105,7 @@ def test_fivec_round_trip(mode_name, h, k, l):  # noqa: E741
 @pytest.mark.parametrize(
     "mode_name, stage, expected_value",
     [
-        pytest.param("bisecting", "mu", 0.0, id="bisecting-mu-zero"),
+        pytest.param("bisecting_4c", "mu", 0.0, id="bisecting_4c-mu-zero"),
         pytest.param("fixed_chi", "mu", 0.0, id="fixed_chi-mu-zero"),
         pytest.param("fixed_chi", "chi", 90.0, id="fixed_chi-chi-value"),
         pytest.param("fixed_phi", "mu", 0.0, id="fixed_phi-mu-zero"),
@@ -1126,8 +1127,81 @@ def test_fivec_constraint_value_in_solution(mode_name, stage, expected_value):
 
 
 def test_fivec_bisecting_omega_equals_ttheta_half():
-    """In fivec bisecting mode, omega must equal ttheta/2 for all solutions."""
+    """In fivec bisecting_4c mode, omega must equal ttheta/2 for all solutions."""
     g = _setup_cubic(fivec, a=4.0)
     solutions = g.forward(1, 0, 0)
     for sol in solutions:
         assert sol["omega"] == pytest.approx(sol["ttheta"] / 2.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Issue #155 — sixc: implemented modes round-trip; stubs raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l",
+    [
+        pytest.param("bisecting_4c", 1, 0, 0, id="bisecting_4c-100"),
+        pytest.param("bisecting_4c", 0, 1, 0, id="bisecting_4c-010"),
+        pytest.param("bisecting_4c", 1, 1, 1, id="bisecting_4c-111"),
+        pytest.param("fixed_gamma_5c", 1, 0, 0, id="fixed_gamma_5c-100"),
+        pytest.param("fixed_gamma_5c", 0, 1, 0, id="fixed_gamma_5c-010"),
+        pytest.param("fixed_alpha_5c", 1, 0, 0, id="fixed_alpha_5c-100"),
+        pytest.param("fixed_alpha_5c", 1, 1, 1, id="fixed_alpha_5c-111"),
+    ],
+)
+def test_sixc_round_trip(mode_name, h, k, l):  # noqa: E741
+    """Implemented sixc modes solve and round-trip correctly."""
+    g = _setup_cubic(sixc, a=4.0)
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [
+        pytest.param("zaxis_alpha_fixed", id="zaxis_alpha_fixed"),
+        pytest.param("zaxis_beta_fixed", id="zaxis_beta_fixed"),
+        pytest.param("zaxis_alpha_eq_beta", id="zaxis_alpha_eq_beta"),
+    ],
+)
+def test_sixc_zaxis_stub_not_implemented(mode_name):
+    """zaxis modes require reference infrastructure (Issue J) — not yet implemented."""
+    g = _setup_cubic(sixc, a=4.0)
+    g.mode_name = mode_name
+    assert not g.modes[mode_name].is_implemented(g)
+    with pytest.raises(NotImplementedError):
+        g.forward(1, 0, 0)
+
+
+def test_sixc_four_circle_matches_fourcv():
+    """sixc four_circle mode with alpha=gamma=0 gives same ttheta as fourcv bisecting."""
+    g_sixc = _setup_cubic(sixc, a=4.0)
+    g_fourcv = _setup_cubic(fourcv, a=4.0)
+
+    sols_sixc = g_sixc.forward(1, 0, 0)
+    sols_fourcv = g_fourcv.forward(1, 0, 0)
+
+    assert len(sols_sixc) > 0 and len(sols_fourcv) > 0
+    # ttheta/delta should match between the two geometries
+    ttheta_fourcv = sols_fourcv[0]["ttheta"]
+    delta_sixc = sols_sixc[0]["delta"]
+    assert delta_sixc == pytest.approx(ttheta_fourcv, abs=1e-8)
+
+
+def test_sixc_four_circle_alpha_gamma_frozen():
+    """In four_circle mode, alpha=0 and gamma=0 in all solutions."""
+    g = _setup_cubic(sixc, a=4.0)
+    solutions = g.forward(1, 0, 0)
+    for sol in solutions:
+        assert sol["alpha"] == pytest.approx(0.0, abs=1e-8)
+        assert sol["gamma"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_sixc_four_circle_omega_equals_delta_half():
+    """In sixc four_circle mode, omega must equal delta/2 for all solutions."""
+    g = _setup_cubic(sixc, a=4.0)
+    solutions = g.forward(1, 0, 0)
+    for sol in solutions:
+        assert sol["omega"] == pytest.approx(sol["delta"] / 2.0, abs=1e-10)

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -48,6 +48,7 @@ from ad_hoc_diffractometer import Stage
 from ad_hoc_diffractometer import fivec
 from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import sixc
 from ad_hoc_diffractometer.constants import XHAT
 from ad_hoc_diffractometer.constants import YHAT
 from ad_hoc_diffractometer.constants import ZHAT
@@ -1484,7 +1485,7 @@ def test_four_circle_modes_round_trip_serialisation(factory):
 # ---------------------------------------------------------------------------
 
 _FIVEC_MODES = {
-    "bisecting",
+    "bisecting_4c",
     "fixed_chi",
     "fixed_phi",
     "fixed_mu",
@@ -1497,9 +1498,9 @@ def test_fivec_factory_mode_names():
     assert set(fivec().modes.keys()) == _FIVEC_MODES
 
 
-def test_fivec_default_mode_is_bisecting():
-    """Default mode for fivec is 'bisecting'."""
-    assert fivec().mode_name == "bisecting"
+def test_fivec_default_mode_is_bisecting_4c():
+    """Default mode for fivec is 'bisecting_4c'."""
+    assert fivec().mode_name == "bisecting_4c"
 
 
 def test_fivec_free_dof():
@@ -1522,7 +1523,7 @@ def test_fivec_mode_is_constraint_set(mode_name):
 @pytest.mark.parametrize(
     "mode_name, expected_implemented",
     [
-        pytest.param("bisecting", True, id="bisecting-implemented"),
+        pytest.param("bisecting_4c", True, id="bisecting_4c-implemented"),
         pytest.param("fixed_chi", True, id="fixed_chi-implemented"),
         pytest.param("fixed_phi", True, id="fixed_phi-implemented"),
         pytest.param("fixed_mu", True, id="fixed_mu-implemented"),
@@ -1542,7 +1543,7 @@ def test_fivec_mode_is_implemented(mode_name, expected_implemented):
 @pytest.mark.parametrize(
     "mode_name, expected_has_bisect",
     [
-        pytest.param("bisecting", True, id="bisecting-has-bisect"),
+        pytest.param("bisecting_4c", True, id="bisecting_4c-has-bisect"),
         pytest.param("fixed_chi", False, id="fixed_chi-no-bisect"),
         pytest.param("fixed_phi", False, id="fixed_phi-no-bisect"),
         pytest.param("fixed_mu", True, id="fixed_mu-has-bisect"),
@@ -1560,7 +1561,9 @@ def test_fivec_mode_has_bisect(mode_name, expected_has_bisect):
 @pytest.mark.parametrize(
     "mode_name, expected_computed",
     [
-        pytest.param("bisecting", ["omega", "chi", "phi", "ttheta"], id="bisecting"),
+        pytest.param(
+            "bisecting_4c", ["omega", "chi", "phi", "ttheta"], id="bisecting_4c"
+        ),
         pytest.param("fixed_chi", ["omega", "phi", "ttheta"], id="fixed_chi"),
         pytest.param("fixed_phi", ["omega", "chi", "ttheta"], id="fixed_phi"),
         pytest.param(
@@ -1586,4 +1589,125 @@ def test_fivec_modes_round_trip_serialisation():
     assert set(d["modes"].keys()) == _FIVEC_MODES
     g2 = AdHocDiffractometer.from_dict(d)
     assert set(g2.modes.keys()) == _FIVEC_MODES
-    assert g2.mode_name == "bisecting"
+    assert g2.mode_name == "bisecting_4c"
+
+
+# ---------------------------------------------------------------------------
+# Issue #155 — sixc mode structure
+# ---------------------------------------------------------------------------
+
+_SIXC_MODES = {
+    "bisecting_4c",
+    "fixed_gamma_5c",
+    "fixed_alpha_5c",
+    "zaxis_alpha_fixed",
+    "zaxis_beta_fixed",
+    "zaxis_alpha_eq_beta",
+}
+
+_SIXC_IMPLEMENTED = {"bisecting_4c", "fixed_gamma_5c", "fixed_alpha_5c"}
+_SIXC_STUBS = {"zaxis_alpha_fixed", "zaxis_beta_fixed", "zaxis_alpha_eq_beta"}
+
+
+def test_sixc_factory_mode_names():
+    """sixc exposes exactly the 6 declared mode names."""
+    assert set(sixc().modes.keys()) == _SIXC_MODES
+
+
+def test_sixc_default_mode_is_bisecting_4c():
+    """Default mode for sixc is 'bisecting_4c'."""
+    assert sixc().mode_name == "bisecting_4c"
+
+
+def test_sixc_free_dof():
+    """sixc has free_dof_after_bragg == 3."""
+    assert sixc().free_dof_after_bragg == 3
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [pytest.param(m, id=m) for m in _SIXC_MODES],
+)
+def test_sixc_mode_is_constraint_set(mode_name):
+    """Every sixc mode is a ConstraintSet with exactly 3 constraints."""
+    g = sixc()
+    cs = g.modes[mode_name]
+    assert isinstance(cs, ConstraintSet)
+    assert len(cs) == 3
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_implemented",
+    [pytest.param(m, True, id=f"{m}-implemented") for m in _SIXC_IMPLEMENTED]
+    + [pytest.param(m, False, id=f"{m}-stub") for m in _SIXC_STUBS],
+)
+def test_sixc_mode_is_implemented(mode_name, expected_implemented):
+    """Implemented modes return True; zaxis stubs return False."""
+    g = sixc()
+    assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_has_bisect",
+    [
+        pytest.param("bisecting_4c", True, id="bisecting_4c-has-bisect"),
+        pytest.param("fixed_gamma_5c", True, id="fixed_gamma_5c-has-bisect"),
+        pytest.param("fixed_alpha_5c", True, id="fixed_alpha_5c-has-bisect"),
+        pytest.param("zaxis_alpha_fixed", False, id="zaxis_alpha_fixed-no-bisect"),
+        pytest.param("zaxis_beta_fixed", False, id="zaxis_beta_fixed-no-bisect"),
+        pytest.param("zaxis_alpha_eq_beta", False, id="zaxis_alpha_eq_beta-no-bisect"),
+    ],
+)
+def test_sixc_mode_has_bisect(mode_name, expected_has_bisect):
+    """BisectConstraint presence matches expected for each sixc mode."""
+    assert sixc().modes[mode_name].has_bisect == expected_has_bisect
+
+
+@pytest.mark.parametrize(
+    "mode_name, extras_key, expected_value",
+    [
+        pytest.param(
+            "zaxis_alpha_fixed", "n_hat", "REQUIRED", id="zaxis_alpha_fixed-n_hat"
+        ),
+        pytest.param(
+            "zaxis_alpha_fixed", "alpha_i", None, id="zaxis_alpha_fixed-alpha_i-output"
+        ),
+        pytest.param(
+            "zaxis_beta_fixed", "n_hat", "REQUIRED", id="zaxis_beta_fixed-n_hat"
+        ),
+        pytest.param(
+            "zaxis_beta_fixed", "beta_out", None, id="zaxis_beta_fixed-beta_out-output"
+        ),
+        pytest.param(
+            "zaxis_alpha_eq_beta", "n_hat", "REQUIRED", id="zaxis_alpha_eq_beta-n_hat"
+        ),
+    ],
+)
+def test_sixc_zaxis_extras_declared(mode_name, extras_key, expected_value):
+    """zaxis mode extras carry the expected sentinel or output placeholder."""
+    g = sixc()
+    mode = g.modes[mode_name]
+    actual = mode.extras.get(extras_key)
+    if expected_value == "REQUIRED":
+        assert actual is REQUIRED
+    else:
+        assert actual is expected_value
+
+
+def test_sixc_four_circle_computed_stages():
+    """four_circle mode computed field lists omega, chi, phi, delta."""
+    cs = sixc().modes["bisecting_4c"]
+    assert cs.computed == ["omega", "chi", "phi", "delta"]
+
+
+def test_sixc_modes_round_trip_serialisation():
+    """Full to_dict / from_dict round-trip preserves all 6 sixc modes."""
+    import json
+
+    g = sixc()
+    d = g.to_dict()
+    assert json.dumps(d)
+    assert set(d["modes"].keys()) == _SIXC_MODES
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == _SIXC_MODES
+    assert g2.mode_name == "bisecting_4c"


### PR DESCRIPTION
## Summary

- Adds 6 diffraction modes to `sixc`: `bisecting_4c`, `fixed_gamma_5c`, `fixed_alpha_5c`, `zaxis_alpha_fixed`, `zaxis_beta_fixed`, `zaxis_alpha_eq_beta`
- Renames `fivec` `"bisecting"` → `"bisecting_4c"` and `sixc` `"four_circle"` → `"bisecting_4c"` for a consistent naming pattern across 5+ circle geometries (compact form, preserves the constraint meaning)
- Renames `five_circle_gamma` → `fixed_gamma_5c` and `five_circle_alpha` → `fixed_alpha_5c` (same pattern: fixed axis name + geometry size suffix)
- Fixes `forward.py` docstring `|Q|` substitution errors and adds `forward → display` edge to the Module Dependency Graph
- Fixes `EwaldSphereViolation` and `ConstraintViolation` docstrings (`Attributes` → `Parameters`) to eliminate duplicate autoapi entries
- Adds `howto/constraints.md`: new HOWTO covering the full constraint framework
- Rewrites `howto/modes.md` and all five geometry pages (fourcv, fourch, fivec, psic, sixc) for `ConstraintSet` semantics; all cross-reference roles use full module paths so links resolve correctly in autoapi HTML

- closes #155

Contributed by: OpenCode (argo/claudesonnet46)