### PR TITLE
docs: audit and update concepts and HOWTO pages for constraint redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 references/
 src/ad_hoc_diffractometer/_version.py
 docs/build/
+docs/_build/
 docs/source/autoapi/
 .coverage
 htmlcov/
@@ -20,3 +21,4 @@ build/
 .loglogin
 dev_*
 dev_*/
+.doctrees/

--- a/docs/source/concepts.md
+++ b/docs/source/concepts.md
@@ -142,15 +142,179 @@ See {doc}`howto/orient`, {doc}`howto/lattice`, {doc}`problem2`, and
 
 ## Diffraction modes
 
-A **diffraction mode** describes how `forward()` will compute the motor
-angles and which ones remain constant.  Modes fix or couple specific stages
-(e.g. bisecting: ω = 2θ/2).  Available modes depend on the geometry.
+A **diffraction mode** is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+that describes how `forward()` resolves the free degrees of freedom: which
+stages are fixed, which are coupled, and which are solved freely.
+Available modes depend on the geometry.
 
 ```python
+# Four-circle geometries use "bisecting"
+g = ahd.fourcv()
 g.mode_name = "bisecting"
+
+# Six-circle psic uses named variants
+g = ahd.psic()
+g.mode_name = "bisecting_vertical"   # vertical scattering plane
+g.mode_name = "bisecting_horizontal" # horizontal scattering plane
 ```
 
-See {doc}`howto/modes` and {mod}`~ad_hoc_diffractometer.mode`.
+Modes can also be added at run time:
+
+```python
+from ad_hoc_diffractometer import ConstraintSet, SampleConstraint
+
+g.modes["my_chi45"] = ConstraintSet([SampleConstraint("chi", 45.0)])
+g.mode_name = "my_chi45"
+```
+
+See {doc}`howto/modes`, {doc}`howto/constraints`, and
+{mod}`~ad_hoc_diffractometer.mode`.
+
+---
+
+## Diffraction constraints
+
+Specifying (h, k, l) provides exactly **3 equations** on the motor angles.
+A geometry with N real axes therefore has **N − 3 free parameters** that must
+each be resolved by a constraint.  Every mode is a
+{class}`~ad_hoc_diffractometer.mode.ConstraintSet` — an ordered list of
+constraints equal in length to N − 3.
+
+Three constraint categories exist:
+
+**Sample constraints** fix one sample motor angle at a declared value, or
+express the bisecting relational condition:
+
+```python
+from ad_hoc_diffractometer import SampleConstraint, BisectConstraint
+
+SampleConstraint("chi", 90.0)       # chi fixed at 90°
+BisectConstraint("eta", "delta")    # eta = delta / 2  (psic bisecting)
+```
+
+**Detector constraints** fix one detector stage at a declared value, or
+constrain the azimuthal angle of Q (the ``"qaz"`` pseudo-angle from You 1999
+eq. 18: ``tan(qaz) = tan(delta) / sin(nu)``):
+
+```python
+from ad_hoc_diffractometer import DetectorConstraint
+
+DetectorConstraint("nu", 0.0)       # nu fixed at 0°
+DetectorConstraint("qaz", 90.0)     # Q in the vertical plane
+```
+
+**Reference constraints** express a condition between Q and an external
+reference vector n̂ (surface normal, polarisation axis, etc.):
+
+```python
+from ad_hoc_diffractometer import ReferenceConstraint
+
+ReferenceConstraint("alpha_i", 5.0)  # incidence angle fixed
+ReferenceConstraint("a_eq_b", True)  # alpha_i = beta_out (symmetric)
+```
+
+Taxonomy rules: at most one {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`,
+at most one {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`.
+
+Two checks distinguish solver availability from prerequisite satisfaction:
+
+- `constraint.is_implemented(geometry)` — returns `True` when a forward
+  solver exists for this constraint on this geometry.
+- `rc.has_reference_vector(geometry)` — returns `True` when the required
+  n̂ vector is set on the geometry (a prerequisite for reference constraints,
+  independent of solver availability).
+
+See {doc}`howto/constraints` and {mod}`~ad_hoc_diffractometer.mode`.
+
+---
+
+## Kappa virtual angles
+
+Kappa geometries (``kappa4cv``, ``kappa4ch``, ``kappa6c``) have **real motor
+angles** (komega, kappa, kphi) and **virtual Eulerian pseudoangles** (omega,
+chi, phi) that are more intuitive to specify.
+
+The conversion follows Walko (2016) eq. [16] with a fixed tilt angle
+α₀ (default 50°):
+
+```python
+from ad_hoc_diffractometer import kappa_to_eulerian, eulerian_to_kappa
+
+# Real kappa angles → virtual Eulerian angles
+omega, chi, phi = kappa_to_eulerian(komega, kappa, kphi, alpha_deg=50.0)
+
+# Virtual Eulerian angles → real kappa angles (two branches)
+komega, kappa, kphi = eulerian_to_kappa(omega, chi, phi, alpha_deg=50.0)
+```
+
+Branch selection: the positive branch (kappa ≥ 0) corresponds to positive
+chi; the negative branch (kappa < 0) to negative chi.
+
+Kappa modes accept virtual angle names directly in
+{class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+
+```python
+from ad_hoc_diffractometer import ConstraintSet, SampleConstraint, BisectConstraint
+
+g = ahd.kappa4cv()
+# "chi" is a virtual angle — the kappa inversion solver handles it
+g.modes["fixed_chi"] = ConstraintSet([SampleConstraint("chi", 90.0)])
+```
+
+See {func}`~ad_hoc_diffractometer.kappa_to_eulerian`,
+{func}`~ad_hoc_diffractometer.eulerian_to_kappa`, and the
+{doc}`howto/constraints` guide.
+
+---
+
+## Surface geometry and reference vector
+
+Some diffraction modes and pseudo-angle functions require an external
+reference vector supplied as **Miller indices (h, k, l)**.  Two separate
+vectors may be set:
+
+- **`surface_normal`** — direction perpendicular to the sample surface;
+  used by incidence/exit angle functions and surface diffraction modes.
+- **`azimuthal_reference`** — direction defining ψ = 0; used by
+  `psi_angle` and `psi_constant_*` modes.
+
+```python
+g.surface_normal = (0, 0, 1)    # (001)-cut sample
+g.azimuthal_reference = (1, 0, 0)
+```
+
+Vectors are stored as Miller indices and converted to the lab frame
+internally via the UB matrix.
+
+See {doc}`howto/surface` and {mod}`~ad_hoc_diffractometer.reference`.
+
+---
+
+## Custom exceptions
+
+Two exceptions signal specific failure modes of the forward solver:
+
+{exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+: Raised when |Q| > 4π/λ — the requested reflection cannot be reached at
+  the current wavelength regardless of motor angles.  Carries attributes
+  `q_mag`, `q_max`, and `wavelength`.
+
+{exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
+: Raised when a solver returns a solution that violates a declared
+  constraint beyond the display-precision tolerance (indicates a solver
+  error or an unimplemented virtual-angle constraint).  Carries attributes
+  `solution_index`, `constraint_repr`, `residual`, and `tolerance`.
+
+```python
+from ad_hoc_diffractometer import EwaldSphereViolation, ConstraintViolation
+
+try:
+    solutions = g.forward(10, 10, 10)   # likely unreachable
+except EwaldSphereViolation as e:
+    print(f"|Q| = {e.q_mag:.3f} Å⁻¹ exceeds Ewald sphere (max {e.q_max:.3f} Å⁻¹)")
+```
+
+See {doc}`howto/forward` and {mod}`~ad_hoc_diffractometer.mode`.
 
 ---
 

--- a/docs/source/howto/constraints.md
+++ b/docs/source/howto/constraints.md
@@ -42,19 +42,29 @@ BisectConstraint("omega", "ttheta")    # omega = ttheta / 2
 BisectConstraint("eta", "delta")       # eta = delta / 2  (psic)
 ```
 
-**Detector constraint** — fixes one detector stage at a declared value:
+**Detector constraint** — fixes one detector stage at a declared value, or
+constrains the ``"qaz"`` pseudo-angle from You (1999) eq. 18
+(``tan(qaz) = tan(delta) / sin(nu)``):
 
 ```python
 from ad_hoc_diffractometer import DetectorConstraint
 
 DetectorConstraint("nu", 0.0)     # nu fixed at 0°
 DetectorConstraint("gamma", 0.0)  # gamma fixed at 0°
+DetectorConstraint("qaz", 90.0)   # Q confined to the vertical plane
 ```
+
+``qaz = 90°`` constrains scattering to the vertical plane;
+``qaz = 0°`` to the horizontal plane.
+This is implemented for all geometries with two or more detector stages
+(psic, kappa6c) and used by the ``lifting_detector_*`` mode family.
 
 **Reference constraint** — expresses a condition between Q and a reference
 vector n̂ (surface normal, polarisation axis, etc.).
-All reference constraints are stubs pending the reference-vector
-infrastructure (see {doc}`surface`):
+The incidence/exit-angle constraints (``alpha_i``, ``beta_out``,
+``a_eq_b``) are implemented when ``surface_normal`` is set;
+``psi`` and ``naz`` are not yet implemented as forward constraints.
+See {doc}`surface`:
 
 ```python
 from ad_hoc_diffractometer import ReferenceConstraint
@@ -69,6 +79,30 @@ at most one {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`,
 remainder must be {class}`~ad_hoc_diffractometer.mode.SampleConstraint`
 or {class}`~ad_hoc_diffractometer.mode.BisectConstraint`.
 Total must equal N − 3.
+
+## Design principles
+
+The constraint system is built on three key decisions from the #122 planning
+discussion:
+
+1. **Constraints are geometry-agnostic.**  A {class}`~ad_hoc_diffractometer.mode.ConstraintSet`
+   is defined without reference to a specific geometry; validation against
+   actual DOF count and stage names happens at solve time
+   (`is_fully_constrained(g)` and `is_implemented(g)`).
+
+2. **At most one detector constraint and at most one reference constraint.**
+   Fixing more than one detector angle over-constrains the scattered beam
+   direction.  More than one reference constraint would also over-constrain
+   the problem.  Any number of sample constraints (fixed-angle or bisect) are
+   allowed, subject to the total equalling N − 3.
+
+3. **The bisect condition is relational, not heuristic.**
+   {class}`~ad_hoc_diffractometer.mode.BisectConstraint` names both stages
+   explicitly (``sample_stage = detector_stage / 2``).  No geometric
+   heuristics are used to infer which stage is "co-axial" with which.
+
+These principles make it possible to define valid modes programmatically
+at run time without any knowledge of geometry internals.
 
 ## Use a factory-defined mode
 

--- a/docs/source/howto/forward.md
+++ b/docs/source/howto/forward.md
@@ -87,7 +87,7 @@ print(f"d = {d:.4f} Å,  2θ = {tth:.3f}°")
 Stage limits are enforced automatically by `forward()`.  To set limits:
 
 ```python
-g.stages["chi"].limits = (-10.0, 100.0)   # degrees
+g.stage("chi").limits = (-10.0, 100.0)   # degrees
 ```
 
 Solutions outside the limits are filtered out.
@@ -119,11 +119,73 @@ This is useful for identifying an unknown peak found during a scan, or
 for verifying that the diffractometer is positioned at the expected
 reflection after moving motors.
 
+## Handle errors from forward()
+
+`forward()` raises specific exceptions for distinct failure modes:
+
+### EwaldSphereViolation
+
+Raised when the requested reflection cannot be reached at the current
+wavelength — `|Q| > 4π/λ` regardless of motor angles:
+
+```python
+from ad_hoc_diffractometer import EwaldSphereViolation
+
+try:
+    solutions = g.forward(10, 10, 10)
+except EwaldSphereViolation as e:
+    print(f"|Q| = {e.q_mag:.4f} Å⁻¹")
+    print(f"Ewald sphere limit = {e.q_max:.4f} Å⁻¹  (λ = {e.wavelength} Å)")
+    print("Reduce wavelength or choose a smaller reflection.")
+```
+
+Attributes: `q_mag` (requested |Q| in Å⁻¹), `q_max` (4π/λ), `wavelength`.
+
+### ConstraintViolation
+
+Raised when the solver returns a solution that violates a declared
+constraint beyond the display-precision tolerance.  This signals either a
+solver bug or an unimplemented virtual-angle constraint:
+
+```python
+from ad_hoc_diffractometer import ConstraintViolation
+
+try:
+    solutions = g.forward(1, 0, 0)
+except ConstraintViolation as e:
+    print(f"Solution {e.solution_index} violated {e.constraint_repr}")
+    print(f"Residual = {e.residual:.2e}°  (tolerance = {e.tolerance:.2e}°)")
+```
+
+Attributes: `solution_index`, `constraint_repr`, `residual`, `tolerance`.
+
+### NotImplementedError
+
+Raised when the active mode is `None` or its `is_implemented(geometry)`
+returns `False`:
+
+```python
+g.mode_name = None
+try:
+    g.forward(1, 0, 0)
+except NotImplementedError as e:
+    print(e)
+
+g.mode_name = "psi_constant"
+try:
+    g.forward(1, 0, 0)
+except NotImplementedError as e:
+    print(e)  # describes which solver is missing
+```
+
 ## See also
 
 - {meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.forward`
 - {meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.inverse`
 - {func}`~ad_hoc_diffractometer.hkl_to_d`
 - {func}`~ad_hoc_diffractometer.hkl_to_two_theta`
+- {exc}`~ad_hoc_diffractometer.mode.EwaldSphereViolation`
+- {exc}`~ad_hoc_diffractometer.mode.ConstraintViolation`
 - {doc}`modes`
+- {doc}`constraints`
 - {doc}`orient`

--- a/docs/source/howto/orient.md
+++ b/docs/source/howto/orient.md
@@ -27,18 +27,18 @@ g.sample.lattice = ahd.Lattice(a=5.431)  # cubic silicon
 
 ```python
 # Add the primary reflection at its measured motor angles
-g.reflections.add("or1", hkl=(0, 0, 4),
-                  angles={"ttheta": 69.13, "omega": 34.56,
-                          "chi": 90.0, "phi": 0.0})
+g.sample.reflections.add("or1", hkl=(0, 0, 4),
+                          angles={"ttheta": 69.13, "omega": 34.56,
+                                  "chi": 90.0, "phi": 0.0})
 
 # Add a second reflection 90° away in phi
-g.reflections.add("or2", hkl=(2, 2, 0),
-                  angles={"ttheta": 47.30, "omega": 23.65,
-                          "chi": 35.26, "phi": 90.0})
+g.sample.reflections.add("or2", hkl=(2, 2, 0),
+                          angles={"ttheta": 47.30, "omega": 23.65,
+                                  "chi": 35.26, "phi": 90.0})
 
-# Designate which reflections to use
-g.reflections.setor0("or1")
-g.reflections.setor0("or2")
+# Designate which reflections to use for the UB calculation
+g.sample.reflections.setor0("or1")
+g.sample.reflections.setor1("or2")
 ```
 
 ## Compute UB from two reflections (Busing & Levy 1967)
@@ -70,13 +70,15 @@ For unknown lattices, UB can be determined directly from three reflections
 without prior knowledge of the unit cell:
 
 ```python
-g.reflections.add("or3", hkl=(1, 1, 3),
-                  angles={"ttheta": 56.12, "omega": 28.06,
-                          "chi": 58.0, "phi": 45.0})
+g.sample.reflections.add("or3", hkl=(1, 1, 3),
+                          angles={"ttheta": 56.12, "omega": 28.06,
+                                  "chi": 58.0, "phi": 45.0})
 
 UB = ahd.ub_from_three_reflections_bl1967(
-    g.sample, g.reflections["or1"],
-    g.reflections["or2"], g.reflections["or3"]
+    g.sample,
+    g.sample.reflections["or1"],
+    g.sample.reflections["or2"],
+    g.sample.reflections["or3"],
 )
 ```
 
@@ -97,7 +99,7 @@ Check that `UB @ h` points in the same direction as the observed Q:
 import numpy as np
 
 def direction_check(geometry, name):
-    r = geometry.reflections[name]
+    r = geometry.sample.reflections[name]
     q_phi = ahd.angles_to_phi_vector(geometry, **r.angles)
     ub_h  = geometry.sample.UB @ r.hkl
     cos_theta = np.dot(q_phi, ub_h) / (np.linalg.norm(q_phi) * np.linalg.norm(ub_h))

--- a/docs/source/howto/serialize.md
+++ b/docs/source/howto/serialize.md
@@ -117,6 +117,65 @@ sample_dict = g.sample.to_dict()
 # sample2 = Sample.from_dict(sample_dict, parent=g)  # requires parent geometry
 ```
 
+## ConstraintSet round-trip
+
+Diffraction modes ({class}`~ad_hoc_diffractometer.mode.ConstraintSet`) are
+serialised as part of the geometry dict.  They can also be inspected and
+round-tripped independently:
+
+```python
+import json
+from ad_hoc_diffractometer import ConstraintSet, BisectConstraint
+from ad_hoc_diffractometer import SampleConstraint, DetectorConstraint
+from ad_hoc_diffractometer import REQUIRED
+
+# A custom psic mode
+cs = ConstraintSet(
+    [
+        BisectConstraint("eta", "delta"),
+        SampleConstraint("mu", 0.0),
+        DetectorConstraint("nu", 0.0),
+    ],
+    computed=["eta", "chi", "phi", "delta"],
+)
+
+# Serialise
+d = cs.to_dict()
+print(json.dumps(d, indent=2))
+
+# Restore
+cs2 = ConstraintSet.from_dict(d)
+assert cs2 == cs
+
+# REQUIRED / OPTIONAL sentinels survive the round-trip
+cs_extras = ConstraintSet(
+    [BisectConstraint("eta", "delta"),
+     SampleConstraint("mu", 0.0),
+     SampleConstraint("chi", 0.0)],
+    extras={"n_hat": REQUIRED, "psi": None},
+)
+d2 = cs_extras.to_dict()
+cs_extras2 = ConstraintSet.from_dict(d2)
+from ad_hoc_diffractometer import REQUIRED as REQ
+assert cs_extras2.extras["n_hat"] is REQ  # sentinel restored
+```
+
+The geometry-level round-trip preserves all modes, the active mode name,
+and cut points:
+
+```python
+import ad_hoc_diffractometer as ahd
+
+g = ahd.psic()
+g.mode_name = "bisecting_vertical"
+
+d = g.to_dict()
+g2 = ahd.AdHocDiffractometer.from_dict(d)
+
+assert set(g2.modes.keys()) == set(g.modes.keys())
+assert g2.mode_name == "bisecting_vertical"
+```
+
 ## Typical workflow
 
 A common pattern is to save the configuration after alignment and restore


### PR DESCRIPTION
## Summary

- `concepts.md`: five new/updated sections — Diffraction Constraints (N−3 rule, three categories, `qaz`, `is_implemented` vs `has_reference_vector`), Kappa Virtual Angles, Surface Geometry / Reference Vector, Custom Exceptions (`EwaldSphereViolation`, `ConstraintViolation`); Diffraction Modes section updated with psic named variants and run-time mode addition
- `howto/constraints.md`: `DetectorConstraint` section extended with `qaz` example; new Design Principles section documenting the three key decisions from #122
- `howto/forward.md`: new error-handling section covering `EwaldSphereViolation`, `ConstraintViolation`, `NotImplementedError` with attribute listings; fix `g.stages["chi"]` → `g.stage("chi")`
- `howto/serialize.md`: new ConstraintSet round-trip section showing `to_dict`/`from_dict`, `REQUIRED`/`OPTIONAL` sentinel preservation, geometry-level mode round-trip
- `howto/orient.md`: fix `g.reflections` → `g.sample.reflections` throughout; fix `setor0` called twice → `setor0`/`setor1`

- closes #173

Contributed by: OpenCode (argo/claudesonnet46)