### PR TITLE
feat: psic diffraction modes; bisecting_vertical naming; fix Published timestamp (#150)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,13 +36,15 @@ version = ".".join(release.split(".")[:2])
 # Falls back to release so local builds still work.
 switcher_version_match = os.environ.get("DOC_VERSION", release)
 
-# Timestamp displayed in the page footer.
-# Uses Chicago local time (America/Chicago — CDT/CST depending on season)
-# regardless of the timezone of the build environment (e.g. UTC in CI).
-html_last_updated_fmt = (
-    datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/Chicago"))
-    .strftime("%Y-%m-%d %H:%M %Z")
-)
+# All build timestamps use Chicago local time (America/Chicago — CDT/CST)
+# regardless of the CI build environment timezone.
+_chicago_now = datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/Chicago"))
+
+# Footer "Last updated on …" timestamp.
+html_last_updated_fmt = _chicago_now.strftime("%Y-%m-%d %H:%M %Z")
+
+# |today| substitution used in index.rst "Published" table row.
+today = _chicago_now.strftime("%Y-%m-%d %H:%M %Z")
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -47,10 +47,15 @@ Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 3 constrain
 See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
 changing constraint values at run time.
 
-### `bisecting` *(default)*
+**Bisect pairs:**
+
+- Vertical plane: eta (lateral) ↔ delta (lateral) → `eta = delta/2`
+- Horizontal plane: mu (vertical) ↔ nu (vertical) → `mu = nu/2`
+
+### `bisecting_vertical` *(default)*
 
 {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
-`eta = delta / 2`, `mu = 0`, `nu = 0`.
+`eta = delta/2`, `mu = 0`, `nu = 0`.
 Vertical scattering plane bisecting condition (You 1999, §5.3).
 
 | | |
@@ -60,11 +65,8 @@ Vertical scattering plane bisecting condition (You 1999, §5.3).
 
 ### `fixed_chi`
 
-{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
-`eta = delta / 2`, `mu = 0`, `nu = 0`.
-`chi` is held at the value declared in the constraint (factory default: 90°).
-The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`; the constraint
-persists until replaced — see {doc}`../howto/constraints`.
+`chi` held at declared value (default 90°), `eta = delta/2`, `nu = 0`.
+The caller chooses the chi value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` — see {doc}`../howto/constraints`.
 
 | | |
 |---|---|
@@ -73,10 +75,7 @@ persists until replaced — see {doc}`../howto/constraints`.
 
 ### `fixed_phi`
 
-{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
-`eta = delta / 2`, `mu = 0`, `nu = 0`.
-`phi` is held at the value declared in the constraint (factory default: 0°).
-The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+`phi` held at declared value (default 0°), `eta = delta/2`, `nu = 0`.
 
 | | |
 |---|---|
@@ -85,15 +84,88 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 
 ### `fixed_mu`
 
-{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
-`eta = delta / 2`, `nu = 0`.
-`mu` is held at the value declared in the constraint (factory default: 0°).
-The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
+`mu` held at declared value (default 0°), `eta = delta/2`, `nu = 0`.
 
 | | |
 |---|---|
 | **Computed** | eta, chi, phi, delta |
 | **Constant during** `forward()` | mu, nu = 0 |
+
+### `bisecting_horizontal`
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`mu = nu/2`, `eta = 0`, `delta = 0`.
+Horizontal scattering plane bisecting condition (You 1999, §5.1).
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0 |
+
+### `fixed_nu`
+
+`nu` held at declared value (default 0°), `eta = delta/2`, `mu = 0`.
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | nu, mu = 0 |
+
+### `double_diffraction_vertical`
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+with secondary-reflection extras.
+Bisecting solver runs; simultaneous diffraction logic not yet implemented.
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
+### `lifting_detector_mu` *(stub)*
+
+Out-of-plane mode: mu and eta frozen, nu and delta free.
+Requires the qaz pseudo-angle solver — not yet implemented.
+
+| | |
+|---|---|
+| **Computed** | mu, nu, delta |
+| **Constant during** `forward()` | mu, eta |
+
+### `lifting_detector_phi` *(stub)*
+
+Out-of-plane mode: phi and mu frozen, nu and delta free.
+Requires the qaz pseudo-angle solver — not yet implemented.
+
+| | |
+|---|---|
+| **Computed** | phi, nu, delta |
+| **Constant during** `forward()` | phi, mu |
+
+### `psi_constant_vertical` *(stub)*
+
+Vertical bisecting with azimuthal angle ψ of n̂ about Q fixed.
+Requires reference vector infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
+
+### `psi_constant_horizontal` *(stub)*
+
+Horizontal bisecting with azimuthal angle ψ fixed.
+Requires reference vector infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0 |
+| **Extras (input)** | n̂, ψ |
+| **Extras (output)** | psi |
 
 ## API reference
 
@@ -104,8 +176,8 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 - {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
 - {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
 - {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
-- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
-- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -485,8 +485,12 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         Stage("nu", +VERTICAL, parent=None, role="detector"),
         Stage("delta", -LATERAL, parent="nu", role="detector"),
     ]
+    # psic: 6 DOF, N-3=3 constraints needed per mode (You 1999, S4D2).
+    # Vertical bisect pair: eta(lateral) <-> delta(lateral)  => eta = delta/2
+    # Horizontal bisect pair: mu(vertical) <-> nu(vertical)  => mu = nu/2
     modes = {
-        "bisecting": ConstraintSet(
+        # ── Implemented analytic modes ──────────────────────────────────────
+        "bisecting_vertical": ConstraintSet(
             [
                 BisectConstraint("eta", "delta"),
                 SampleConstraint("mu", 0.0),
@@ -518,6 +522,66 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             ],
             computed=["eta", "chi", "phi", "delta"],
         ),
+        "bisecting_horizontal": ConstraintSet(
+            [
+                BisectConstraint("mu", "nu"),
+                SampleConstraint("eta", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "chi", "phi", "nu"],
+        ),
+        "fixed_nu": ConstraintSet(
+            [
+                DetectorConstraint("nu", 0.0),
+                BisectConstraint("eta", "delta"),
+                SampleConstraint("mu", 0.0),
+            ],
+            computed=["eta", "chi", "phi", "delta"],
+        ),
+        "double_diffraction_vertical": ConstraintSet(
+            [
+                BisectConstraint("eta", "delta"),
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+            ],
+            computed=["eta", "chi", "phi", "delta"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
+        ),
+        # ── Stubs: solver not yet implemented ───────────────────────────────
+        "lifting_detector_mu": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                SampleConstraint("eta", 0.0),
+                DetectorConstraint("qaz", 90.0),
+            ],
+            computed=["mu", "nu", "delta"],
+        ),
+        "lifting_detector_phi": ConstraintSet(
+            [
+                SampleConstraint("phi", 0.0),
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("qaz", 90.0),
+            ],
+            computed=["phi", "nu", "delta"],
+        ),
+        "psi_constant_vertical": ConstraintSet(
+            [
+                BisectConstraint("eta", "delta"),
+                SampleConstraint("mu", 0.0),
+                ReferenceConstraint("psi", 0.0),
+            ],
+            computed=["eta", "chi", "phi", "delta"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "psi_constant_horizontal": ConstraintSet(
+            [
+                BisectConstraint("mu", "nu"),
+                SampleConstraint("eta", 0.0),
+                ReferenceConstraint("psi", 0.0),
+            ],
+            computed=["mu", "chi", "phi", "nu"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
     }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
@@ -528,7 +592,7 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "(lateral detector, vertical scattering plane, synchrotron)"
         ),
         modes=modes,
-        default_mode="bisecting",
+        default_mode="bisecting_vertical",
     )
 
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -251,7 +251,7 @@ def test_fourcv_bisecting_ttheta_from_bragg():
 def test_psic_bisecting_round_trip(a, h, k, l):  # noqa: E741
     """psic bisecting round-trip: inverse(forward(hkl)) == hkl."""
     g = _setup_cubic(psic, a=a)
-    assert g.mode_name == "bisecting"
+    assert g.mode_name == "bisecting_vertical"
     assert _round_trip_ok(g, h, k, l)
 
 
@@ -1205,3 +1205,177 @@ def test_sixc_four_circle_omega_equals_delta_half():
     solutions = g.forward(1, 0, 0)
     for sol in solutions:
         assert sol["omega"] == pytest.approx(sol["delta"] / 2.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Issue #150 — psic: all modes, bisecting_horizontal, stubs
+# ---------------------------------------------------------------------------
+
+_PSIC_MODES_ALL = {
+    "bisecting_vertical",
+    "fixed_chi",
+    "fixed_phi",
+    "fixed_mu",
+    "bisecting_horizontal",
+    "fixed_nu",
+    "double_diffraction_vertical",
+    "lifting_detector_mu",
+    "lifting_detector_phi",
+    "psi_constant_vertical",
+    "psi_constant_horizontal",
+}
+
+_PSIC_MODES_IMPLEMENTED = {
+    "bisecting_vertical",
+    "fixed_chi",
+    "fixed_phi",
+    "fixed_mu",
+    "bisecting_horizontal",
+    "fixed_nu",
+    "double_diffraction_vertical",
+}
+
+_PSIC_MODES_STUBS = _PSIC_MODES_ALL - _PSIC_MODES_IMPLEMENTED
+
+
+def test_psic_has_all_eleven_modes():
+    """psic exposes exactly 11 declared modes."""
+    assert set(psic().modes.keys()) == _PSIC_MODES_ALL
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_implemented",
+    [pytest.param(m, True, id=f"{m}-impl") for m in sorted(_PSIC_MODES_IMPLEMENTED)]
+    + [pytest.param(m, False, id=f"{m}-stub") for m in sorted(_PSIC_MODES_STUBS)],
+)
+def test_psic_mode_is_implemented(mode_name, expected_implemented):
+    """Implemented psic modes return True; stubs return False."""
+    g = psic()
+    assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l",
+    [
+        pytest.param("bisecting_vertical", 1, 0, 0, id="bisecting_vertical-100"),
+        pytest.param("bisecting_vertical", 1, 1, 1, id="bisecting_vertical-111"),
+        pytest.param("fixed_chi", 0, 0, 1, id="fixed_chi-001"),
+        pytest.param("fixed_chi", 0, 1, 0, id="fixed_chi-010"),
+        pytest.param("fixed_phi", 0, 1, 0, id="fixed_phi-010"),
+        pytest.param("fixed_phi", 1, 1, 1, id="fixed_phi-111"),
+        pytest.param("fixed_mu", 1, 0, 0, id="fixed_mu-100"),
+        pytest.param("fixed_mu", 0, 1, 0, id="fixed_mu-010"),
+        # bisecting_horizontal: Q must lie in the horizontal plane (no longitudinal component)
+        pytest.param("bisecting_horizontal", 1, 0, 0, id="bisecting_horiz-100"),
+        pytest.param("bisecting_horizontal", 0, 0, 1, id="bisecting_horiz-001"),
+        pytest.param("bisecting_horizontal", 1, 0, 1, id="bisecting_horiz-101"),
+        pytest.param("fixed_nu", 1, 0, 0, id="fixed_nu-100"),
+        pytest.param("fixed_nu", 1, 1, 1, id="fixed_nu-111"),
+        pytest.param("double_diffraction_vertical", 1, 0, 0, id="double_diff-100"),
+    ],
+)
+def test_psic_mode_round_trip(mode_name, h, k, l):  # noqa: E741
+    """All implemented psic modes solve and round-trip correctly."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [pytest.param(m, id=m) for m in sorted(_PSIC_MODES_STUBS)],
+)
+def test_psic_stub_not_implemented(mode_name):
+    """Stub modes raise NotImplementedError on forward()."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = mode_name
+    with pytest.raises(NotImplementedError):
+        g.forward(1, 0, 0)
+
+
+def test_psic_bisecting_horizontal_mu_equals_nu_half():
+    """bisecting_horizontal: mu = nu/2 for all solutions."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = "bisecting_horizontal"
+    solutions = g.forward(1, 0, 0)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol["mu"] == pytest.approx(sol["nu"] / 2.0, abs=1e-10)
+
+
+def test_psic_bisecting_horizontal_eta_delta_frozen():
+    """bisecting_horizontal: eta=0 and delta=0 in all solutions."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = "bisecting_horizontal"
+    solutions = g.forward(1, 0, 0)
+    for sol in solutions:
+        assert sol["eta"] == pytest.approx(0.0, abs=1e-8)
+        assert sol["delta"] == pytest.approx(0.0, abs=1e-8)
+
+
+@pytest.mark.parametrize(
+    "mode_name, stage, expected_value, h, k, l",
+    [
+        pytest.param(
+            "bisecting_vertical", "mu", 0.0, 1, 0, 0, id="bisecting_vertical-mu=0"
+        ),
+        pytest.param(
+            "bisecting_vertical", "nu", 0.0, 1, 0, 0, id="bisecting_vertical-nu=0"
+        ),
+        pytest.param("fixed_phi", "phi", 0.0, 0, 1, 0, id="fixed_phi-phi=0"),
+        pytest.param("fixed_mu", "mu", 0.0, 1, 0, 0, id="fixed_mu-mu=0"),
+        pytest.param("fixed_nu", "nu", 0.0, 1, 0, 0, id="fixed_nu-nu=0"),
+        # fixed_chi: (0,0,1) gives mu=0; chi=90 is the only declared constraint
+        pytest.param("fixed_chi", "chi", 90.0, 0, 0, 1, id="fixed_chi-chi=90"),
+        # bisecting_horizontal: Q must lie in horizontal plane; (1,0,0) works
+        pytest.param(
+            "bisecting_horizontal", "eta", 0.0, 1, 0, 0, id="bisecting_horiz-eta=0"
+        ),
+        pytest.param(
+            "bisecting_horizontal", "delta", 0.0, 1, 0, 0, id="bisecting_horiz-delta=0"
+        ),
+    ],
+)
+def test_psic_constraint_value_in_solution(mode_name, stage, expected_value, h, k, l):  # noqa: E741
+    """Constraint values appear at their declared values in all solutions."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol[stage] == pytest.approx(expected_value, abs=1e-8)
+
+
+def test_psic_psi_constant_extras_declared():
+    """psi_constant modes carry REQUIRED n_hat and None psi output extras."""
+    from ad_hoc_diffractometer import REQUIRED
+
+    for mode_name in ("psi_constant_vertical", "psi_constant_horizontal"):
+        cs = psic().modes[mode_name]
+        assert cs.extras.get("n_hat") is REQUIRED
+        assert cs.extras.get("psi") is None
+
+
+def test_psic_double_diffraction_extras_declared():
+    """double_diffraction_vertical carries REQUIRED h2, k2, l2 extras."""
+    from ad_hoc_diffractometer import REQUIRED
+
+    cs = psic().modes["double_diffraction_vertical"]
+    assert cs.extras.get("h2") is REQUIRED
+    assert cs.extras.get("k2") is REQUIRED
+    assert cs.extras.get("l2") is REQUIRED
+
+
+def test_psic_modes_serialisation_round_trip():
+    """All 11 psic modes survive to_dict / from_dict round-trip."""
+    import json
+
+    from ad_hoc_diffractometer import AdHocDiffractometer
+
+    g = psic()
+    d = g.to_dict()
+    assert json.dumps(d)
+    assert set(d["modes"].keys()) == _PSIC_MODES_ALL
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == _PSIC_MODES_ALL
+    assert g2.mode_name == "bisecting_vertical"

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -47,13 +47,17 @@ WAVELENGTH = 1.5406  # Cu Kα in Å
 HKL_TEST = (1, 1, 0)  # reflection used throughout psi tests
 
 
-def _setup(factory, a=4.0, *, mode="bisecting"):
-    """Return a geometry with wavelength set, cubic lattice, UB=B."""
+def _setup(factory, a=4.0, *, mode=None):
+    """Return a geometry with wavelength set, cubic lattice, UB=B.
+
+    If mode is None (default), use the geometry's factory default mode.
+    """
     g = factory()
     g.wavelength = WAVELENGTH
     g.sample.lattice = Lattice(a=a)
     ub_identity(g.sample)
-    g.mode_name = mode
+    if mode is not None:
+        g.mode_name = mode
     return g
 
 


### PR DESCRIPTION
## Summary

- Adds 11 diffraction modes to `psic` (You 1999, S4D2)
- Renames psic `"bisecting"` → `"bisecting_vertical"` for consistency with the new `"bisecting_horizontal"` mode (vertical/horizontal plane naming pattern)
- 7 modes implemented by the generic solver; 4 are stubs pending reference/qaz infrastructure
- Fixes the `|today|` "Published" date on the docs index page to display Chicago local time (was UTC)
- Fixes `test_scan.py _setup()` to use geometry default mode instead of hardcoding `"bisecting"`

**New implemented modes:**
- `bisecting_vertical` (renamed from `bisecting`) — eta=delta/2, mu=0, nu=0
- `bisecting_horizontal` (new) — mu=nu/2, eta=0, delta=0 (horizontal scattering plane, You 1999 §5.1)
- `fixed_nu`, `double_diffraction_vertical`

**New stubs:**
- `lifting_detector_mu`, `lifting_detector_phi`, `psi_constant_vertical`, `psi_constant_horizontal`

- closes #150

Contributed by: OpenCode (argo/claudesonnet46)