### PR TITLE
feat: kappa4cv and kappa4ch diffraction modes (#151)

### DIFF
--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -5,7 +5,7 @@ Four-circle kappa diffractometer, horizontal scattering plane. Kappa axis tilted
 
 **Walko (2016) designation:** S3D1 (kappa)
 
-**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy ({data}`~ad_hoc_diffractometer.factories.BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa4ch` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L733) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.kappa4ch` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L964) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -39,32 +39,75 @@ and mode configuration.
 |---|---|---|
 | ``ttheta`` | −vertical (−z BL) | left-handed |
 
+**Virtual Eulerian angles** (computed from real kappa angles via Walko 2016 eq. [16]):
+omega, chi, phi.  Used as constraint names for stub modes; converted back to
+komega, kappa, kphi by the kappa inversion solver (Issue I / #153).
+
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+Identical mode set to {doc}`kappa4cv`.
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`komega = ttheta / 2` (approximates the bisecting condition).
 
-`komega` is constrained to `ttheta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
+> **Note:** The correct bisecting condition is virtual `omega_euler = 0`.
+> Corrected in Issue I / #153.
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | — |
 
 ### `fixed_kphi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`kphi` held at declared value (default 0°) — real stage, no kappa inversion needed.
 
-Holds `kphi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("kphi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | komega, kappa, ttheta |
+| **Constant during** `forward()` | kphi |
 
+### `constant_omega` *(stub)*
+
+Fix virtual Eulerian omega (default 0°). Requires Issue I / #153.
+
+### `constant_chi` *(stub)*
+
+Fix virtual Eulerian chi (default 90°). Requires Issue I / #153.
+
+### `constant_phi` *(stub)*
+
+Fix virtual Eulerian phi (default 0°). Requires Issue I / #153.
+
+### `psi_constant` *(stub)*
+
+Fix azimuthal angle ψ of n̂ about Q.
+Requires kappa inversion (Issue I) and reference infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.kappa4ch`
+- {func}`~ad_hoc_diffractometer.factories.kappa4ch`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 
 - ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016), eq. [16].

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -5,7 +5,7 @@ Four-circle kappa diffractometer, vertical scattering plane. The chi circle is r
 
 **Walko (2016) designation:** S3D1 (kappa)
 
-**Coordinate basis:** Busing & Levy (`BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
+**Coordinate basis:** Busing & Levy ({data}`~ad_hoc_diffractometer.factories.BASIS_BL`): lateral=+x, longitudinal=+y, vertical=+z.
 
 ## Quick start
 
@@ -19,8 +19,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa4cv` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L668) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.kappa4cv` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L871) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -39,32 +39,98 @@ and mode configuration.
 |---|---|---|
 | ``ttheta`` | −lateral (−x BL) | left-handed |
 
+**Virtual Eulerian angles** (computed from real kappa angles via Walko 2016 eq. [16]):
+omega, chi, phi.  Used as constraint names for stub modes; converted back to
+komega, kappa, kphi by the kappa inversion solver (Issue I / #153).
+
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
+(N − 3 = 1 for N = 4 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint`:
+`komega = ttheta / 2` (approximates the bisecting condition).
 
-`komega` is constrained to `ttheta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
+> **Note:** The correct bisecting condition is virtual `omega_euler = 0`,
+> which differs from `komega = ttheta/2`. Corrected in Issue I / #153.
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | — |
 
 ### `fixed_kphi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`kphi` held at declared value (default 0°) — real stage, no kappa inversion needed.
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
-Holds `kphi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("kphi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | komega, kappa, ttheta |
+| **Constant during** `forward()` | kphi |
 
+### `constant_omega` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+Fix the virtual Eulerian omega at declared value (default 0°).
+Requires kappa inversion solver (Issue I / #153).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | omega (virtual) |
+
+### `constant_chi` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+Fix the virtual Eulerian chi at declared value (default 90°).
+Requires kappa inversion solver (Issue I / #153).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | chi (virtual) |
+
+### `constant_phi` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+Fix the virtual Eulerian phi at declared value (default 0°).
+Requires kappa inversion solver (Issue I / #153).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | phi (virtual) |
+
+### `psi_constant` *(stub)*
+
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+Fix the azimuthal angle ψ of n̂ about Q.
+Requires kappa inversion (Issue I) and reference infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.kappa4cv`
+- {func}`~ad_hoc_diffractometer.factories.kappa4cv`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 
 - ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016), eq. [16].

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -914,9 +914,11 @@ def kappa4cv(
         Stage("ttheta", -LATERAL, parent=None, role="detector"),
     ]
     # kappa4cv: 4 DOF, N-3=1 constraint needed per mode.
-    # Note: bisect on kappa means virtual omega=0 (not real komega=ttheta/2).
-    # komega is named as the sample bisect stage; the kappa inversion solver
-    # (Issue I) will correct this to operate in virtual Eulerian space.
+    # Virtual Eulerian angles (omega, chi, phi) are computed from real kappa
+    # angles (komega, kappa, kphi) via Walko (2016) eq. [16].  Constraints
+    # using virtual angle names are stubs pending Issue I (#153).
+    # BisectConstraint('komega','ttheta') approximates bisecting but is
+    # physically inaccurate — true bisect requires virtual omega=0.
     modes = {
         "bisecting": ConstraintSet(
             [BisectConstraint("komega", "ttheta")],
@@ -925,6 +927,23 @@ def kappa4cv(
         "fixed_kphi": ConstraintSet(
             [SampleConstraint("kphi", 0.0)],
             computed=["komega", "kappa", "ttheta"],
+        ),
+        "constant_omega": ConstraintSet(
+            [SampleConstraint("omega", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "constant_chi": ConstraintSet(
+            [SampleConstraint("chi", 90.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "constant_phi": ConstraintSet(
+            [SampleConstraint("phi", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "psi_constant": ConstraintSet(
+            [ReferenceConstraint("psi", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+            extras={"n_hat": REQUIRED, "psi": None},
         ),
     }
     return AdHocDiffractometer(
@@ -984,6 +1003,7 @@ def kappa4ch(
         Stage("ttheta", -VERTICAL, parent=None, role="detector"),
     ]
     # kappa4ch: 4 DOF, N-3=1 constraint needed per mode.
+    # Same mode set as kappa4cv; virtual angle stubs pending Issue I (#153).
     modes = {
         "bisecting": ConstraintSet(
             [BisectConstraint("komega", "ttheta")],
@@ -992,6 +1012,23 @@ def kappa4ch(
         "fixed_kphi": ConstraintSet(
             [SampleConstraint("kphi", 0.0)],
             computed=["komega", "kappa", "ttheta"],
+        ),
+        "constant_omega": ConstraintSet(
+            [SampleConstraint("omega", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "constant_chi": ConstraintSet(
+            [SampleConstraint("chi", 90.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "constant_phi": ConstraintSet(
+            [SampleConstraint("phi", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+        ),
+        "psi_constant": ConstraintSet(
+            [ReferenceConstraint("psi", 0.0)],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+            extras={"n_hat": REQUIRED, "psi": None},
         ),
     }
     return AdHocDiffractometer(

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -33,6 +33,7 @@ from ad_hoc_diffractometer import compute_forward
 from ad_hoc_diffractometer import fivec
 from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import kappa4ch
 from ad_hoc_diffractometer import kappa4cv
 from ad_hoc_diffractometer import psic
 from ad_hoc_diffractometer import sixc
@@ -282,6 +283,73 @@ def test_kappa4cv_bisecting_round_trip():
     g = _setup_cubic(kappa4cv, a=4.0)
     assert g.mode_name == "bisecting"
     assert _round_trip_ok(g, 0, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# Issue #151 — kappa4cv and kappa4ch: mode counts, stubs, fixed_kphi
+# ---------------------------------------------------------------------------
+
+_KAPPA4_ALL_MODES = {
+    "bisecting",
+    "fixed_kphi",
+    "constant_omega",
+    "constant_chi",
+    "constant_phi",
+    "psi_constant",
+}
+_KAPPA4_STUB_MODES = {"constant_omega", "constant_chi", "constant_phi", "psi_constant"}
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_has_all_six_modes(factory):
+    """kappa4cv and kappa4ch both expose all 6 declared modes."""
+    assert set(factory().modes.keys()) == _KAPPA4_ALL_MODES
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [pytest.param(kappa4cv, m, id=f"kappa4cv-{m}") for m in sorted(_KAPPA4_STUB_MODES)]
+    + [
+        pytest.param(kappa4ch, m, id=f"kappa4ch-{m}")
+        for m in sorted(_KAPPA4_STUB_MODES)
+    ],
+)
+def test_kappa4_stub_not_implemented(factory, mode_name):
+    """Virtual-angle stubs raise NotImplementedError on forward()."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    assert not g.modes[mode_name].is_implemented(g)
+    with pytest.raises(NotImplementedError):
+        g.forward(0, 1, 0)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_fixed_kphi_round_trip(factory):
+    """fixed_kphi (real stage) is implemented and round-trips correctly."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = "fixed_kphi"
+    assert g.modes["fixed_kphi"].is_implemented(g)
+    assert _round_trip_ok(g, 0, 1, 0)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_fixed_kphi_value_in_solution(factory):
+    """fixed_kphi: kphi=0 in all solutions."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = "fixed_kphi"
+    solutions = g.forward(0, 1, 0)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol["kphi"] == pytest.approx(0.0, abs=1e-8)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -48,6 +48,8 @@ from ad_hoc_diffractometer import Stage
 from ad_hoc_diffractometer import fivec
 from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
+from ad_hoc_diffractometer import kappa4ch
+from ad_hoc_diffractometer import kappa4cv
 from ad_hoc_diffractometer import s2d2
 from ad_hoc_diffractometer import sixc
 from ad_hoc_diffractometer import zaxis
@@ -1838,3 +1840,152 @@ def test_zaxis_s2d2_modes_round_trip(factory, expected_modes):
     g2 = AdHocDiffractometer.from_dict(d)
     assert set(g2.modes.keys()) == expected_modes
     assert g2.mode_name is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #151 — kappa4cv and kappa4ch mode structure
+# ---------------------------------------------------------------------------
+
+_KAPPA4_MODES = {
+    "bisecting",
+    "fixed_kphi",
+    "constant_omega",
+    "constant_chi",
+    "constant_phi",
+    "psi_constant",
+}
+
+_KAPPA4_IMPLEMENTED = {"bisecting", "fixed_kphi"}
+_KAPPA4_STUBS = _KAPPA4_MODES - _KAPPA4_IMPLEMENTED
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_factory_mode_names(factory):
+    """kappa4cv and kappa4ch expose exactly the 6 declared mode names."""
+    assert set(factory().modes.keys()) == _KAPPA4_MODES
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_free_dof(factory):
+    """kappa4cv and kappa4ch have free_dof_after_bragg == 1."""
+    assert factory().free_dof_after_bragg == 1
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_default_mode(factory):
+    """Default mode for kappa4cv and kappa4ch is 'bisecting'."""
+    assert factory().mode_name == "bisecting"
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_implemented",
+    [
+        pytest.param(kappa4cv, m, True, id=f"kappa4cv-{m}-impl")
+        for m in sorted(_KAPPA4_IMPLEMENTED)
+    ]
+    + [
+        pytest.param(kappa4cv, m, False, id=f"kappa4cv-{m}-stub")
+        for m in sorted(_KAPPA4_STUBS)
+    ]
+    + [
+        pytest.param(kappa4ch, m, True, id=f"kappa4ch-{m}-impl")
+        for m in sorted(_KAPPA4_IMPLEMENTED)
+    ]
+    + [
+        pytest.param(kappa4ch, m, False, id=f"kappa4ch-{m}-stub")
+        for m in sorted(_KAPPA4_STUBS)
+    ],
+)
+def test_kappa4_mode_is_implemented(factory, mode_name, expected_implemented):
+    """Implemented modes return True; virtual-angle stubs return False."""
+    g = factory()
+    assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_has_bisect",
+    [
+        pytest.param(kappa4cv, "bisecting", True, id="kappa4cv-bisecting-has-bisect"),
+        pytest.param(kappa4cv, "fixed_kphi", False, id="kappa4cv-fixed_kphi-no-bisect"),
+        pytest.param(
+            kappa4cv, "constant_omega", False, id="kappa4cv-constant_omega-no-bisect"
+        ),
+        pytest.param(
+            kappa4cv, "psi_constant", False, id="kappa4cv-psi_constant-no-bisect"
+        ),
+    ],
+)
+def test_kappa4_mode_has_bisect(factory, mode_name, expected_has_bisect):
+    """BisectConstraint presence matches expected for kappa4cv modes."""
+    assert factory().modes[mode_name].has_bisect == expected_has_bisect
+
+
+@pytest.mark.parametrize(
+    "mode_name, extras_key, expected_value",
+    [
+        pytest.param("psi_constant", "n_hat", "REQUIRED", id="psi_constant-n_hat"),
+        pytest.param("psi_constant", "psi", None, id="psi_constant-psi-output"),
+    ],
+)
+def test_kappa4_psi_constant_extras(mode_name, extras_key, expected_value):
+    """psi_constant carries REQUIRED n_hat and None psi output extras."""
+    for g in (kappa4cv(), kappa4ch()):
+        actual = g.modes[mode_name].extras.get(extras_key)
+        if expected_value == "REQUIRED":
+            assert actual is REQUIRED
+        else:
+            assert actual is expected_value
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, expected_computed",
+    [
+        pytest.param(
+            kappa4cv,
+            "bisecting",
+            ["komega", "kappa", "kphi", "ttheta"],
+            id="kappa4cv-bisecting",
+        ),
+        pytest.param(
+            kappa4cv,
+            "fixed_kphi",
+            ["komega", "kappa", "ttheta"],
+            id="kappa4cv-fixed_kphi",
+        ),
+        pytest.param(
+            kappa4cv,
+            "constant_chi",
+            ["komega", "kappa", "kphi", "ttheta"],
+            id="kappa4cv-constant_chi",
+        ),
+    ],
+)
+def test_kappa4_computed_stages(factory, mode_name, expected_computed):
+    """computed field lists the correct stage names."""
+    assert factory().modes[mode_name].computed == expected_computed
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+)
+def test_kappa4_modes_round_trip(factory):
+    """Full to_dict / from_dict round-trip preserves all 6 modes."""
+    import json
+
+    g = factory()
+    d = g.to_dict()
+    assert json.dumps(d)
+    assert set(d["modes"].keys()) == _KAPPA4_MODES
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == _KAPPA4_MODES
+    assert g2.mode_name == "bisecting"


### PR DESCRIPTION
## Summary

- Adds 6 diffraction modes to both `kappa4cv` and `kappa4ch` (N−3=1 constraint each)
- `bisecting` and `fixed_kphi` are implemented; the four virtual-angle stubs require kappa inversion (Issue I / #153)
- Updates `kappa4cv.md` and `kappa4ch.md` with full mode tables, virtual Eulerian angle explanation, and correct cross-reference roles

| Mode | Status |
|---|---|
| `bisecting` | ✓ implemented (approximate — true bisect requires #153) |
| `fixed_kphi` | ✓ implemented (real stage, no inversion needed) |
| `constant_omega`, `constant_chi`, `constant_phi` | stub — requires #153 |
| `psi_constant` | stub — requires #153 + #157 |

- closes #151

Contributed by: OpenCode (argo/claudesonnet46)