### PR TITLE
feat: kappa6c diffraction modes; fix references.md links (#152)

### DIFF
--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -3,7 +3,7 @@
 
 Six-circle kappa diffractometer with psic-style outer axes (mu, nu). The inner sample axes (komega, kappa, and kphi) replace the Eulerian chi circle. Lateral detector, vertical scattering plane.
 
-**Coordinate basis:** You (1999) (`BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
+**Coordinate basis:** You (1999) ({data}`~ad_hoc_diffractometer.factories.BASIS_YOU`): vertical=+x, longitudinal=+y, lateral=+z.
 
 ## Quick start
 
@@ -17,8 +17,8 @@ print(g.summary())
 
 ## Pre-built geometry definition
 
-This geometry is defined by the {func}`~ad_hoc_diffractometer.kappa6c` factory
-function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L794) for the complete stage
+This geometry is defined by the {func}`~ad_hoc_diffractometer.factories.kappa6c` factory
+function — see the [source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/factories.py#L1049) for the complete stage
 and mode configuration.
 
 ## Stage layout
@@ -39,40 +39,142 @@ and mode configuration.
 | ``nu`` | +vertical (+x) | right-handed |
 | ``delta`` | −lateral (−z) | left-handed |
 
+**Virtual Eulerian angles** (computed from komega, kappa, kphi via Walko 2016 eq. [16]):
+omega, chi, phi.  Used in stub mode descriptions; kappa inversion required (Issue I / #153).
+
+**Bisect pairs:**
+
+- Vertical: komega (lateral) ↔ delta (lateral) → `komega = delta/2`
+- Horizontal: mu (vertical) ↔ nu (vertical) → `mu = nu/2`
+
 ## Diffraction modes
 
-Set the active mode with `g.mode_name = "<mode>"`. Preset any fixed-stage angles with `g.set_angle(name, value)` before calling `forward()`. See {doc}`../howto/modes` for usage details and {class}`~ad_hoc_diffractometer.mode.DiffractionMode` for the base class.
+Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 3 constraints
+(N − 3 = 3 for N = 6 DOF).
+See {doc}`../howto/modes` for usage and {doc}`../howto/constraints` for
+changing constraint values at run time.
 
-### `bisecting`
+### `bisecting_vertical` *(default)*
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.BisectingMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L227))
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`komega = delta/2`, `mu = 0`, `nu = 0`.
+Vertical scattering plane (psic-style).
 
-`komega` is constrained to `delta` / 2, placing the sample symmetrically between the incident and diffracted beams (the bisecting condition).
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
 
-Additional stages frozen at their current angles: `mu` = current angle, `nu` = current angle.
+### `bisecting_horizontal`
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`mu = nu/2`, `komega = 0`, `delta = 0`.
+Horizontal scattering plane.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
 
 ### `fixed_kphi`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`kphi` held at declared value (default 0°), `mu = 0`, `nu = 0`.
 
-Holds `kphi` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("kphi", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | komega, kappa, delta |
+| **Constant during** `forward()` | kphi, mu = 0, nu = 0 |
 
 ### `fixed_mu`
 
-**Class:** {class}`~ad_hoc_diffractometer.mode.FixedAngleMode` ([source](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/src/ad_hoc_diffractometer/mode.py#L156))
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`mu` held at declared value (default 0°), `komega = delta/2`, `nu = 0`.
 
-Holds `mu` fixed at its **current angle** during `forward()`. Preset the angle with `g.set_angle("mu", value)` before calling `forward()`.
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | mu, nu = 0 |
 
+### `fixed_nu`
+
+{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`nu` held at declared value (default 0°), `komega = delta/2`, `mu = 0`.
+Analogous to psic `fixed_nu`.
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | nu, mu = 0 |
+
+### `fixed_delta`
+
+{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`delta` held at declared value (default 0°), `mu = nu/2`, `komega = 0`.
+Horizontal plane with delta frozen.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | delta, komega = 0 |
+
+### `lifting_detector_mu` *(stub)*
+
+Out-of-plane mode — requires the qaz pseudo-angle solver (not yet implemented).
+
+| | |
+|---|---|
+| **Computed** | mu, nu, delta |
+| **Constant during** `forward()` | mu, komega |
+
+### `lifting_detector_kphi` *(stub)*
+
+Out-of-plane mode — requires the qaz pseudo-angle solver (not yet implemented).
+
+| | |
+|---|---|
+| **Computed** | kphi, nu, delta |
+| **Constant during** `forward()` | kphi, mu |
+
+### `psi_constant_vertical` *(stub)*
+
+Vertical bisecting with azimuthal angle ψ of n̂ about Q fixed.
+Requires reference vector infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
+
+### `psi_constant_horizontal` *(stub)*
+
+Horizontal bisecting with azimuthal angle ψ of n̂ about Q fixed.
+Symmetric with `psi_constant_vertical` in the horizontal plane.
+Requires reference vector infrastructure (Issue J / #157).
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
 
 ## API reference
 
-- {func}`~ad_hoc_diffractometer.kappa6c`
+- {func}`~ad_hoc_diffractometer.factories.kappa6c`
 - {class}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer`
-- {class}`~ad_hoc_diffractometer.mode.DiffractionMode`
-- {class}`~ad_hoc_diffractometer.mode.BisectingMode`
-- {class}`~ad_hoc_diffractometer.mode.FixedAngleMode`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+- {class}`~ad_hoc_diffractometer.mode.BisectConstraint`
+- {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
+- {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
+- {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`
+- {class}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {class}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 
 ## References
 
 - ITC Vol. C §2.2.6 (2006). DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
-- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016).
+- You, *J. Appl. Cryst.* **32**, 614–623 (1999). DOI: [10.1107/S0021889899001223](https://doi.org/10.1107/S0021889899001223)
+- Walko, *Ref. Module Mater. Sci. Mater. Eng.* (2016), eq. [16].

--- a/docs/source/references.md
+++ b/docs/source/references.md
@@ -16,10 +16,10 @@ Geometries, algorithms, and conventions are traced to their primary sources.
 
   Foundational reference for the four-circle geometry, B matrix, U matrix,
   and UB matrix.  Defines the orientation refinement least-squares procedure.
-  Used by: {func}`~ad_hoc_diffractometer.fourcv`,
-  {func}`~ad_hoc_diffractometer.fourch`,
-  {func}`~ad_hoc_diffractometer.kappa4cv`,
-  {func}`~ad_hoc_diffractometer.kappa4ch`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.fourcv`,
+  {func}`~ad_hoc_diffractometer.factories.fourch`,
+  {func}`~ad_hoc_diffractometer.factories.kappa4cv`,
+  {func}`~ad_hoc_diffractometer.factories.kappa4ch`.
 
 **Bloch (1985)**
 : J.M. Bloch.
@@ -29,7 +29,7 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1107/S0021889885009858](https://doi.org/10.1107/S0021889885009858)
 
   Defines the Z-axis diffractometer geometry.
-  Used by: {func}`~ad_hoc_diffractometer.zaxis`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.zaxis`.
 
 **Vlieg et al. (1987)**
 : E. Vlieg, A.E.M.J. Fischer, J.F. van der Veen, B.N. Dev, and G. Materlik.
@@ -38,7 +38,7 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1107/S0021889887087266](https://doi.org/10.1107/S0021889887087266)
 
   Defines the five-circle geometry.
-  Used by: {func}`~ad_hoc_diffractometer.fivec`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.fivec`.
 
 **Lohmeier & Vlieg (1993)**
 : M. Lohmeier and E. Vlieg.
@@ -47,7 +47,7 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1107/S0021889893006198](https://doi.org/10.1107/S0021889893006198)
 
   Defines the six-circle surface diffractometer geometry.
-  Used by: {func}`~ad_hoc_diffractometer.sixc`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.sixc`.
 
 **Evans-Lutterodt & Tang (1995)**
 : K.W. Evans-Lutterodt and M.-T. Tang.
@@ -56,7 +56,7 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1107/S0021889895001063](https://doi.org/10.1107/S0021889895001063)
 
   Defines the S2D2 (2+2) diffractometer geometry.
-  Used by: {func}`~ad_hoc_diffractometer.s2d2`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.s2d2`.
 
 **You (1999)**
 : H. You.
@@ -66,8 +66,8 @@ Geometries, algorithms, and conventions are traced to their primary sources.
 
   Defines the psic (4S+2D) six-circle geometry; axis sign conventions
   (mixed handedness); ψ angle definitions (eqs. 10–11).
-  Used by: {func}`~ad_hoc_diffractometer.psic`,
-  {func}`~ad_hoc_diffractometer.kappa6c`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.psic`,
+  {func}`~ad_hoc_diffractometer.factories.kappa6c`.
 
 **ITC Vol. C §2.2.6 (2006)**
 : International Tables for Crystallography, Volume C, Section 2.2.6.
@@ -75,9 +75,9 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1107/97809553602060000577](https://doi.org/10.1107/97809553602060000577)
 
   Confirms the kappa 50° tilt convention and normal-beam equatorial geometry.
-  Used by: {func}`~ad_hoc_diffractometer.kappa4cv`,
-  {func}`~ad_hoc_diffractometer.kappa4ch`,
-  {func}`~ad_hoc_diffractometer.kappa6c`.
+  Used by: {func}`~ad_hoc_diffractometer.factories.kappa4cv`,
+  {func}`~ad_hoc_diffractometer.factories.kappa4ch`,
+  {func}`~ad_hoc_diffractometer.factories.kappa6c`.
 
 **Walko (2016)**
 : D.A. Walko.
@@ -102,8 +102,8 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   - $h^2/(2m_n) = 81.804\,210\,235\,2\,\text{meV·Å}^2$ — from CODATA 2022
     neutron mass $m_n$.
 
-  See {data}`~ad_hoc_diffractometer.HC_KEV_ANGSTROM` and
-  {data}`~ad_hoc_diffractometer.NEUTRON_MEV_ANGSTROM2`.
+  See {data}`~ad_hoc_diffractometer.radiation.HC_KEV_ANGSTROM` and
+  {data}`~ad_hoc_diffractometer.radiation.NEUTRON_MEV_ANGSTROM2`.
 
 ---
 
@@ -116,7 +116,7 @@ Geometries, algorithms, and conventions are traced to their primary sources.
   DOI: [10.1093/comjnl/7.4.308](https://doi.org/10.1093/comjnl/7.4.308)
 
   Derivative-free simplex optimisation algorithm used by
-  {func}`~ad_hoc_diffractometer.refine_lattice_simplex`.
+  {func}`~ad_hoc_diffractometer.refinement.refine_lattice_simplex`.
 
 ---
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -1094,16 +1094,27 @@ def kappa6c(
         Stage("delta", -LATERAL, parent="nu", role="detector"),
     ]
     # kappa6c: 6 DOF, N-3=3 constraints needed per mode.
-    # komega is named as the bisect sample stage; the kappa inversion solver
-    # (Issue I) will correct operation to virtual Eulerian space.
+    # Vertical bisect pair: komega(lateral) <-> delta(lateral) => komega = delta/2
+    #   (approximates virtual omega_euler = delta/2; corrected by Issue I / #153)
+    # Horizontal bisect pair: mu(vertical) <-> nu(vertical) => mu = nu/2
+    # Virtual Eulerian angles (omega, chi, phi) via Walko (2016) eq. [16].
     modes = {
-        "bisecting": ConstraintSet(
+        # ── Implemented (generic solver) ────────────────────────────────────
+        "bisecting_vertical": ConstraintSet(
             [
                 BisectConstraint("komega", "delta"),
                 SampleConstraint("mu", 0.0),
                 DetectorConstraint("nu", 0.0),
             ],
             computed=["komega", "kappa", "kphi", "delta"],
+        ),
+        "bisecting_horizontal": ConstraintSet(
+            [
+                BisectConstraint("mu", "nu"),
+                SampleConstraint("komega", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "kappa", "kphi", "nu"],
         ),
         "fixed_kphi": ConstraintSet(
             [
@@ -1121,6 +1132,57 @@ def kappa6c(
             ],
             computed=["komega", "kappa", "kphi", "delta"],
         ),
+        "fixed_nu": ConstraintSet(
+            [
+                DetectorConstraint("nu", 0.0),
+                BisectConstraint("komega", "delta"),
+                SampleConstraint("mu", 0.0),
+            ],
+            computed=["komega", "kappa", "kphi", "delta"],
+        ),
+        "fixed_delta": ConstraintSet(
+            [
+                DetectorConstraint("delta", 0.0),
+                BisectConstraint("mu", "nu"),
+                SampleConstraint("komega", 0.0),
+            ],
+            computed=["mu", "kappa", "kphi", "nu"],
+        ),
+        # ── Stubs: solver not yet implemented ───────────────────────────────
+        "lifting_detector_mu": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                SampleConstraint("komega", 0.0),
+                DetectorConstraint("qaz", 90.0),
+            ],
+            computed=["mu", "nu", "delta"],
+        ),
+        "lifting_detector_kphi": ConstraintSet(
+            [
+                SampleConstraint("kphi", 0.0),
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("qaz", 90.0),
+            ],
+            computed=["kphi", "nu", "delta"],
+        ),
+        "psi_constant_vertical": ConstraintSet(
+            [
+                BisectConstraint("komega", "delta"),
+                SampleConstraint("mu", 0.0),
+                ReferenceConstraint("psi", 0.0),
+            ],
+            computed=["komega", "kappa", "kphi", "delta"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "psi_constant_horizontal": ConstraintSet(
+            [
+                BisectConstraint("mu", "nu"),
+                SampleConstraint("komega", 0.0),
+                ReferenceConstraint("psi", 0.0),
+            ],
+            computed=["mu", "kappa", "kphi", "nu"],
+            extras={"n_hat": REQUIRED, "psi": None},
+        ),
     }
     return AdHocDiffractometer(
         name=inspect.currentframe().f_code.co_name,
@@ -1133,7 +1195,7 @@ def kappa6c(
         ),
         kappa_alpha_deg=alpha_deg,
         modes=modes,
-        default_mode="bisecting",
+        default_mode="bisecting_vertical",
     )
 
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -35,6 +35,7 @@ from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import kappa4ch
 from ad_hoc_diffractometer import kappa4cv
+from ad_hoc_diffractometer import kappa6c
 from ad_hoc_diffractometer import psic
 from ad_hoc_diffractometer import sixc
 from ad_hoc_diffractometer import ub_identity
@@ -1447,3 +1448,86 @@ def test_psic_modes_serialisation_round_trip():
     g2 = AdHocDiffractometer.from_dict(d)
     assert set(g2.modes.keys()) == _PSIC_MODES_ALL
     assert g2.mode_name == "bisecting_vertical"
+
+
+# ---------------------------------------------------------------------------
+# Issue #152 — kappa6c: implemented modes round-trip; stubs raise
+# ---------------------------------------------------------------------------
+
+_KAPPA6C_ALL_MODES = {
+    "bisecting_vertical",
+    "bisecting_horizontal",
+    "fixed_kphi",
+    "fixed_mu",
+    "fixed_nu",
+    "fixed_delta",
+    "lifting_detector_mu",
+    "lifting_detector_kphi",
+    "psi_constant_vertical",
+    "psi_constant_horizontal",
+}
+_KAPPA6C_STUB_MODES = {
+    "lifting_detector_mu",
+    "lifting_detector_kphi",
+    "psi_constant_vertical",
+    "psi_constant_horizontal",
+}
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l",
+    [
+        pytest.param("bisecting_vertical", 1, 0, 0, id="bisecting_vertical-100"),
+        pytest.param("bisecting_vertical", 0, 1, 0, id="bisecting_vertical-010"),
+        pytest.param("bisecting_horizontal", 1, 0, 0, id="bisecting_horizontal-100"),
+        pytest.param("bisecting_horizontal", 0, 0, 1, id="bisecting_horizontal-001"),
+        pytest.param("fixed_kphi", 0, 1, 0, id="fixed_kphi-010"),
+        pytest.param("fixed_kphi", 1, 0, 0, id="fixed_kphi-100"),
+        pytest.param("fixed_mu", 1, 0, 0, id="fixed_mu-100"),
+        pytest.param("fixed_mu", 0, 1, 0, id="fixed_mu-010"),
+        pytest.param("fixed_nu", 1, 0, 0, id="fixed_nu-100"),
+        pytest.param("fixed_nu", 0, 1, 0, id="fixed_nu-010"),
+        pytest.param("fixed_delta", 1, 0, 0, id="fixed_delta-100"),
+        pytest.param("fixed_delta", 0, 0, 1, id="fixed_delta-001"),
+    ],
+)
+def test_kappa6c_mode_round_trip(mode_name, h, k, l):  # noqa: E741
+    """Implemented kappa6c modes solve and round-trip correctly."""
+    g = _setup_cubic(kappa6c, a=4.0)
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [pytest.param(m, id=m) for m in sorted(_KAPPA6C_STUB_MODES)],
+)
+def test_kappa6c_stub_not_implemented(mode_name):
+    """kappa6c stub modes raise NotImplementedError on forward()."""
+    g = _setup_cubic(kappa6c, a=4.0)
+    g.mode_name = mode_name
+    with pytest.raises(NotImplementedError):
+        g.forward(1, 0, 0)
+
+
+def test_kappa6c_bisecting_vertical_invariants():
+    """bisecting_vertical: komega=delta/2, mu=0, nu=0 in all solutions."""
+    g = _setup_cubic(kappa6c, a=4.0)
+    solutions = g.forward(1, 0, 0)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol["komega"] == pytest.approx(sol["delta"] / 2.0, abs=1e-10)
+        assert sol["mu"] == pytest.approx(0.0, abs=1e-8)
+        assert sol["nu"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_kappa6c_bisecting_horizontal_invariants():
+    """bisecting_horizontal: mu=nu/2, komega=0, delta=0 in all solutions."""
+    g = _setup_cubic(kappa6c, a=4.0)
+    g.mode_name = "bisecting_horizontal"
+    solutions = g.forward(1, 0, 0)
+    assert len(solutions) > 0
+    for sol in solutions:
+        assert sol["mu"] == pytest.approx(sol["nu"] / 2.0, abs=1e-10)
+        assert sol["komega"] == pytest.approx(0.0, abs=1e-8)
+        assert sol["delta"] == pytest.approx(0.0, abs=1e-8)

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -50,6 +50,7 @@ from ad_hoc_diffractometer import fourch
 from ad_hoc_diffractometer import fourcv
 from ad_hoc_diffractometer import kappa4ch
 from ad_hoc_diffractometer import kappa4cv
+from ad_hoc_diffractometer import kappa6c
 from ad_hoc_diffractometer import s2d2
 from ad_hoc_diffractometer import sixc
 from ad_hoc_diffractometer import zaxis
@@ -1989,3 +1990,135 @@ def test_kappa4_modes_round_trip(factory):
     g2 = AdHocDiffractometer.from_dict(d)
     assert set(g2.modes.keys()) == _KAPPA4_MODES
     assert g2.mode_name == "bisecting"
+
+
+# ---------------------------------------------------------------------------
+# Issue #152 — kappa6c mode structure
+# ---------------------------------------------------------------------------
+
+_KAPPA6C_MODES = {
+    "bisecting_vertical",
+    "bisecting_horizontal",
+    "fixed_kphi",
+    "fixed_mu",
+    "fixed_nu",
+    "fixed_delta",
+    "lifting_detector_mu",
+    "lifting_detector_kphi",
+    "psi_constant_vertical",
+    "psi_constant_horizontal",
+}
+
+_KAPPA6C_IMPLEMENTED = {
+    "bisecting_vertical",
+    "bisecting_horizontal",
+    "fixed_kphi",
+    "fixed_mu",
+    "fixed_nu",
+    "fixed_delta",
+}
+_KAPPA6C_STUBS = (
+    _KAPPA6C_MODES - _KAPPA6C_IMPLEMENTED
+)  # psi_constant_*, lifting_detector_*
+
+
+def test_kappa6c_factory_mode_names():
+    """kappa6c exposes exactly the 7 declared mode names."""
+    assert set(kappa6c().modes.keys()) == _KAPPA6C_MODES
+
+
+def test_kappa6c_free_dof():
+    """kappa6c has free_dof_after_bragg == 3."""
+    assert kappa6c().free_dof_after_bragg == 3
+
+
+def test_kappa6c_default_mode():
+    """Default mode for kappa6c is 'bisecting_vertical'."""
+    assert kappa6c().mode_name == "bisecting_vertical"
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_implemented",
+    [pytest.param(m, True, id=f"{m}-impl") for m in sorted(_KAPPA6C_IMPLEMENTED)]
+    + [pytest.param(m, False, id=f"{m}-stub") for m in sorted(_KAPPA6C_STUBS)],
+)
+def test_kappa6c_mode_is_implemented(mode_name, expected_implemented):
+    """Implemented modes return True; stubs return False."""
+    g = kappa6c()
+    assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_has_bisect",
+    [
+        pytest.param("bisecting_vertical", True, id="bisecting_vertical-has-bisect"),
+        pytest.param(
+            "bisecting_horizontal", True, id="bisecting_horizontal-has-bisect"
+        ),
+        pytest.param("fixed_kphi", False, id="fixed_kphi-no-bisect"),
+        pytest.param("fixed_mu", True, id="fixed_mu-has-bisect"),
+        pytest.param("fixed_nu", True, id="fixed_nu-has-bisect"),
+        pytest.param("fixed_delta", True, id="fixed_delta-has-bisect"),
+        pytest.param("lifting_detector_mu", False, id="lifting_detector_mu-no-bisect"),
+        pytest.param(
+            "psi_constant_vertical", True, id="psi_constant_vertical-has-bisect"
+        ),
+        pytest.param(
+            "psi_constant_horizontal", True, id="psi_constant_horizontal-has-bisect"
+        ),
+    ],
+)
+def test_kappa6c_mode_has_bisect(mode_name, expected_has_bisect):
+    """BisectConstraint presence matches expected."""
+    assert kappa6c().modes[mode_name].has_bisect == expected_has_bisect
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [
+        pytest.param("psi_constant_vertical", id="psi_constant_vertical"),
+        pytest.param("psi_constant_horizontal", id="psi_constant_horizontal"),
+    ],
+)
+def test_kappa6c_psi_constant_extras(mode_name):
+    """Both psi_constant modes carry REQUIRED n_hat and None psi output."""
+    cs = kappa6c().modes[mode_name]
+    assert cs.extras.get("n_hat") is REQUIRED
+    assert cs.extras.get("psi") is None
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_computed",
+    [
+        pytest.param(
+            "bisecting_vertical",
+            ["komega", "kappa", "kphi", "delta"],
+            id="bisecting_vertical",
+        ),
+        pytest.param(
+            "bisecting_horizontal",
+            ["mu", "kappa", "kphi", "nu"],
+            id="bisecting_horizontal",
+        ),
+        pytest.param("fixed_kphi", ["komega", "kappa", "delta"], id="fixed_kphi"),
+        pytest.param("fixed_mu", ["komega", "kappa", "kphi", "delta"], id="fixed_mu"),
+        pytest.param("fixed_nu", ["komega", "kappa", "kphi", "delta"], id="fixed_nu"),
+        pytest.param("fixed_delta", ["mu", "kappa", "kphi", "nu"], id="fixed_delta"),
+    ],
+)
+def test_kappa6c_computed_stages(mode_name, expected_computed):
+    """computed field lists the correct stage names."""
+    assert kappa6c().modes[mode_name].computed == expected_computed
+
+
+def test_kappa6c_modes_round_trip():
+    """Full to_dict / from_dict round-trip preserves all 7 kappa6c modes."""
+    import json
+
+    g = kappa6c()
+    d = g.to_dict()
+    assert json.dumps(d)
+    assert set(d["modes"].keys()) == _KAPPA6C_MODES
+    g2 = AdHocDiffractometer.from_dict(d)
+    assert set(g2.modes.keys()) == _KAPPA6C_MODES
+    assert g2.mode_name == "bisecting_vertical"


### PR DESCRIPTION
## Summary

- Adds 10 diffraction modes to `kappa6c` (N−3=3 constraints each)
- 6 implemented by the generic solver; 4 stubs pending kappa inversion (#153) and/or reference infrastructure (#157)
- Adds `fixed_nu` and `fixed_delta` modes (discovered feasible during implementation — analogous to psic `fixed_nu`)
- Adds `psi_constant_horizontal` (symmetric with `psi_constant_vertical`, per discussion)
- Renames `"bisecting"` → `"bisecting_vertical"` for naming consistency
- Fixes `docs/source/references.md`: all 13 API cross-references updated to full module paths so autoapi HTML links resolve correctly
- Updates `kappa6c.md` with all 10 modes

- closes #152

Contributed by: OpenCode (argo/claudesonnet46)