### PR TITLE
feat: zaxis and s2d2 diffraction modes; rename sixc zaxis stubs (#156)

### DIFF
--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -5,7 +5,7 @@ S2D2 geometry with two independent sample axes (mu, Z) and two independent detec
 
 **Walko (2016) designation:** S2D2
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.s2d2` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L921) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.s2d2` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L1173) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -41,16 +41,46 @@ and mode configuration.
 
 ## Diffraction modes
 
-*(No modes defined for this geometry.  All stages are free during*
-*`forward()` — the solver explores the full solution space.)*
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+See {doc}`../howto/constraints` for the constraint framework.
+
+### `mu_fixed`
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`mu` held at declared value (default 0°) — the incidence angle when the
+surface normal is aligned.
+The caller chooses the value by constructing a
+{class}`~ad_hoc_diffractometer.mode.ConstraintSet` — see
+{doc}`../howto/constraints`.
+
+| | |
+|---|---|
+| **Computed** | Z, nu, delta |
+| **Constant during** `forward()` | mu |
+
+### `reflectivity` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+symmetric reflection — incidence angle equals exit angle (alpha_i = beta_out).
+Requires n̂ — not yet implemented (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | mu, Z, nu, delta |
+| **Constant during** `forward()` | — |
+| **Extras (input)** | n̂ (surface normal) |
+| **Extras (output)** | alpha_i, beta_out |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.s2d2`
+- {func}`~ad_hoc_diffractometer.factories.s2d2`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -87,7 +87,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | omega, chi, phi, delta, gamma |
 | **Constant during** `forward()` | alpha, gamma = 0 |
 
-### `zaxis_alpha_fixed` *(stub)*
+### `fixed_alpha_zaxis` *(stub)*
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 Z-axis mode with fixed incidence angle. Requires n̂ — not yet implemented (Issue J).
@@ -99,7 +99,7 @@ Z-axis mode with fixed incidence angle. Requires n̂ — not yet implemented (Is
 | **Extras (input)** | n̂ (surface normal) |
 | **Extras (output)** | alpha_i (incidence angle), beta_out (exit angle) |
 
-### `zaxis_beta_fixed` *(stub)*
+### `fixed_beta_zaxis` *(stub)*
 
 {class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 Z-axis mode with fixed exit angle. Requires n̂ — not yet implemented (Issue J).
@@ -111,7 +111,7 @@ Z-axis mode with fixed exit angle. Requires n̂ — not yet implemented (Issue J
 | **Extras (input)** | n̂ |
 | **Extras (output)** | alpha_i, beta_out |
 
-### `zaxis_alpha_eq_beta` *(stub)*
+### `alpha_eq_beta_zaxis` *(stub)*
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 Z-axis mode, symmetric reflection (α = γ, β_in = β_out). Requires n̂ — not yet implemented (Issue J).

--- a/docs/source/geometries/zaxis.md
+++ b/docs/source/geometries/zaxis.md
@@ -5,7 +5,7 @@ Z-axis four-circle diffractometer for surface diffraction. The sample surface no
 
 **Walko (2016) designation:** (S1D2)1
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.zaxis` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L872) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.zaxis` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L1109) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -43,16 +43,44 @@ and mode configuration.
 
 ## Diffraction modes
 
-*(No modes defined for this geometry.  All stages are free during*
-*`forward()` — the solver explores the full solution space.)*
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+All modes require the reference vector n̂ (surface normal) via Issue J / #157.
+See {doc}`../howto/constraints` for the extras dict pattern.
+
+### `zaxis` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+surface normal aligned with the Z-axis; alpha directly equals the incidence
+angle β_in, gamma directly equals the exit angle β_out.
+
+| | |
+|---|---|
+| **Computed** | Z, delta, gamma |
+| **Constant during** `forward()` | — |
+| **Extras (input)** | n̂ (surface normal) |
+| **Extras (output)** | alpha_i (= alpha), beta_out (= gamma) |
+
+### `reflectivity` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+symmetric reflection — alpha_i = beta_out (alpha = gamma).
+
+| | |
+|---|---|
+| **Computed** | Z, delta, alpha, gamma |
+| **Constant during** `forward()` | — |
+| **Extras (input)** | n̂ |
+| **Extras (output)** | alpha_i, beta_out |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.zaxis`
+- {func}`~ad_hoc_diffractometer.factories.zaxis`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -817,7 +817,7 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             ],
             computed=["omega", "chi", "phi", "delta", "gamma"],
         ),
-        "zaxis_alpha_fixed": ConstraintSet(
+        "fixed_alpha_zaxis": ConstraintSet(
             [
                 SampleConstraint("alpha", 0.0),
                 SampleConstraint("chi", 0.0),
@@ -826,7 +826,7 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             computed=["omega", "delta", "gamma"],
             extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
         ),
-        "zaxis_beta_fixed": ConstraintSet(
+        "fixed_beta_zaxis": ConstraintSet(
             [
                 DetectorConstraint("gamma", 0.0),
                 SampleConstraint("chi", 0.0),
@@ -835,7 +835,7 @@ def sixc(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             computed=["omega", "delta", "alpha"],
             extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
         ),
-        "zaxis_alpha_eq_beta": ConstraintSet(
+        "alpha_eq_beta_zaxis": ConstraintSet(
             [
                 SampleConstraint("chi", 0.0),
                 SampleConstraint("phi", 0.0),
@@ -1142,6 +1142,20 @@ def zaxis(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         Stage("delta", -LATERAL, parent="alpha", role="detector"),
         Stage("gamma", +VERTICAL, parent="delta", role="detector"),
     ]
+    # zaxis: 4 DOF, N-3=1 constraint needed per mode.
+    # All modes require reference vector n̂ (Issue J / #157).
+    modes = {
+        "zaxis": ConstraintSet(
+            [ReferenceConstraint("alpha_i", 0.0)],
+            computed=["Z", "delta", "gamma"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+        "reflectivity": ConstraintSet(
+            [ReferenceConstraint("a_eq_b", True)],
+            computed=["Z", "delta", "alpha", "gamma"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -1151,6 +1165,7 @@ def zaxis(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "Surface normal parallel to Z-axis. "
             "Sample and detector share the alpha (base) stage."
         ),
+        modes=modes,
     )
 
 
@@ -1195,6 +1210,18 @@ def s2d2(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         Stage("nu", +VERTICAL, parent=None, role="detector"),
         Stage("delta", -LATERAL, parent="nu", role="detector"),
     ]
+    # s2d2: 4 DOF, N-3=1 constraint needed per mode.
+    modes = {
+        "mu_fixed": ConstraintSet(
+            [SampleConstraint("mu", 0.0)],
+            computed=["Z", "nu", "delta"],
+        ),
+        "reflectivity": ConstraintSet(
+            [ReferenceConstraint("a_eq_b", True)],
+            computed=["mu", "Z", "nu", "delta"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+    }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
         stages=stages,
@@ -1204,6 +1231,7 @@ def s2d2(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
             "Walko 2016 S2D2). "
             "Fully decoupled sample (mu, Z) and detector (nu, delta) axes."
         ),
+        modes=modes,
     )
 
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1161,9 +1161,9 @@ def test_sixc_round_trip(mode_name, h, k, l):  # noqa: E741
 @pytest.mark.parametrize(
     "mode_name",
     [
-        pytest.param("zaxis_alpha_fixed", id="zaxis_alpha_fixed"),
-        pytest.param("zaxis_beta_fixed", id="zaxis_beta_fixed"),
-        pytest.param("zaxis_alpha_eq_beta", id="zaxis_alpha_eq_beta"),
+        pytest.param("fixed_alpha_zaxis", id="fixed_alpha_zaxis"),
+        pytest.param("fixed_beta_zaxis", id="fixed_beta_zaxis"),
+        pytest.param("alpha_eq_beta_zaxis", id="alpha_eq_beta_zaxis"),
     ],
 )
 def test_sixc_zaxis_stub_not_implemented(mode_name):

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -48,7 +48,9 @@ from ad_hoc_diffractometer import Stage
 from ad_hoc_diffractometer import fivec
 from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import s2d2
 from ad_hoc_diffractometer import sixc
+from ad_hoc_diffractometer import zaxis
 from ad_hoc_diffractometer.constants import XHAT
 from ad_hoc_diffractometer.constants import YHAT
 from ad_hoc_diffractometer.constants import ZHAT
@@ -1600,13 +1602,13 @@ _SIXC_MODES = {
     "bisecting_4c",
     "fixed_gamma_5c",
     "fixed_alpha_5c",
-    "zaxis_alpha_fixed",
-    "zaxis_beta_fixed",
-    "zaxis_alpha_eq_beta",
+    "fixed_alpha_zaxis",
+    "fixed_beta_zaxis",
+    "alpha_eq_beta_zaxis",
 }
 
 _SIXC_IMPLEMENTED = {"bisecting_4c", "fixed_gamma_5c", "fixed_alpha_5c"}
-_SIXC_STUBS = {"zaxis_alpha_fixed", "zaxis_beta_fixed", "zaxis_alpha_eq_beta"}
+_SIXC_STUBS = {"fixed_alpha_zaxis", "fixed_beta_zaxis", "alpha_eq_beta_zaxis"}
 
 
 def test_sixc_factory_mode_names():
@@ -1653,9 +1655,9 @@ def test_sixc_mode_is_implemented(mode_name, expected_implemented):
         pytest.param("bisecting_4c", True, id="bisecting_4c-has-bisect"),
         pytest.param("fixed_gamma_5c", True, id="fixed_gamma_5c-has-bisect"),
         pytest.param("fixed_alpha_5c", True, id="fixed_alpha_5c-has-bisect"),
-        pytest.param("zaxis_alpha_fixed", False, id="zaxis_alpha_fixed-no-bisect"),
-        pytest.param("zaxis_beta_fixed", False, id="zaxis_beta_fixed-no-bisect"),
-        pytest.param("zaxis_alpha_eq_beta", False, id="zaxis_alpha_eq_beta-no-bisect"),
+        pytest.param("fixed_alpha_zaxis", False, id="fixed_alpha_zaxis-no-bisect"),
+        pytest.param("fixed_beta_zaxis", False, id="fixed_beta_zaxis-no-bisect"),
+        pytest.param("alpha_eq_beta_zaxis", False, id="alpha_eq_beta_zaxis-no-bisect"),
     ],
 )
 def test_sixc_mode_has_bisect(mode_name, expected_has_bisect):
@@ -1667,19 +1669,19 @@ def test_sixc_mode_has_bisect(mode_name, expected_has_bisect):
     "mode_name, extras_key, expected_value",
     [
         pytest.param(
-            "zaxis_alpha_fixed", "n_hat", "REQUIRED", id="zaxis_alpha_fixed-n_hat"
+            "fixed_alpha_zaxis", "n_hat", "REQUIRED", id="fixed_alpha_zaxis-n_hat"
         ),
         pytest.param(
-            "zaxis_alpha_fixed", "alpha_i", None, id="zaxis_alpha_fixed-alpha_i-output"
+            "fixed_alpha_zaxis", "alpha_i", None, id="fixed_alpha_zaxis-alpha_i-output"
         ),
         pytest.param(
-            "zaxis_beta_fixed", "n_hat", "REQUIRED", id="zaxis_beta_fixed-n_hat"
+            "fixed_beta_zaxis", "n_hat", "REQUIRED", id="fixed_beta_zaxis-n_hat"
         ),
         pytest.param(
-            "zaxis_beta_fixed", "beta_out", None, id="zaxis_beta_fixed-beta_out-output"
+            "fixed_beta_zaxis", "beta_out", None, id="fixed_beta_zaxis-beta_out-output"
         ),
         pytest.param(
-            "zaxis_alpha_eq_beta", "n_hat", "REQUIRED", id="zaxis_alpha_eq_beta-n_hat"
+            "alpha_eq_beta_zaxis", "n_hat", "REQUIRED", id="alpha_eq_beta_zaxis-n_hat"
         ),
     ],
 )
@@ -1711,3 +1713,128 @@ def test_sixc_modes_round_trip_serialisation():
     g2 = AdHocDiffractometer.from_dict(d)
     assert set(g2.modes.keys()) == _SIXC_MODES
     assert g2.mode_name == "bisecting_4c"
+
+
+# ---------------------------------------------------------------------------
+# Issue #156 — zaxis and s2d2 mode structure
+# ---------------------------------------------------------------------------
+
+_ZAXIS_MODES = {"zaxis", "reflectivity"}
+_S2D2_MODES = {"mu_fixed", "reflectivity"}
+
+
+@pytest.mark.parametrize(
+    "factory, expected_modes",
+    [
+        pytest.param(zaxis, _ZAXIS_MODES, id="zaxis"),
+        pytest.param(s2d2, _S2D2_MODES, id="s2d2"),
+    ],
+)
+def test_zaxis_s2d2_factory_mode_names(factory, expected_modes):
+    """zaxis and s2d2 expose exactly their declared mode names."""
+    assert set(factory().modes.keys()) == expected_modes
+
+
+@pytest.mark.parametrize(
+    "factory, expected_modes",
+    [
+        pytest.param(zaxis, _ZAXIS_MODES, id="zaxis"),
+        pytest.param(s2d2, _S2D2_MODES, id="s2d2"),
+    ],
+)
+def test_zaxis_s2d2_free_dof(factory, expected_modes):
+    """Both geometries have free_dof_after_bragg == 1."""
+    assert factory().free_dof_after_bragg == 1
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(zaxis, "zaxis", id="zaxis-zaxis"),
+        pytest.param(zaxis, "reflectivity", id="zaxis-reflectivity"),
+        pytest.param(s2d2, "reflectivity", id="s2d2-reflectivity"),
+    ],
+)
+def test_zaxis_s2d2_reference_modes_are_stubs(factory, mode_name):
+    """All reference-constraint modes return is_implemented=False."""
+    g = factory()
+    cs = g.modes[mode_name]
+    assert isinstance(cs, ConstraintSet)
+    assert len(cs) == 1
+    assert cs.reference_constraint is not None
+    assert cs.is_implemented(g) is False
+
+
+def test_s2d2_mu_fixed_is_implemented():
+    """s2d2 mu_fixed uses a SampleConstraint — is_implemented returns True."""
+    g = s2d2()
+    cs = g.modes["mu_fixed"]
+    assert isinstance(cs, ConstraintSet)
+    assert len(cs) == 1
+    assert cs.is_implemented(g) is True
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, extras_key, expected_value",
+    [
+        pytest.param(zaxis, "zaxis", "n_hat", "REQUIRED", id="zaxis-n_hat"),
+        pytest.param(zaxis, "zaxis", "alpha_i", None, id="zaxis-alpha_i-output"),
+        pytest.param(zaxis, "zaxis", "beta_out", None, id="zaxis-beta_out-output"),
+        pytest.param(zaxis, "reflectivity", "n_hat", "REQUIRED", id="zaxis-refl-n_hat"),
+        pytest.param(s2d2, "reflectivity", "n_hat", "REQUIRED", id="s2d2-refl-n_hat"),
+        pytest.param(s2d2, "reflectivity", "alpha_i", None, id="s2d2-alpha_i-output"),
+    ],
+)
+def test_zaxis_s2d2_extras_declared(factory, mode_name, extras_key, expected_value):
+    """Reference modes carry expected REQUIRED sentinels and output placeholders."""
+    g = factory()
+    mode = g.modes[mode_name]
+    actual = mode.extras.get(extras_key)
+    if expected_value == "REQUIRED":
+        assert actual is REQUIRED
+    else:
+        assert actual is expected_value
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_computed",
+    [
+        pytest.param(zaxis, "zaxis", ["Z", "delta", "gamma"], id="zaxis-computed"),
+        pytest.param(
+            zaxis,
+            "reflectivity",
+            ["Z", "delta", "alpha", "gamma"],
+            id="zaxis-refl-computed",
+        ),
+        pytest.param(
+            s2d2, "mu_fixed", ["Z", "nu", "delta"], id="s2d2-mu_fixed-computed"
+        ),
+        pytest.param(
+            s2d2, "reflectivity", ["mu", "Z", "nu", "delta"], id="s2d2-refl-computed"
+        ),
+    ],
+)
+def test_zaxis_s2d2_computed_stages(factory, mode_name, expected_computed):
+    """computed field lists the correct stage names."""
+    cs = factory().modes[mode_name]
+    assert cs.computed == expected_computed
+
+
+@pytest.mark.parametrize(
+    "factory, expected_modes",
+    [
+        pytest.param(zaxis, _ZAXIS_MODES, id="zaxis"),
+        pytest.param(s2d2, _S2D2_MODES, id="s2d2"),
+    ],
+)
+def test_zaxis_s2d2_modes_round_trip(factory, expected_modes):
+    """Full to_dict / from_dict round-trip preserves all modes."""
+    import json
+
+    g = factory()
+    d = g.to_dict()
+    assert json.dumps(d)
+    assert set(d["modes"].keys()) == expected_modes
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == expected_modes
+    assert g2.mode_name is None


### PR DESCRIPTION
## Summary

- Adds 2 modes to `zaxis` (`zaxis`, `reflectivity`) — both `ReferenceConstraint` stubs pending Issue J (#157)
- Adds 2 modes to `s2d2` (`mu_fixed`, `reflectivity`) — `mu_fixed` uses `SampleConstraint` and is implemented; `reflectivity` is a stub
- Renames sixc zaxis surface mode stubs for consistency with `fixed_<stage>_<geometry>` naming pattern:
  - `zaxis_alpha_fixed` → `fixed_alpha_zaxis`
  - `zaxis_beta_fixed` → `fixed_beta_zaxis`
  - `zaxis_alpha_eq_beta` → `alpha_eq_beta_zaxis`
- Updates `zaxis.md` and `s2d2.md` geometry docs with full mode tables and correct cross-reference roles

- closes #156

Contributed by: OpenCode (argo/claudesonnet46)