### PR TITLE
feat: kappa virtual-angle dispatcher; constant_omega/chi/phi now implemented (#174)

### DIFF
--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -74,17 +74,32 @@ changing constraint values at run time.
 | **Computed** | komega, kappa, ttheta |
 | **Constant during** `forward()` | kphi |
 
-### `constant_omega` *(stub)*
+### `constant_omega`
 
-Fix virtual Eulerian omega (default 0°). Requires Issue I / #153.
+Fix virtual Eulerian omega at declared value (default 0°) — see {doc}`kappa4cv` for details.
 
-### `constant_chi` *(stub)*
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | omega (virtual) |
 
-Fix virtual Eulerian chi (default 90°). Requires Issue I / #153.
+### `constant_chi`
 
-### `constant_phi` *(stub)*
+Fix virtual Eulerian chi at declared value (default 90°).
 
-Fix virtual Eulerian phi (default 0°). Requires Issue I / #153.
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | chi (virtual) |
+
+### `constant_phi`
+
+Fix virtual Eulerian phi at declared value (default 0°).
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Constant during** `forward()` | phi (virtual) |
 
 ### `psi_constant` *(stub)*
 

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -74,33 +74,34 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | komega, kappa, ttheta |
 | **Constant during** `forward()` | kphi |
 
-### `constant_omega` *(stub)*
+### `constant_omega`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian omega at declared value (default 0°).
-Requires kappa inversion solver (Issue I / #153).
+Uses the kappa Newton-Raphson solver — the caller chooses the value by
+constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
 | | |
 |---|---|
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | omega (virtual) |
 
-### `constant_chi` *(stub)*
+### `constant_chi`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian chi at declared value (default 90°).
-Requires kappa inversion solver (Issue I / #153).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
 | | |
 |---|---|
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | chi (virtual) |
 
-### `constant_phi` *(stub)*
+### `constant_phi`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian phi at declared value (default 0°).
-Requires kappa inversion solver (Issue I / #153).
+The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 
 | | |
 |---|---|

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -219,6 +219,10 @@ def _solve_constraint_set(
     if mode.has_bisect:
         return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
 
+    # Virtual kappa angle mode (omega, chi, phi on a kappa geometry).
+    if _is_kappa_virtual_mode(geometry, mode):
+        return _solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode)
+
     # Fixed-angle only (no bisect).
     return _solve_fixed_sample(geometry, Q_phi, ttheta_deg, mode)
 
@@ -562,6 +566,133 @@ def _solve_two_angles(
         a2 = float(x[1]) if not _one_dimensional else start_2  # pragma: no cover
         return (a1, a2)  # pragma: no cover
     return None  # pragma: no cover
+
+
+def _is_kappa_virtual_mode(
+    geometry: AdHocDiffractometer,
+    mode,
+) -> bool:
+    """
+    Return True when the mode contains a virtual Eulerian angle constraint
+    (omega, chi, or phi) on a kappa geometry.
+
+    Delegates to :func:`~kappa.is_kappa_virtual_mode`.
+    """
+    from .kappa import is_kappa_virtual_mode
+
+    return is_kappa_virtual_mode(geometry, mode)
+
+
+def _solve_kappa_virtual(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Kappa virtual-angle solver.
+
+    Delegates the geometric computation to :func:`~kappa.solve_kappa_virtual`,
+    then applies cut-points, limits, and deduplication.
+    """
+    from .kappa import solve_kappa_virtual
+    from .mode import DetectorConstraint
+    from .mode import SampleConstraint
+
+    # Get (komega, kappa, kphi, det_name, ttheta, other_constraints) raw tuples
+    raw = solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode)
+    if not raw:  # pragma: no cover
+        return []
+
+    from .kappa import KAPPA_VIRTUAL_ANGLES
+    from .kappa import kappa_to_eulerian
+
+    # Extract non-virtual other constraints for applying to angles dict
+    other_constraints = [
+        c
+        for c in mode.constraints
+        if not (isinstance(c, SampleConstraint) and c.name in KAPPA_VIRTUAL_ANGLES)
+    ]
+
+    # Identify kappa stage names for virtual angle validation
+    sample_stages = geometry.sample_stages
+    kappa_idx = next(
+        (i for i, s in enumerate(sample_stages) if s.name == "kappa"), None
+    )
+    komega_name = sample_stages[kappa_idx - 1].name if kappa_idx else None
+    kphi_name = sample_stages[kappa_idx + 1].name if kappa_idx else None
+    alpha_deg = geometry.kappa_alpha_deg
+
+    # Virtual angle constraints that must be verified
+    virtual_constraints = [
+        c
+        for c in mode.constraints
+        if isinstance(c, SampleConstraint) and c.name in KAPPA_VIRTUAL_ANGLES
+    ]
+
+    solutions = []
+    for angle_dict in raw:
+        angles = dict(angle_dict)
+
+        # Apply non-virtual constraints (e.g. DetectorConstraint on kappa6c modes)
+        for c in other_constraints:
+            if isinstance(c, SampleConstraint):  # pragma: no cover
+                if c.name in geometry._stages:  # noqa: SLF001
+                    angles[c.name] = float(c.value)
+            elif isinstance(c, DetectorConstraint) and not c.is_qaz:  # pragma: no cover
+                angles[c.name] = c.value
+
+        # Normalise kappa angles to (-180, 180] to satisfy typical stage limits
+        if komega_name and kphi_name:  # pragma: no branch
+            for kname in (komega_name, "kappa", kphi_name):
+                if kname in angles:  # pragma: no branch
+                    a = angles[kname]
+                    a = (a + 180.0) % 360.0 - 180.0
+                    angles[kname] = a
+
+        # Validate virtual angle constraints using kappa_to_eulerian
+        if (
+            virtual_constraints and komega_name and kphi_name and alpha_deg is not None
+        ):  # pragma: no branch
+            try:
+                om_v, chi_v, phi_v = kappa_to_eulerian(
+                    angles[komega_name],
+                    angles["kappa"],
+                    angles[kphi_name],
+                    alpha_deg=alpha_deg,
+                )
+                virtual_vals = {"omega": om_v, "chi": chi_v, "phi": phi_v}
+                valid = all(
+                    abs(virtual_vals[c.name] - float(c.value)) < 1e-2
+                    for c in virtual_constraints
+                )
+                if not valid:
+                    continue
+            except (ValueError, KeyError):  # pragma: no cover
+                continue
+
+        # Verify geometric consistency: Q_computed must match Q_target
+        from .orientation import angles_to_phi_vector as _a2phi
+
+        Q_computed = _a2phi(geometry, **angles)
+        if not np.allclose(Q_computed, Q_phi, atol=1e-3):
+            continue
+
+        _apply_cut_points(angles, mode, geometry)
+        if not _check_limits(geometry, angles):
+            continue  # pragma: no cover
+
+        duplicate = False
+        for existing in solutions:
+            if all(
+                abs(existing.get(kk, 0) - angles.get(kk, 0)) < 1e-4 for kk in angles
+            ):
+                duplicate = True
+                break
+        if not duplicate:
+            solutions.append(angles)
+
+    return solutions
 
 
 def _solve_fixed_sample(

--- a/src/ad_hoc_diffractometer/kappa.py
+++ b/src/ad_hoc_diffractometer/kappa.py
@@ -46,6 +46,13 @@ References
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .geometry import AdHocDiffractometer
+
+#: Virtual Eulerian pseudoangle names on kappa geometries.
+KAPPA_VIRTUAL_ANGLES: frozenset[str] = frozenset({"omega", "chi", "phi"})
 
 
 def kappa_to_eulerian(
@@ -204,3 +211,273 @@ def eulerian_to_kappa(
     kphi = phi + offset
 
     return komega, kappa, kphi
+
+
+# ---------------------------------------------------------------------------
+# Kappa virtual-angle mode detection and solving
+# ---------------------------------------------------------------------------
+
+
+def is_kappa_virtual_mode(
+    geometry: AdHocDiffractometer,
+    mode,
+) -> bool:
+    """
+    Return True when *mode* contains a virtual Eulerian angle constraint
+    (omega, chi, or phi) and *geometry* is a kappa diffractometer.
+
+    Used by :func:`~forward._solve_constraint_set` to detect when the
+    kappa virtual-angle solver should be dispatched.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    mode : ConstraintSet
+
+    Returns
+    -------
+    bool
+    """
+    from .mode import SampleConstraint
+
+    if geometry.kappa_alpha_deg is None:
+        return False
+    stage_names = {s.name for s in geometry._stages.values()}  # noqa: SLF001
+    if "kappa" not in stage_names:
+        return False
+    return any(
+        isinstance(c, SampleConstraint) and c.name in KAPPA_VIRTUAL_ANGLES
+        for c in mode.constraints
+    )
+
+
+def solve_kappa_virtual(
+    geometry: AdHocDiffractometer,
+    Q_phi,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Solve a kappa virtual-angle mode: find real kappa motor angles satisfying
+    the virtual Eulerian angle constraints and the Bragg condition.
+
+    The solver works in virtual Eulerian space by using the sample rotation
+    Newton-Raphson numeric solver (2D free virtual angles):
+
+    1. Reads the fixed virtual Eulerian angles (omega, chi, phi) from the mode.
+    2. Applies fixed-angle rotations to reduce Q to the remaining free-angle
+       subspace, then decomposes to find the free angles.
+    3. Converts each Eulerian solution to real kappa motor angles via
+       :func:`eulerian_to_kappa` (both branches ±1).
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        A kappa geometry with ``kappa_alpha_deg`` set.
+    Q_phi : array-like, shape (3,)
+        Scattering vector in the phi frame (Å⁻¹).
+    ttheta_deg : float
+        Detector angle (2θ) in degrees.
+    mode : ConstraintSet
+        Must contain at least one ``SampleConstraint`` naming a virtual
+        Eulerian angle.
+
+    Returns
+    -------
+    list of dict[str, float]
+        One angles dict per solution, keyed by real stage names.
+        Cut-points, limits, and deduplication are applied by the caller
+        (:func:`~forward._solve_kappa_virtual`).
+    """
+    import numpy as np
+
+    from .mode import SampleConstraint
+
+    alpha_deg = geometry.kappa_alpha_deg
+    sample_stages = geometry.sample_stages
+    stage_names = [s.name for s in sample_stages]
+
+    # Locate komega, kappa, kphi by position relative to the "kappa" stage
+    kappa_idx = next(
+        (i for i, s in enumerate(sample_stages) if s.name == "kappa"), None
+    )
+    if (
+        kappa_idx is None or kappa_idx == 0 or kappa_idx >= len(stage_names) - 1
+    ):  # pragma: no cover
+        return []
+
+    komega_name = stage_names[kappa_idx - 1]
+    kphi_name = stage_names[kappa_idx + 1]
+    det_stage = geometry.detector_stages[-1]
+
+    # The kappa stage (middle) acts as the virtual chi axis in the Newton solver
+    chi_stage_eq = sample_stages[kappa_idx]  # kappa ↔ virtual chi
+
+    # Extract fixed virtual angle values from mode constraints
+    fixed_virtual: dict[str, float] = {}
+    for c in mode.constraints:
+        if (
+            isinstance(c, SampleConstraint) and c.name in KAPPA_VIRTUAL_ANGLES
+        ):  # pragma: no branch
+            fixed_virtual[c.name] = float(c.value)
+
+    Q_phi_arr = np.asarray(Q_phi, dtype=float)
+    Q_mag = float(np.linalg.norm(Q_phi_arr))
+    if Q_mag < 1e-14:  # pragma: no cover
+        return []
+    Q_hat = Q_phi_arr / Q_mag
+
+    fixed_omega = fixed_virtual.get("omega")
+    fixed_chi = fixed_virtual.get("chi")
+    fixed_phi = fixed_virtual.get("phi")
+
+    # Strategy: parameterise the problem in terms of the two free virtual angles,
+    # then use a numeric Newton-Raphson to find (chi_e, phi_e) [or whichever two are
+    # free] such that the scattering condition is satisfied.
+    #
+    # For a given set of virtual Eulerian angles (omega_e, chi_e, phi_e), the real
+    # kappa angles are determined by eulerian_to_kappa.  The scattering condition
+    # is:  angles_to_phi_vector(geometry, komega=ko, kappa=k, kphi=kp, ttheta=tt)
+    #      == Q_phi_target
+    #
+    # This is 3 equations in 2 unknowns (the two free virtual angles), but the
+    # system is consistent when a solution exists.  We solve the 2D sub-system
+    # (2 of the 3 components) and verify the third.
+
+    from .orientation import angles_to_phi_vector as _a2phi
+
+    def _newton_solve(x0: np.ndarray, branch: int = +1) -> np.ndarray | None:
+        """Newton-Raphson solver for the 2D free virtual angle problem."""
+        x = x0.copy()
+        h = 1e-4
+        for _ in range(60):
+            r = _q_residual_branch(x, branch)
+            rn = float(np.linalg.norm(r[:2]))  # use first 2 components
+            if rn < 1e-10:
+                return x
+            # Finite-difference Jacobian (2×2 from 3×2)
+            J = np.zeros((2, 2))
+            for j in range(2):
+                xph = x.copy()
+                xph[j] += h
+                rph = _q_residual_branch(xph, branch)
+                J[:, j] = (rph[:2] - r[:2]) / h
+            try:
+                dx = np.linalg.solve(J, -r[:2])
+            except np.linalg.LinAlgError:
+                return None
+            x = x + np.clip(dx, -30.0, 30.0)
+        r = _q_residual_branch(x, branch)
+        return x if float(np.linalg.norm(r)) < 1e-6 else None
+
+    def _q_residual_branch(free_vals: np.ndarray, branch: int) -> np.ndarray:
+        if fixed_omega is not None:
+            omega_e, chi_e, phi_e = fixed_omega, free_vals[0], free_vals[1]
+        elif fixed_chi is not None:
+            omega_e, chi_e, phi_e = free_vals[0], fixed_chi, free_vals[1]
+        else:
+            omega_e, chi_e, phi_e = free_vals[0], free_vals[1], fixed_phi
+        try:
+            ko, k, kp = eulerian_to_kappa(
+                omega_e, chi_e, phi_e, alpha_deg=alpha_deg, branch=branch
+            )
+        except ValueError:  # pragma: no cover
+            return np.array([1e6, 1e6, 1e6])
+        trial = {s.name: s.angle for s in list(geometry._stages.values())}  # noqa: SLF001
+        trial[komega_name] = ko
+        trial["kappa"] = k
+        trial[kphi_name] = kp
+        trial[det_stage.name] = ttheta_deg
+        return _a2phi(geometry, **trial) - Q_phi_arr
+
+    # Build seed points from Q geometry — chi_abs is a natural seed
+    chi_ax = np.asarray(chi_stage_eq.axis, dtype=float)
+    chi_ax /= np.linalg.norm(chi_ax)
+    q_along_chi = float(np.clip(np.dot(Q_hat, chi_ax), -1.0, 1.0))
+    chi_abs = math.degrees(math.asin(abs(q_along_chi)))
+
+    if fixed_omega is not None:
+        seeds = [
+            np.array([chi_abs, 0.0]),
+            np.array([-chi_abs, 0.0]),
+            np.array([chi_abs, 90.0]),
+            np.array([-chi_abs, 90.0]),
+            np.array([chi_abs, 180.0]),
+            np.array([-chi_abs, 180.0]),
+            np.array([chi_abs, 270.0]),
+            np.array([-chi_abs, 270.0]),
+            np.array([0.0, 0.0]),
+            np.array([0.0, 90.0]),
+        ]
+    elif fixed_chi is not None:
+        seeds = [
+            np.array([0.0, 0.0]),
+            np.array([0.0, 90.0]),
+            np.array([0.0, 180.0]),
+            np.array([0.0, 270.0]),
+            np.array([30.0, 0.0]),
+            np.array([-30.0, 0.0]),
+            np.array([60.0, 45.0]),
+        ]
+    else:  # fixed_phi — (omega, chi) are free
+        seeds = []
+        for o_s in range(-180, 180, 20):
+            for c_s in [-chi_abs, 0.0, chi_abs, 45.0, 90.0, -45.0, -90.0]:
+                seeds.append(np.array([float(o_s), float(c_s)]))
+
+    solutions_eulerian: list[tuple[float, float, float]] = []
+    seen: list[np.ndarray] = []
+
+    for branch in (+1, -1):
+        for seed in seeds:
+            sol = _newton_solve(seed, branch)
+            if sol is None:
+                continue
+            # Check residual
+            r = _q_residual_branch(sol, branch)
+            if float(np.linalg.norm(r)) > 1e-6:
+                continue
+            # Reconstruct full virtual angles
+            if fixed_omega is not None:
+                omega_e, chi_e, phi_e = fixed_omega, float(sol[0]), float(sol[1])
+            elif fixed_chi is not None:
+                omega_e, chi_e, phi_e = float(sol[0]), fixed_chi, float(sol[1])
+            else:
+                omega_e, chi_e, phi_e = float(sol[0]), float(sol[1]), fixed_phi
+            # Deduplicate
+            is_dup = any(
+                abs(omega_e - float(s[0])) < 1e-3
+                and abs(chi_e - float(s[1])) < 1e-3
+                and abs(phi_e - float(s[2])) < 1e-3
+                for s in seen
+            )
+            if not is_dup:
+                seen.append(np.array([omega_e, chi_e, phi_e]))
+                solutions_eulerian.append((omega_e, chi_e, phi_e))
+
+    if not solutions_eulerian:  # pragma: no cover
+        return []
+
+    # Build the baseline angles dict
+    base_angles: dict[str, float] = {
+        s.name: s.angle
+        for s in list(geometry._stages.values())  # noqa: SLF001
+    }
+    base_angles[det_stage.name] = ttheta_deg
+
+    results: list[dict[str, float]] = []
+    for omega_e, chi_e, phi_e in solutions_eulerian:
+        for branch in (+1, -1):
+            try:
+                ko, k, kp = eulerian_to_kappa(
+                    omega_e, chi_e, phi_e, alpha_deg=alpha_deg, branch=branch
+                )
+            except ValueError:  # pragma: no cover
+                continue
+            angles = dict(base_angles)
+            angles[komega_name] = ko
+            angles["kappa"] = k
+            angles[kphi_name] = kp
+            results.append(angles)
+
+    return results

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -445,14 +445,23 @@ class SampleConstraint:
 
     def is_implemented(self, geometry: AdHocDiffractometer) -> bool:
         """
-        Return True when the named stage exists in the geometry.
+        Return True when the named stage exists in the geometry, or when the
+        name is a virtual Eulerian kappa pseudoangle on a kappa geometry.
 
-        Virtual kappa angles (``"omega"``, ``"chi"``, ``"phi"`` on kappa
-        geometries) are not yet implemented — the kappa inversion solver
-        is a separate issue.
+        Virtual kappa angles ``"omega"``, ``"chi"``, and ``"phi"`` are
+        implemented when the geometry has a ``kappa_alpha_deg`` attribute set
+        (i.e. it is a kappa diffractometer) and contains a stage named
+        ``"kappa"``.  The kappa inversion solver (:func:`~kappa.eulerian_to_kappa`)
+        converts the virtual angle constraint to real kappa motor angles.
         """
         stage_names = {s.name for s in geometry._stages.values()}  # noqa: SLF001
-        return self._name in stage_names
+        if self._name in stage_names:
+            return True
+        # Virtual Eulerian pseudoangles on kappa geometries
+        _KAPPA_VIRTUAL = {"omega", "chi", "phi"}
+        if self._name in _KAPPA_VIRTUAL:
+            return geometry.kappa_alpha_deg is not None and "kappa" in stage_names
+        return False
 
     def to_dict(self) -> dict:
         """Return a JSON-serialisable dict."""

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -298,7 +298,7 @@ _KAPPA4_ALL_MODES = {
     "constant_phi",
     "psi_constant",
 }
-_KAPPA4_STUB_MODES = {"constant_omega", "constant_chi", "constant_phi", "psi_constant"}
+_KAPPA4_STUB_MODES = {"psi_constant"}
 
 
 @pytest.mark.parametrize(
@@ -351,6 +351,74 @@ def test_kappa4_fixed_kphi_value_in_solution(factory):
     assert len(solutions) > 0
     for sol in solutions:
         assert sol["kphi"] == pytest.approx(0.0, abs=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Issue #174 — kappa4cv/kappa4ch virtual-angle modes now implemented
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        # kappa4cv (BL basis: lateral=x, longitudinal=y, vertical=z)
+        pytest.param(kappa4cv, "constant_omega", 0, 1, 0, id="kappa4cv-constant_omega"),
+        pytest.param(kappa4cv, "constant_chi", 0, 0, 1, id="kappa4cv-constant_chi"),
+        pytest.param(kappa4cv, "constant_phi", 0, 1, 0, id="kappa4cv-constant_phi"),
+        # kappa4ch (horizontal scattering plane — different reachable reflections)
+        pytest.param(kappa4ch, "constant_omega", 0, 0, 1, id="kappa4ch-constant_omega"),
+        pytest.param(kappa4ch, "constant_chi", 0, 0, 1, id="kappa4ch-constant_chi"),
+        pytest.param(kappa4ch, "constant_phi", 0, 1, 0, id="kappa4ch-constant_phi"),
+    ],
+)
+def test_kappa4_virtual_angle_round_trip(factory, mode_name, h, k, l):  # noqa: E741
+    """Virtual Eulerian angle modes on kappa4cv/kappa4ch round-trip correctly."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    assert g.modes[mode_name].is_implemented(g)
+    # Newton-Raphson converges to ~1e-6; use looser tolerance for these modes
+    assert _round_trip_ok(g, h, k, l, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, virtual_angle, expected_value, h, k, l",
+    [
+        pytest.param(
+            kappa4cv, "constant_omega", "omega", 0.0, 0, 1, 0, id="kappa4cv-omega=0"
+        ),
+        pytest.param(
+            kappa4cv, "constant_chi", "chi", 90.0, 0, 0, 1, id="kappa4cv-chi=90"
+        ),
+        pytest.param(
+            kappa4cv, "constant_phi", "phi", 0.0, 0, 1, 0, id="kappa4cv-phi=0"
+        ),
+    ],
+)
+def test_kappa4_virtual_angle_constraint_satisfied(
+    factory,
+    mode_name,
+    virtual_angle,
+    expected_value,
+    h,
+    k,
+    l,  # noqa: E741
+):
+    """Virtual angle constraint is satisfied in all returned solutions."""
+    from ad_hoc_diffractometer import kappa_to_eulerian
+
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        o, c, p = kappa_to_eulerian(
+            sol["komega"],
+            sol["kappa"],
+            sol["kphi"],
+            alpha_deg=g.kappa_alpha_deg,
+        )
+        virtual_vals = {"omega": o, "chi": c, "phi": p}
+        assert virtual_vals[virtual_angle] == pytest.approx(expected_value, abs=1e-4)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kappa.py
+++ b/tests/test_kappa.py
@@ -357,3 +357,97 @@ def test_default_alpha_inverse():
     k2 = eulerian_to_kappa(10.0, 45.0, 5.0, alpha_deg=50.0)
     for v1, v2 in zip(k1, k2, strict=False):
         assert v1 == pytest.approx(v2)
+
+
+# ---------------------------------------------------------------------------
+# Issue #174 — kappa virtual-angle mode helpers and coverage
+# ---------------------------------------------------------------------------
+
+
+def test_is_kappa_virtual_mode_no_kappa_alpha():
+    """is_kappa_virtual_mode returns False when geometry has no kappa_alpha_deg."""
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.kappa import is_kappa_virtual_mode
+
+    g = ahd.fourcv()  # no kappa_alpha_deg
+    mode = ConstraintSet([SampleConstraint("omega", 0.0)])
+    assert is_kappa_virtual_mode(g, mode) is False
+
+
+def test_is_kappa_virtual_mode_kappa_alpha_but_no_kappa_stage():
+    """is_kappa_virtual_mode returns False when kappa_alpha_deg is set but no 'kappa' stage."""
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.kappa import is_kappa_virtual_mode
+
+    g = ahd.fourcv()
+    g._kappa_alpha_deg = 50.0  # noqa: SLF001  — set kappa_alpha_deg manually
+    mode = ConstraintSet([SampleConstraint("omega", 0.0)])
+    # Has kappa_alpha_deg but no stage named "kappa" → False (line 247)
+    assert is_kappa_virtual_mode(g, mode) is False
+
+
+def test_is_kappa_virtual_mode_no_virtual_constraint():
+    """is_kappa_virtual_mode returns False when mode has no virtual angle."""
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.kappa import is_kappa_virtual_mode
+
+    g = ahd.kappa4cv()
+    # fixed_kphi uses real stage name — not virtual
+    mode = ConstraintSet([SampleConstraint("kphi", 0.0)])
+    assert is_kappa_virtual_mode(g, mode) is False
+
+
+def test_solve_kappa_virtual_no_kappa_stage_returns_empty():
+    """solve_kappa_virtual returns [] when geometry has no kappa stage."""
+    import math
+
+    import numpy as np
+
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.kappa import solve_kappa_virtual
+
+    # Build a fake geometry with no "kappa" stage
+    g = ahd.fourcv()
+    g.wavelength = 1.5406
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ahd.ub_identity(g.sample)
+    # Override kappa_alpha_deg to non-None so the function proceeds
+    g._kappa_alpha_deg = 50.0  # noqa: SLF001
+
+    mode = ConstraintSet([SampleConstraint("omega", 0.0)])
+    Q_phi = g.sample.UB @ np.array([0.0, 1.0, 0.0])
+    ttheta = 2 * math.degrees(
+        math.asin(float(np.linalg.norm(Q_phi)) * g.wavelength / (4 * math.pi))
+    )
+    result = solve_kappa_virtual(g, Q_phi, ttheta, mode)
+    # No "kappa" stage found → returns []
+    assert result == []
+
+
+def test_sample_constraint_is_implemented_kappa_geometry():
+    """SampleConstraint with virtual name returns True on kappa geometry."""
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import SampleConstraint
+
+    g = ahd.kappa4cv()
+    for vname in ("omega", "chi", "phi"):
+        assert SampleConstraint(vname, 0.0).is_implemented(g) is True
+
+
+def test_sample_constraint_is_implemented_virtual_on_non_kappa():
+    """Virtual kappa names not in a non-kappa geometry return False if not real stages."""
+    import ad_hoc_diffractometer as ahd
+    from ad_hoc_diffractometer import SampleConstraint
+
+    # psic has mu, eta, chi, phi — 'omega' is NOT a real stage, and psic
+    # has no kappa_alpha_deg, so SampleConstraint('omega') returns False.
+    g = ahd.psic()
+    assert SampleConstraint("omega", 0.0).is_implemented(g) is False

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1856,7 +1856,13 @@ _KAPPA4_MODES = {
     "psi_constant",
 }
 
-_KAPPA4_IMPLEMENTED = {"bisecting", "fixed_kphi"}
+_KAPPA4_IMPLEMENTED = {
+    "bisecting",
+    "fixed_kphi",
+    "constant_omega",
+    "constant_chi",
+    "constant_phi",
+}
 _KAPPA4_STUBS = _KAPPA4_MODES - _KAPPA4_IMPLEMENTED
 
 


### PR DESCRIPTION
## Summary

- Wires the kappa inversion solver (`eulerian_to_kappa`) into the forward dispatcher for `constant_omega`, `constant_chi`, and `constant_phi` modes on `kappa4cv` and `kappa4ch`
- `SampleConstraint.is_implemented()` now returns `True` for virtual Eulerian names (`omega`, `chi`, `phi`) on kappa geometries
- Newton-Raphson solver in virtual Eulerian space: finds the two free virtual angles for a given fixed virtual angle and target Q, then converts to real kappa motor angles via `eulerian_to_kappa` (both branches ±1)
- Removes *(stub)* markers from `constant_omega`, `constant_chi`, `constant_phi` in `kappa4cv.md` and `kappa4ch.md` — only `psi_constant` remains a stub (#176)

- closes #174

Contributed by: OpenCode (argo/claudesonnet46)