### PR TITLE
feat: surface diffraction forward solvers; remove (stub) from surface modes (#175)

### DIFF
--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -59,11 +59,11 @@ The caller chooses the value by constructing a
 | **Computed** | Z, nu, delta |
 | **Constant during** `forward()` | mu |
 
-### `reflectivity` *(stub)*
+### `reflectivity`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 symmetric reflection — incidence angle equals exit angle (alpha_i = beta_out).
-Set ``g.surface_normal = (h, k, l)`` to supply n̂; the forward solver is not yet implemented.
+Requires ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -87,10 +87,10 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | omega, chi, phi, delta, gamma |
 | **Constant during** `forward()` | alpha, gamma = 0 |
 
-### `fixed_alpha_zaxis` *(stub)*
+### `fixed_alpha_zaxis`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Z-axis mode with fixed incidence angle. Set ``g.surface_normal = (h, k, l)`` to supply n̂; the forward solver is not yet implemented.
+Z-axis mode with fixed incidence angle. Requires ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.
 
 | | |
 |---|---|
@@ -99,10 +99,10 @@ Z-axis mode with fixed incidence angle. Set ``g.surface_normal = (h, k, l)`` to 
 | **Extras (input)** | n̂ (surface normal) |
 | **Extras (output)** | alpha_i (incidence angle), beta_out (exit angle) |
 
-### `fixed_beta_zaxis` *(stub)*
+### `fixed_beta_zaxis`
 
 {class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Z-axis mode with fixed exit angle. Set ``g.surface_normal = (h, k, l)`` to supply n̂; the forward solver is not yet implemented.
+Z-axis mode with fixed exit angle. Requires ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.
 
 | | |
 |---|---|
@@ -111,10 +111,10 @@ Z-axis mode with fixed exit angle. Set ``g.surface_normal = (h, k, l)`` to suppl
 | **Extras (input)** | n̂ |
 | **Extras (output)** | alpha_i, beta_out |
 
-### `alpha_eq_beta_zaxis` *(stub)*
+### `alpha_eq_beta_zaxis`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2 + {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Z-axis mode, symmetric reflection (α = γ, β_in = β_out). Set ``g.surface_normal = (h, k, l)`` to supply n̂; the forward solver is not yet implemented.
+Z-axis mode, symmetric reflection (α = γ, β_in = β_out). Requires ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/zaxis.md
+++ b/docs/source/geometries/zaxis.md
@@ -45,10 +45,10 @@ and mode configuration.
 
 Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constraint
 (N − 3 = 1 for N = 4 DOF).
-All modes require ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.  The forward solver is not yet implemented.
+Requires ``g.surface_normal = (h, k, l)`` — see {doc}`../howto/surface`.
 See {doc}`../howto/constraints` for the extras dict pattern.
 
-### `zaxis` *(stub)*
+### `zaxis`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 surface normal aligned with the Z-axis; alpha directly equals the incidence
@@ -61,7 +61,7 @@ angle β_in, gamma directly equals the exit angle β_out.
 | **Extras (input)** | n̂ (surface normal) |
 | **Extras (output)** | alpha_i (= alpha), beta_out (= gamma) |
 
-### `reflectivity` *(stub)*
+### `reflectivity`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 symmetric reflection — alpha_i = beta_out (alpha = gamma).

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -223,6 +223,10 @@ def _solve_constraint_set(
     if _is_kappa_virtual_mode(geometry, mode):
         return _solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode)
 
+    # Surface diffraction mode (ReferenceConstraint with surface_normal).
+    if _is_surface_mode(geometry, mode):
+        return _solve_surface(geometry, Q_phi, ttheta_deg, mode)
+
     # Fixed-angle only (no bisect).
     return _solve_fixed_sample(geometry, Q_phi, ttheta_deg, mode)
 
@@ -693,6 +697,173 @@ def _solve_kappa_virtual(
             solutions.append(angles)
 
     return solutions
+
+
+# ---------------------------------------------------------------------------
+# Surface diffraction solvers (ReferenceConstraint modes)
+# ---------------------------------------------------------------------------
+
+
+def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """Return True when mode has a ReferenceConstraint and surface_normal is set."""
+    from .mode import ReferenceConstraint
+
+    return geometry.surface_normal is not None and any(
+        isinstance(c, ReferenceConstraint) for c in mode.constraints
+    )
+
+
+def _solve_surface(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Surface diffraction forward solver.
+
+    Supports ReferenceConstraint modes where the constraint is:
+
+    - ``"alpha_i"`` — incidence angle fixed at target value
+    - ``"beta_out"`` — exit angle fixed at target value
+    - ``"a_eq_b"`` — symmetric reflection: alpha_i = beta_out
+
+    The solver builds a baseline angles dict (applying all fixed sample/detector
+    constraints and setting the detector stage to ttheta_deg), then performs a
+    1D Newton-Raphson root-find over the remaining free stage to satisfy the
+    surface reference constraint.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+    mode : ConstraintSet
+
+    Returns
+    -------
+    list of dict[str, float]
+    """
+
+    from .mode import ReferenceConstraint
+
+    # Extract the reference constraint
+    rc = next(c for c in mode.constraints if isinstance(c, ReferenceConstraint))
+    target_name = rc.name  # "alpha_i", "beta_out", or "a_eq_b"
+    target_value = rc.value  # float or True
+
+    # Build baseline angles dict with all fixed constraints applied
+    angles: dict[str, float] = {
+        s.name: s.angle
+        for s in list(geometry._stages.values())  # noqa: SLF001
+    }
+
+    # Apply fixed sample constraints
+    for c in mode.fixed_sample_constraints:
+        if c.name in geometry._stages:  # noqa: SLF001  # pragma: no branch
+            angles[c.name] = float(c.value)
+
+    # Apply detector constraint if present
+    det_constraint = mode.detector_constraint
+    if det_constraint is not None and not det_constraint.is_qaz:
+        angles[det_constraint.name] = det_constraint.value
+
+    # Set the active detector stage to ttheta_deg
+    det_stage = geometry.detector_stages[-1]
+    angles[det_stage.name] = ttheta_deg
+
+    # Identify the one free sample stage (the one not fixed by any constraint)
+    constrained_names = set(mode.constrained_stages(geometry))
+    constrained_names.add(det_stage.name)
+    if det_constraint is not None and not det_constraint.is_qaz:
+        constrained_names.add(det_constraint.name)
+    free_sample = [s for s in geometry.sample_stages if s.name not in constrained_names]
+
+    if not free_sample:  # pragma: no cover
+        # All stages fixed — evaluate the constraint and return if satisfied
+        if _surface_residual(angles, geometry, target_name, target_value) < 1e-6:
+            _apply_cut_points(angles, mode, geometry)
+            if _check_limits(geometry, angles):
+                return [angles]
+        return []
+
+    if len(free_sample) > 1:  # pragma: no branch
+        # More than one free sample stage — use the first one (rocking stage)
+        # and leave others at current values.  This handles cases where the
+        # reference constraint only restricts one angle.
+        pass
+
+    free_stage = free_sample[0]
+
+    # 1D Newton-Raphson over the free stage angle
+    def residual(angle_val: float) -> float:
+        trial = dict(angles)
+        trial[free_stage.name] = angle_val
+        return _surface_residual(trial, geometry, target_name, target_value)
+
+    solutions = []
+    # Seed from a grid of starting values
+    lim_lo, lim_hi = free_stage.limits
+    step = max(5.0, (lim_hi - lim_lo) / 40.0)
+    seeds = list(np.arange(lim_lo + step / 2, lim_hi, step))
+
+    seen_angles: list[float] = []
+    for seed in seeds:
+        x = float(seed)
+        r0 = residual(x)
+        for _ in range(60):
+            h = 1e-4
+            dr = (residual(x + h) - residual(x - h)) / (2 * h)
+            if abs(dr) < 1e-12:
+                break
+            dx = -r0 / dr
+            dx = float(np.clip(dx, -10.0, 10.0))
+            x += dx
+            r0 = residual(x)
+            if abs(r0) < 1e-8:
+                break
+        if abs(r0) > 1e-5:
+            continue
+        # Check it's within limits
+        if not (lim_lo <= x <= lim_hi):
+            continue
+        # Deduplicate
+        if any(abs(x - xs) < 1e-3 for xs in seen_angles):
+            continue
+        seen_angles.append(x)
+        sol = dict(angles)
+        sol[free_stage.name] = x
+        _apply_cut_points(sol, mode, geometry)
+        if _check_limits(geometry, sol):  # pragma: no branch
+            solutions.append(sol)
+
+    return solutions
+
+
+def _surface_residual(
+    angles: dict[str, float],
+    geometry: AdHocDiffractometer,
+    target_name: str,
+    target_value,
+) -> float:
+    """
+    Compute the surface constraint residual for the given angles.
+
+    Returns a float residual in degrees (zero = constraint satisfied).
+    """
+    from .reference import exit_angle as _beta_out
+    from .reference import incidence_angle as _alpha_i
+
+    if target_name == "alpha_i":
+        ai = _alpha_i(geometry, angles=angles)
+        return ai - float(target_value)
+    if target_name == "beta_out":
+        bo = _beta_out(geometry, angles=angles)
+        return bo - float(target_value)
+    # a_eq_b: alpha_i = beta_out
+    ai = _alpha_i(geometry, angles=angles)
+    bo = _beta_out(geometry, angles=angles)
+    return ai - bo
 
 
 def _solve_fixed_sample(

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -709,14 +709,25 @@ class ReferenceConstraint:
 
     def is_implemented(self, geometry: AdHocDiffractometer) -> bool:
         """
-        Return False — reference constraint solvers are not yet implemented.
+        Return True when the required reference vector is set on the geometry
+        and a forward solver is available for this constraint name.
 
-        Will return True once the forward solvers for reference-constraint
-        modes are registered (Issue J).  The reference vector infrastructure
-        is available (``has_reference_vector``), but the solver that uses
-        it to compute motor angles has not been written yet.
+        Implemented constraints (surface normal / incidence / exit angle):
+
+        - ``"alpha_i"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
+        - ``"beta_out"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
+        - ``"a_eq_b"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
+
+        Not yet implemented (psi / azimuthal reference):
+
+        - ``"psi"`` — requires :attr:`~geometry.AdHocDiffractometer.azimuthal_reference`
+          and a psi-constant forward solver (Issue #176)
+        - ``"naz"`` — not yet implemented
         """
-        return False
+        if self._name in {"psi", "naz"}:
+            return False
+        # alpha_i, beta_out, a_eq_b — implemented when surface_normal is set
+        return geometry.surface_normal is not None
 
     def to_dict(self) -> dict:
         """Return a JSON-serialisable dict."""

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -34,7 +34,6 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from ad_hoc_diffractometer import OPTIONAL
-from ad_hoc_diffractometer import REFERENCE_NAMES
 from ad_hoc_diffractometer import REQUIRED
 from ad_hoc_diffractometer import AdHocDiffractometer
 from ad_hoc_diffractometer import BisectConstraint
@@ -621,12 +620,26 @@ def test_reference_constraint_to_dict_from_dict_a_eq_b():
     assert rc2 == rc
 
 
-def test_reference_constraint_is_implemented_always_false():
+@pytest.mark.parametrize(
+    "name, value, surface_normal, expected",
+    [
+        # alpha_i/beta_out/a_eq_b: implemented when surface_normal is set
+        pytest.param("alpha_i", 0.0, (0, 0, 1), True, id="alpha_i-with-sn"),
+        pytest.param("alpha_i", 0.0, None, False, id="alpha_i-no-sn"),
+        pytest.param("beta_out", 0.0, (0, 0, 1), True, id="beta_out-with-sn"),
+        pytest.param("a_eq_b", True, (0, 0, 1), True, id="a_eq_b-with-sn"),
+        pytest.param("a_eq_b", True, None, False, id="a_eq_b-no-sn"),
+        # psi/naz: never implemented (no forward solver yet)
+        pytest.param("psi", 0.0, (0, 0, 1), False, id="psi-not-implemented"),
+        pytest.param("naz", 0.0, (0, 0, 1), False, id="naz-not-implemented"),
+    ],
+)
+def test_reference_constraint_is_implemented(name, value, surface_normal, expected):
+    """ReferenceConstraint.is_implemented() reflects surface_normal presence and solver."""
     g = _psic_like()
-    for name in REFERENCE_NAMES:
-        value = True if name == "a_eq_b" else 0.0
-        rc = ReferenceConstraint(name, value)
-        assert rc.is_implemented(g) is False
+    g._surface_normal = surface_normal  # noqa: SLF001
+    rc = ReferenceConstraint(name, value)
+    assert rc.is_implemented(g) is expected
 
 
 def test_reference_constraint_evaluate_raises():
@@ -1644,12 +1657,23 @@ def test_sixc_mode_is_constraint_set(mode_name):
 @pytest.mark.parametrize(
     "mode_name, expected_implemented",
     [pytest.param(m, True, id=f"{m}-implemented") for m in _SIXC_IMPLEMENTED]
-    + [pytest.param(m, False, id=f"{m}-stub") for m in _SIXC_STUBS],
+    + [pytest.param(m, False, id=f"{m}-no-sn") for m in _SIXC_STUBS],
 )
 def test_sixc_mode_is_implemented(mode_name, expected_implemented):
-    """Implemented modes return True; zaxis stubs return False."""
+    """Implemented modes return True; surface modes return False without surface_normal."""
     g = sixc()
     assert g.modes[mode_name].is_implemented(g) == expected_implemented
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    [pytest.param(m, id=m) for m in _SIXC_STUBS],
+)
+def test_sixc_surface_mode_implemented_with_surface_normal(mode_name):
+    """sixc surface modes return is_implemented=True when surface_normal is set."""
+    g = sixc()
+    g._surface_normal = (0, 0, 1)  # noqa: SLF001
+    assert g.modes[mode_name].is_implemented(g) is True
 
 
 @pytest.mark.parametrize(
@@ -1758,14 +1782,31 @@ def test_zaxis_s2d2_free_dof(factory, expected_modes):
         pytest.param(s2d2, "reflectivity", id="s2d2-reflectivity"),
     ],
 )
-def test_zaxis_s2d2_reference_modes_are_stubs(factory, mode_name):
-    """All reference-constraint modes return is_implemented=False."""
+def test_zaxis_s2d2_reference_modes_not_implemented_without_surface_normal(
+    factory, mode_name
+):
+    """Reference modes return is_implemented=False without surface_normal."""
     g = factory()
     cs = g.modes[mode_name]
     assert isinstance(cs, ConstraintSet)
     assert len(cs) == 1
     assert cs.reference_constraint is not None
     assert cs.is_implemented(g) is False
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(zaxis, "zaxis", id="zaxis-zaxis"),
+        pytest.param(zaxis, "reflectivity", id="zaxis-reflectivity"),
+        pytest.param(s2d2, "reflectivity", id="s2d2-reflectivity"),
+    ],
+)
+def test_zaxis_s2d2_reference_modes_implemented_with_surface_normal(factory, mode_name):
+    """Reference modes return is_implemented=True when surface_normal is set."""
+    g = factory()
+    g._surface_normal = (0, 0, 1)  # noqa: SLF001
+    assert g.modes[mode_name].is_implemented(g) is True
 
 
 def test_s2d2_mu_fixed_is_implemented():

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -206,15 +206,51 @@ def test_naz_angle_vertical_normal_returns_zero():
 # ---------------------------------------------------------------------------
 
 
-def test_reference_constraint_is_implemented_always_false():
-    """ReferenceConstraint.is_implemented() always returns False — no solver yet."""
+@pytest.mark.parametrize(
+    "name, value, ref_attr, ref_value, expected",
+    [
+        # surface-normal constraints: implemented when surface_normal is set
+        pytest.param(
+            "alpha_i", 0.0, "surface_normal", (0, 0, 1), True, id="alpha_i-with-sn"
+        ),
+        pytest.param("alpha_i", 0.0, "surface_normal", None, False, id="alpha_i-no-sn"),
+        pytest.param(
+            "beta_out", 0.0, "surface_normal", (0, 0, 1), True, id="beta_out-with-sn"
+        ),
+        pytest.param(
+            "beta_out", 0.0, "surface_normal", None, False, id="beta_out-no-sn"
+        ),
+        pytest.param(
+            "a_eq_b", True, "surface_normal", (0, 0, 1), True, id="a_eq_b-with-sn"
+        ),
+        pytest.param("a_eq_b", True, "surface_normal", None, False, id="a_eq_b-no-sn"),
+        # psi/naz: not yet implemented regardless of reference vector
+        pytest.param(
+            "psi",
+            0.0,
+            "azimuthal_reference",
+            (0, 0, 1),
+            False,
+            id="psi-not-implemented",
+        ),
+        pytest.param(
+            "naz",
+            0.0,
+            "azimuthal_reference",
+            (0, 0, 1),
+            False,
+            id="naz-not-implemented",
+        ),
+    ],
+)
+def test_reference_constraint_is_implemented(
+    name, value, ref_attr, ref_value, expected
+):
+    """ReferenceConstraint.is_implemented() reflects solver availability."""
     g = _setup_psic()
-    g.surface_normal = (0, 0, 1)
-    g.azimuthal_reference = (0, 0, 1)
-    for name in ("alpha_i", "beta_out", "a_eq_b", "psi", "naz"):
-        value = True if name == "a_eq_b" else 0.0
-        rc = ReferenceConstraint(name, value)
-        assert rc.is_implemented(g) is False
+    setattr(g, ref_attr, ref_value)
+    rc = ReferenceConstraint(name, value)
+    assert rc.is_implemented(g) is expected
 
 
 @pytest.mark.parametrize(
@@ -321,3 +357,148 @@ def test_psi_constant_not_yet_solvable():
     # forward() raises because is_implemented=False
     with pytest.raises(NotImplementedError):
         g.forward(1, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Issue #175 — surface diffraction forward solvers
+# ---------------------------------------------------------------------------
+
+WAVELENGTH = 1.5406
+
+
+def _setup_surface(factory, surface_normal=(0, 0, 1)):
+    """Return a geometry with wavelength, lattice, UB, and surface_normal set."""
+    g = factory()
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ub_identity(g.sample)
+    g.surface_normal = surface_normal
+    return g
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(ahd.zaxis, "zaxis", id="zaxis-zaxis"),
+        pytest.param(ahd.zaxis, "reflectivity", id="zaxis-reflectivity"),
+        pytest.param(ahd.s2d2, "reflectivity", id="s2d2-reflectivity"),
+        pytest.param(ahd.sixc, "fixed_alpha_zaxis", id="sixc-fixed_alpha_zaxis"),
+        pytest.param(ahd.sixc, "fixed_beta_zaxis", id="sixc-fixed_beta_zaxis"),
+        pytest.param(ahd.sixc, "alpha_eq_beta_zaxis", id="sixc-alpha_eq_beta_zaxis"),
+    ],
+)
+def test_surface_mode_is_implemented_with_surface_normal(factory, mode_name):
+    """Surface reference modes return is_implemented=True when surface_normal is set."""
+    g = _setup_surface(factory)
+    assert g.modes[mode_name].is_implemented(g) is True
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(ahd.zaxis, "zaxis", id="zaxis-zaxis"),
+        pytest.param(ahd.zaxis, "reflectivity", id="zaxis-reflectivity"),
+        pytest.param(ahd.s2d2, "reflectivity", id="s2d2-reflectivity"),
+        pytest.param(ahd.sixc, "fixed_alpha_zaxis", id="sixc-fixed_alpha_zaxis"),
+        pytest.param(ahd.sixc, "fixed_beta_zaxis", id="sixc-fixed_beta_zaxis"),
+        pytest.param(ahd.sixc, "alpha_eq_beta_zaxis", id="sixc-alpha_eq_beta_zaxis"),
+    ],
+)
+def test_surface_mode_not_implemented_without_surface_normal(factory, mode_name):
+    """Surface reference modes return is_implemented=False without surface_normal."""
+    g = factory()
+    assert g.modes[mode_name].is_implemented(g) is False
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        pytest.param(ahd.zaxis, "zaxis", 0, 1, 0, id="zaxis-zaxis"),
+        pytest.param(ahd.zaxis, "reflectivity", 0, 0, 1, id="zaxis-reflectivity"),
+        pytest.param(ahd.s2d2, "reflectivity", 0, 1, 0, id="s2d2-reflectivity"),
+        pytest.param(
+            ahd.sixc, "fixed_alpha_zaxis", 0, 1, 0, id="sixc-fixed_alpha_zaxis"
+        ),
+        pytest.param(ahd.sixc, "fixed_beta_zaxis", 0, 1, 0, id="sixc-fixed_beta_zaxis"),
+        pytest.param(
+            ahd.sixc, "alpha_eq_beta_zaxis", 0, 1, 0, id="sixc-alpha_eq_beta_zaxis"
+        ),
+    ],
+)
+def test_surface_mode_returns_solutions(factory, mode_name, h, k, l):  # noqa: E741
+    """Surface modes return at least one solution when surface_normal is set."""
+    g = _setup_surface(factory)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        pytest.param(ahd.zaxis, "zaxis", 0, 1, 0, id="zaxis-zaxis-alpha_i=0"),
+        pytest.param(
+            ahd.sixc, "fixed_alpha_zaxis", 0, 1, 0, id="sixc-fixed_alpha-alpha_i=0"
+        ),
+    ],
+)
+def test_surface_alpha_i_fixed_constraint_satisfied(factory, mode_name, h, k, l):  # noqa: E741
+    """alpha_i modes: incidence angle equals declared target (0°) in all solutions."""
+    g = _setup_surface(factory)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        ai = incidence_angle(g, angles=sol)
+        assert ai == pytest.approx(0.0, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        pytest.param(
+            ahd.sixc, "fixed_beta_zaxis", 0, 1, 0, id="sixc-fixed_beta-beta_out=0"
+        ),
+    ],
+)
+def test_surface_beta_out_fixed_constraint_satisfied(factory, mode_name, h, k, l):  # noqa: E741
+    """beta_out modes: exit angle equals declared target (0°) in all solutions."""
+    g = _setup_surface(factory)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        bo = exit_angle(g, angles=sol)
+        assert bo == pytest.approx(0.0, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l",
+    [
+        pytest.param(ahd.zaxis, "reflectivity", 0, 0, 1, id="zaxis-reflectivity"),
+        pytest.param(ahd.s2d2, "reflectivity", 0, 1, 0, id="s2d2-reflectivity"),
+        pytest.param(ahd.sixc, "alpha_eq_beta_zaxis", 0, 1, 0, id="sixc-alpha_eq_beta"),
+    ],
+)
+def test_surface_a_eq_b_constraint_satisfied(factory, mode_name, h, k, l):  # noqa: E741
+    """a_eq_b modes: alpha_i ≈ beta_out in all solutions."""
+    g = _setup_surface(factory)
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0
+    for sol in solutions:
+        ai = incidence_angle(g, angles=sol)
+        bo = exit_angle(g, angles=sol)
+        assert ai == pytest.approx(bo, abs=1e-4)
+
+
+def test_surface_mode_not_implemented_raises():
+    """Surface modes without surface_normal raise NotImplementedError on forward()."""
+    g = ahd.zaxis()
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ub_identity(g.sample)
+    # No surface_normal set
+    g.mode_name = "zaxis"
+    with pytest.raises(NotImplementedError):
+        g.forward(0, 1, 0)


### PR DESCRIPTION
## Summary

- Implements forward solvers for all 6 surface diffraction reference-constraint modes via 1D Newton-Raphson over the free rocking stage
- `ReferenceConstraint.is_implemented()` now returns `True` for `alpha_i`, `beta_out`, `a_eq_b` when `geometry.surface_normal` is set; `psi` and `naz` remain `False` (#176)
- Removes *(stub)* markers from `zaxis.md`, `s2d2.md`, `sixc.md`

**Now implemented:**
- `zaxis`: `zaxis` (α_i=0), `reflectivity` (α_i=β_out)
- `s2d2`: `reflectivity` (α_i=β_out)
- `sixc`: `fixed_alpha_zaxis`, `fixed_beta_zaxis`, `alpha_eq_beta_zaxis`

- closes #175

Contributed by: OpenCode (argo/claudesonnet46)