### PR TITLE
feat: psi_constant and double_diffraction forward solvers

### DIFF
--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -92,11 +92,13 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | chi, phi, ttheta |
 | **Constant during** `forward()` | omega |
 
-### `psi_constant` *(stub)*
+### `psi_constant`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Fix the azimuthal angle ψ of the reference vector about Q.
-Set ``g.azimuthal_reference = (h, k, l)`` — see {doc}`../howto/surface`. The forward solver is not yet implemented.
+azimuthal angle ψ validation filter.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+Returns bisecting solutions only when the natural ψ for (h,k,l) matches
+the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -105,13 +105,16 @@ the stored target.  See {doc}`../howto/surface`.
 | **Extras (input)** | n̂ (reference vector), ψ (target, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
-### `double_diffraction` *(stub)*
+### `double_diffraction`
 
-{class}`~ad_hoc_diffractometer.mode.BisectConstraint` with secondary reflection extras.
-Simultaneous diffraction condition — not yet implemented.
+Full 4D simultaneous solver: finds motor angles where both the primary
+(h₁,k₁,l₁) and secondary (h₂,k₂,l₂) reflections satisfy the Ewald
+sphere condition.  Set ``mode.extras['h2']``, ``['k2']``, ``['l2']``
+before calling ``forward()``.
 
 | | |
 |---|---|
+| **Computed** | omega, chi, phi, ttheta |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
 ## API reference

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -92,11 +92,13 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | chi, phi, ttheta |
 | **Constant during** `forward()` | omega |
 
-### `psi_constant` *(stub)*
+### `psi_constant`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Fix the azimuthal angle ψ of the reference vector about Q.
-Set ``g.azimuthal_reference = (h, k, l)`` — see {doc}`../howto/surface`. The forward solver is not yet implemented.
+azimuthal angle ψ validation filter.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+Returns bisecting solutions only when the natural ψ for (h,k,l) matches
+the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -105,13 +105,16 @@ the stored target.  See {doc}`../howto/surface`.
 | **Extras (input)** | n̂ (reference vector), ψ (target, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
-### `double_diffraction` *(stub)*
+### `double_diffraction`
 
-{class}`~ad_hoc_diffractometer.mode.BisectConstraint` with secondary reflection extras.
-Simultaneous diffraction condition — not yet implemented.
+Full 4D simultaneous solver: finds motor angles where both the primary
+(h₁,k₁,l₁) and secondary (h₂,k₂,l₂) reflections satisfy the Ewald
+sphere condition.  Set ``mode.extras['h2']``, ``['k2']``, ``['l2']``
+before calling ``forward()``.
 
 | | |
 |---|---|
+| **Computed** | omega, chi, phi, ttheta |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
 ## API reference

--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -101,10 +101,13 @@ Fix virtual Eulerian phi at declared value (default 0°).
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | phi (virtual) |
 
-### `psi_constant` *(stub)*
+### `psi_constant`
 
-Fix azimuthal angle ψ of n̂ about Q.
-Requires kappa inversion (#153) and a forward solver for psi constraints (not yet implemented).  Set ``g.azimuthal_reference = (h, k, l)`` — see {doc}`../howto/surface`.
+{class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
+azimuthal angle ψ validation filter.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+Returns bisecting solutions only when the natural ψ for (h,k,l) matches
+the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -122,6 +122,18 @@ the stored target.  See {doc}`../howto/surface`.
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
+### `double_diffraction`
+
+Full 4D simultaneous solver: finds motor angles where both the primary
+(h₁,k₁,l₁) and secondary (h₂,k₂,l₂) reflections satisfy the Ewald
+sphere condition.  Set ``mode.extras['h2']``, ``['k2']``, ``['l2']``
+before calling ``forward()``.
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, ttheta |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.factories.kappa4cv`

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -108,11 +108,13 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | phi (virtual) |
 
-### `psi_constant` *(stub)*
+### `psi_constant`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
-Fix the azimuthal angle ψ of n̂ about Q.
-Requires kappa inversion (#153) and a forward solver for psi constraints (not yet implemented).  Set ``g.azimuthal_reference = (h, k, l)`` — see {doc}`../howto/surface`.
+azimuthal angle ψ validation filter.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+Returns bisecting solutions only when the natural ψ for (h,k,l) matches
+the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -167,6 +167,28 @@ Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
+### `double_diffraction_vertical`
+
+Full 4D simultaneous solver in the vertical scattering plane: finds motor
+angles where both the primary (h₁,k₁,l₁) and secondary (h₂,k₂,l₂)
+reflections satisfy the Ewald sphere condition.
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
+### `double_diffraction_horizontal`
+
+Full 4D simultaneous solver in the horizontal scattering plane.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.factories.kappa6c`

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -140,10 +140,12 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 | **Computed** | kphi, nu, delta |
 | **Constant during** `forward()` | kphi = 0, mu = 0 |
 
-### `psi_constant_vertical` *(stub)*
+### `psi_constant_vertical`
 
-Vertical bisecting with azimuthal angle ψ of n̂ about Q fixed.
-Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; the forward solver is not yet implemented.  See {doc}`../howto/surface`.
+Vertical bisecting with azimuthal angle ψ validation.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+The solver returns bisecting solutions only when the natural ψ for the
+requested (h,k,l) matches the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|
@@ -152,11 +154,11 @@ Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; 
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
-### `psi_constant_horizontal` *(stub)*
+### `psi_constant_horizontal`
 
-Horizontal bisecting with azimuthal angle ψ of n̂ about Q fixed.
+Horizontal bisecting with azimuthal angle ψ validation.
 Symmetric with `psi_constant_vertical` in the horizontal plane.
-Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; the forward solver is not yet implemented.  See {doc}`../howto/surface`.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
 
 | | |
 |---|---|

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -113,14 +113,25 @@ Horizontal scattering plane bisecting condition (You 1999, §5.1).
 
 ### `double_diffraction_vertical`
 
-{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`
-with secondary-reflection extras.
-Bisecting solver runs; simultaneous diffraction logic not yet implemented.
+Full 4D simultaneous solver in the vertical scattering plane: finds motor
+angles where both the primary (h₁,k₁,l₁) and secondary (h₂,k₂,l₂)
+reflections satisfy the Ewald sphere condition.  Set
+``mode.extras['h2']``, ``['k2']``, ``['l2']`` before calling ``forward()``.
 
 | | |
 |---|---|
 | **Computed** | eta, chi, phi, delta |
 | **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
+### `double_diffraction_horizontal`
+
+Full 4D simultaneous solver in the horizontal scattering plane.
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0 |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
 ### `lifting_detector_mu`

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -145,10 +145,12 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 | **Computed** | phi, nu, delta |
 | **Constant during** `forward()` | phi = 0, mu = 0 |
 
-### `psi_constant_vertical` *(stub)*
+### `psi_constant_vertical`
 
-Vertical bisecting with azimuthal angle ψ of n̂ about Q fixed.
-Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; the forward solver is not yet implemented.  See {doc}`../howto/surface`.
+Vertical bisecting with azimuthal angle ψ validation.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+The solver returns bisecting solutions only when the natural ψ for the
+requested (h,k,l) matches the stored target.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|
@@ -157,10 +159,10 @@ Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; 
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
-### `psi_constant_horizontal` *(stub)*
+### `psi_constant_horizontal`
 
-Horizontal bisecting with azimuthal angle ψ fixed.
-Set ``g.azimuthal_reference = (h, k, l)`` and ``g.surface_normal = (h, k, l)``; the forward solver is not yet implemented.  See {doc}`../howto/surface`.
+Horizontal bisecting with azimuthal angle ψ validation.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
 
 | | |
 |---|---|

--- a/docs/source/howto/constraints.md
+++ b/docs/source/howto/constraints.md
@@ -219,18 +219,21 @@ print(cs.extras)
 
 Modes whose constraint patterns do not yet have a solver implementation
 return `False` from `is_implemented()` and raise `NotImplementedError`
-when `forward()` is called:
+when `forward()` is called.  Some modes require a prerequisite to be
+set on the geometry (e.g. ``azimuthal_reference`` for psi modes,
+``surface_normal`` for surface modes) — they are considered stubs until
+the prerequisite is met:
 
 ```python
 g = ahd.fourcv()
 g.mode_name = "psi_constant"
 
+# Without azimuthal_reference: not implemented
 print(g.modes["psi_constant"].is_implemented(g))  # False
 
-try:
-    g.forward(1, 0, 0)
-except NotImplementedError as e:
-    print(e)   # describes which infrastructure is missing
+# With azimuthal_reference: implemented
+g.azimuthal_reference = (0, 0, 1)
+print(g.modes["psi_constant"].is_implemented(g))  # True
 ```
 
 ## Serialisation

--- a/docs/source/howto/forward.md
+++ b/docs/source/howto/forward.md
@@ -162,7 +162,8 @@ Attributes: `solution_index`, `constraint_repr`, `residual`, `tolerance`.
 ### NotImplementedError
 
 Raised when the active mode is `None` or its `is_implemented(geometry)`
-returns `False`:
+returns `False` (e.g. a prerequisite like ``azimuthal_reference`` or
+``surface_normal`` is not set):
 
 ```python
 g.mode_name = None
@@ -171,11 +172,13 @@ try:
 except NotImplementedError as e:
     print(e)
 
+# psi_constant requires azimuthal_reference to be set
 g.mode_name = "psi_constant"
+g.azimuthal_reference = None
 try:
     g.forward(1, 0, 0)
 except NotImplementedError as e:
-    print(e)  # describes which solver is missing
+    print(e)  # describes which prerequisite is missing
 ```
 
 ## See also

--- a/docs/source/howto/modes.md
+++ b/docs/source/howto/modes.md
@@ -112,12 +112,15 @@ print(cs.is_implemented(g))
 
 ## Check if a mode is implemented
 
-Stub modes (e.g. `psi_constant`) have `is_implemented(g)` returning `False`
-and raise `NotImplementedError` when `forward()` is called:
+Some modes require a prerequisite on the geometry.  For example,
+`psi_constant` requires ``g.azimuthal_reference`` to be set:
 
 ```python
 g.mode_name = "psi_constant"
-print(g.modes["psi_constant"].is_implemented(g))  # False
+print(g.modes["psi_constant"].is_implemented(g))  # False (no azimuthal_reference)
+
+g.azimuthal_reference = (0, 0, 1)
+print(g.modes["psi_constant"].is_implemented(g))  # True
 
 # forward() raises NotImplementedError for unimplemented modes
 ```

--- a/docs/source/howto/surface.md
+++ b/docs/source/howto/surface.md
@@ -158,13 +158,12 @@ g2 = AdHocDiffractometer.from_dict(d)
 print(g2.surface_normal)          # (0.0, 0.0, 1.0)
 ```
 
-## Reference constraint modes (stubs)
+## Reference constraint modes
 
-Modes such as `psi_constant_vertical`, `zaxis`, and `reflectivity` require
-both the reference vector *and* a forward solver.  Setting `surface_normal`
-or `azimuthal_reference` satisfies the vector prerequisite (check with
-{meth}`~ad_hoc_diffractometer.mode.ReferenceConstraint.has_reference_vector`),
-but the forward solver for these modes is not yet implemented.
+Modes that use a ``ReferenceConstraint`` require the appropriate reference
+vector to be set on the geometry.  ``psi_constant_*`` modes require
+``azimuthal_reference``; surface modes (``zaxis``, ``reflectivity``) require
+``surface_normal``.
 
 ```python
 g.azimuthal_reference = (0, 0, 1)
@@ -174,10 +173,16 @@ cs = g.modes["psi_constant_vertical"]
 rc = cs.reference_constraint
 
 print(rc.has_reference_vector(g))   # True  — vector is set
-print(rc.is_implemented(g))          # False — solver not yet available
+print(rc.is_implemented(g))          # True  — solver available
 
-# forward() raises NotImplementedError until the solver is implemented
+# forward() returns bisecting solutions whose natural ψ matches the target
+solutions = g.forward(1, 0, 0)
 ```
+
+The ``psi_constant`` solver acts as a **validation filter**: ψ is a pure
+phi-frame quantity that is the same for every Bragg solution of a given
+(h,k,l) and UB.  The solver computes the natural ψ and returns solutions
+only if it matches the stored target — otherwise it returns an empty list.
 
 ## See also
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -540,14 +540,20 @@ def psic(basis: dict = _BASIS_YOU) -> AdHocDiffractometer:
         ),
         "double_diffraction_vertical": ConstraintSet(
             [
-                BisectConstraint("eta", "delta"),
                 SampleConstraint("mu", 0.0),
                 DetectorConstraint("nu", 0.0),
             ],
             computed=["eta", "chi", "phi", "delta"],
             extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
-        # ── Stubs: solver not yet implemented ───────────────────────────────
+        "double_diffraction_horizontal": ConstraintSet(
+            [
+                SampleConstraint("eta", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "chi", "phi", "nu"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
+        ),
         "lifting_detector_mu": ConstraintSet(
             [
                 SampleConstraint("mu", 0.0),
@@ -655,7 +661,7 @@ def fourcv(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
             extras={"n_hat": REQUIRED, "psi": None},
         ),
         "double_diffraction": ConstraintSet(
-            [BisectConstraint("omega", "ttheta")],
+            [],
             computed=["omega", "chi", "phi", "ttheta"],
             extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
@@ -731,7 +737,7 @@ def fourch(basis: dict = _BASIS_BL) -> AdHocDiffractometer:
             extras={"n_hat": REQUIRED, "psi": None},
         ),
         "double_diffraction": ConstraintSet(
-            [BisectConstraint("omega", "ttheta")],
+            [],
             computed=["omega", "chi", "phi", "ttheta"],
             extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
@@ -944,6 +950,11 @@ def kappa4cv(
             [ReferenceConstraint("psi", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
             extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "double_diffraction": ConstraintSet(
+            [],
+            computed=["komega", "kappa", "kphi", "ttheta"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
     }
     return AdHocDiffractometer(
@@ -1182,6 +1193,22 @@ def kappa6c(
             ],
             computed=["mu", "kappa", "kphi", "nu"],
             extras={"n_hat": REQUIRED, "psi": None},
+        ),
+        "double_diffraction_vertical": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+            ],
+            computed=["komega", "kappa", "kphi", "delta"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
+        ),
+        "double_diffraction_horizontal": ConstraintSet(
+            [
+                SampleConstraint("komega", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "kappa", "kphi", "nu"],
+            extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
     }
     return AdHocDiffractometer(

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -216,6 +216,12 @@ def _solve_constraint_set(
     Unsupported patterns fall back to the numeric solver.
     """
 
+    # Psi-constant mode (ReferenceConstraint("psi") validation filter).
+    # Must be checked FIRST: psic/kappa6c psi_constant_vertical has a
+    # BisectConstraint but needs psi validation before bisecting.
+    if _is_psi_mode(geometry, mode):
+        return _solve_psi_mode(geometry, Q_phi, ttheta_deg, mode)
+
     if mode.has_bisect:
         return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
 
@@ -704,16 +710,190 @@ def _solve_kappa_virtual(
 
 
 # ---------------------------------------------------------------------------
+# Psi-constant solver (ReferenceConstraint("psi") validation filter)
+# ---------------------------------------------------------------------------
+
+
+def _compute_natural_psi(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+) -> float | None:
+    """
+    Compute the natural azimuthal angle ψ from the phi frame only.
+
+    ψ is a pure phi-frame quantity: it depends on ``Q_phi = UB @ hkl``,
+    ``n_phi = UB @ n_hkl`` (the azimuthal reference in the phi frame),
+    and ``y_hat`` (the incident-beam direction from the geometry's basis).
+    **No motor angles are involved.**
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Must have ``sample.UB`` and ``azimuthal_reference`` set.
+    Q_phi : numpy.ndarray, shape (3,)
+        Target scattering vector in the phi frame (``UB @ hkl``).
+
+    Returns
+    -------
+    float or None
+        ψ in degrees (−180°, +180°], or ``None`` when ψ is undefined
+        (Q ∥ incident beam, or reference vector ∥ Q).
+    """
+    n_hkl = geometry.azimuthal_reference
+    if n_hkl is None:
+        return None  # pragma: no cover
+
+    n_phi = geometry.sample.UB @ np.asarray(n_hkl, dtype=float)
+    y_raw = np.asarray(
+        geometry.basis.get("longitudinal", np.array([0.0, 1.0, 0.0])),
+        dtype=float,
+    )
+    y_hat = y_raw / np.linalg.norm(y_raw)
+
+    Q_mag = float(np.linalg.norm(Q_phi))
+    if Q_mag < 1e-14:
+        return None  # pragma: no cover
+    Q_hat = Q_phi / Q_mag
+
+    # Project n and y onto the plane perpendicular to Q
+    n_perp = n_phi - np.dot(n_phi, Q_hat) * Q_hat
+    y_perp = y_hat - np.dot(y_hat, Q_hat) * Q_hat
+
+    n_perp_mag = float(np.linalg.norm(n_perp))
+    y_perp_mag = float(np.linalg.norm(y_perp))
+
+    if n_perp_mag < 1e-10 or y_perp_mag < 1e-10:
+        return None  # ψ undefined (reference ∥ Q, or Q ∥ incident beam)
+
+    n_perp_hat = n_perp / n_perp_mag
+    y_perp_hat = y_perp / y_perp_mag
+
+    cos_psi = float(np.clip(np.dot(y_perp_hat, n_perp_hat), -1.0, 1.0))
+    sin_psi = float(np.dot(Q_hat, np.cross(y_perp_hat, n_perp_hat)))
+    return math.degrees(math.atan2(sin_psi, cos_psi))
+
+
+def _is_psi_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """Return True when the mode contains a psi ReferenceConstraint and the reference is set."""
+    from .mode import ReferenceConstraint
+
+    if geometry.azimuthal_reference is None:
+        return False
+    return any(
+        isinstance(c, ReferenceConstraint) and c.name == "psi" for c in mode.constraints
+    )
+
+
+def _solve_psi_mode(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Forward solver for ``psi_constant`` modes (validation filter).
+
+    For a given (h,k,l) and UB, the azimuthal angle ψ is a pure phi-frame
+    quantity — the same for every Bragg solution.  This solver:
+
+    1. Computes the natural ψ from ``Q_phi`` (no motor angles).
+    2. Compares with ``psi_target`` from the mode's
+       :class:`~mode.ReferenceConstraint`.
+    3. If they disagree (beyond 0.1° tolerance): returns ``[]``.
+    4. If they agree: delegates to the appropriate existing solver
+       (bisecting, kappa-virtual, or synthetic bisecting) and returns
+       all solutions.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+    mode : ConstraintSet
+
+    Returns
+    -------
+    list of dict[str, float]
+    """
+    from .mode import BisectConstraint
+    from .mode import ConstraintSet
+    from .mode import ReferenceConstraint
+
+    # Extract the psi target value
+    rc = next(
+        c
+        for c in mode.constraints
+        if isinstance(c, ReferenceConstraint) and c.name == "psi"
+    )
+    psi_target = float(rc.value)
+
+    # Compute natural psi from the phi frame (motor-angle independent)
+    natural_psi = _compute_natural_psi(geometry, Q_phi)
+    if natural_psi is None:
+        return []  # ψ undefined for this reflection
+
+    # Compare natural psi with target (tolerance 0.1° — generous enough
+    # to handle float rounding, tight enough to be physically meaningful)
+    diff = abs(natural_psi - psi_target)
+    # Handle wraparound: e.g. -179.9 vs 180.1
+    if diff > 180.0:
+        diff = 360.0 - diff
+    if diff > 0.1:
+        return []  # this (h,k,l) is not accessible at the stored ψ
+
+    # ψ is satisfied — delegate to the appropriate existing solver.
+    # The psi constraint is automatically satisfied by ALL Bragg solutions.
+
+    if mode.has_bisect:
+        # psic, kappa6c: mode already has a BisectConstraint
+        return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
+
+    if _is_kappa_virtual_mode(geometry, mode):  # pragma: no cover
+        # kappa4cv, kappa4ch: kappa virtual angle mode
+        return _solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode)
+
+    # fourcv, fourch, kappa4cv, kappa4ch: no BisectConstraint in the mode.
+    # Build a synthetic bisecting mode using the geometry's natural
+    # bisect pair: first sample stage + first detector stage.
+    sample_stages = geometry.sample_stages
+    detector_stages = geometry.detector_stages
+
+    if not sample_stages or not detector_stages:
+        return []  # pragma: no cover
+
+    bisect_sample = sample_stages[0].name  # omega in fourcv/fourch
+    bisect_detector = detector_stages[-1].name  # ttheta in fourcv/fourch
+
+    # Collect any non-psi constraints from the original mode
+    other_constraints = [
+        c
+        for c in mode.constraints
+        if not (isinstance(c, ReferenceConstraint) and c.name == "psi")
+    ]
+
+    synthetic = ConstraintSet(
+        [BisectConstraint(bisect_sample, bisect_detector)] + other_constraints,
+        computed=mode.computed,
+    )
+
+    return _solve_bisecting(geometry, Q_phi, ttheta_deg, synthetic)
+
+
+# ---------------------------------------------------------------------------
 # Surface diffraction solvers (ReferenceConstraint modes)
 # ---------------------------------------------------------------------------
 
 
 def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
-    """Return True when mode has a ReferenceConstraint and surface_normal is set."""
+    """Return True when mode has a surface ReferenceConstraint and surface_normal is set.
+
+    The ``"psi"`` ReferenceConstraint is NOT a surface mode — it is handled
+    by :func:`_is_psi_mode` / :func:`_solve_psi_mode` instead.
+    """
     from .mode import ReferenceConstraint
 
     return geometry.surface_normal is not None and any(
-        isinstance(c, ReferenceConstraint) for c in mode.constraints
+        isinstance(c, ReferenceConstraint) and c.name != "psi" for c in mode.constraints
     )
 
 

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -222,6 +222,12 @@ def _solve_constraint_set(
     if _is_psi_mode(geometry, mode):
         return _solve_psi_mode(geometry, Q_phi, ttheta_deg, mode)
 
+    # Double-diffraction mode (simultaneous Bragg for two reflections).
+    # Must be checked before has_bisect: double_diffraction modes have a
+    # BisectConstraint but use a 4D solver instead of plain bisecting.
+    if _is_double_diffraction_mode(geometry, mode):
+        return _solve_double_diffraction(geometry, Q_phi, ttheta_deg, mode)
+
     if mode.has_bisect:
         return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
 
@@ -877,6 +883,231 @@ def _solve_psi_mode(
     )
 
     return _solve_bisecting(geometry, Q_phi, ttheta_deg, synthetic)
+
+
+# ---------------------------------------------------------------------------
+# Double-diffraction solver (simultaneous Bragg for two reflections)
+# ---------------------------------------------------------------------------
+
+
+def _is_double_diffraction_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """Return True when mode.extras contains h2, k2, l2 keys."""
+    extras = mode.extras
+    return extras is not None and all(k in extras for k in ("h2", "k2", "l2"))
+
+
+def _solve_double_diffraction(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Full 4D simultaneous solver for double-diffraction modes.
+
+    Finds motor angles where both the primary reflection (h₁,k₁,l₁) and a
+    secondary reflection (h₂,k₂,l₂) simultaneously satisfy the Ewald sphere
+    condition.  Matches the Hkl library's ``_double_diffraction`` function
+    (``hkl-pseudoaxis-common-hkl.c``).
+
+    Four equations, four unknowns:
+
+    1-3. Bragg condition for primary hkl₁:
+         ``Q_phi_computed - Q_phi_target = 0``  (3 components)
+    4.   Ewald sphere for secondary hkl₂:
+         ``|ki + Z @ UB @ hkl₂|² - |ki|² = 0``
+
+    where ``Z`` is the sample rotation matrix and ``ki = (2π/λ) ŷ``.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+    mode : ConstraintSet
+
+    Returns
+    -------
+    list of dict[str, float]
+
+    Raises
+    ------
+    ValueError
+        If h2, k2, l2 are not set in ``mode.extras`` (still ``REQUIRED``).
+    """
+    from .mode import REQUIRED
+    from .rotation import rotation_matrix
+
+    extras = mode.extras
+
+    # Validate that h2, k2, l2 are set to numeric values
+    hkl2_values = [extras.get("h2"), extras.get("k2"), extras.get("l2")]
+    if any(v is REQUIRED for v in hkl2_values):
+        raise ValueError(
+            "double_diffraction mode requires h2, k2, l2 to be set in "
+            "mode.extras before calling forward(). "
+            "Set them with e.g. "
+            "g.modes['double_diffraction'].extras['h2'] = 1.0"
+        )
+
+    hkl2 = np.array([float(v) for v in hkl2_values], dtype=float)
+    Q2_phi = geometry.sample.UB @ hkl2
+
+    # Incident beam: ki = (2π/λ) * longitudinal_hat
+    wavelength = geometry.wavelength
+    k_mag = 2.0 * math.pi / wavelength
+    y_raw = np.asarray(
+        geometry.basis.get("longitudinal", np.array([0.0, 1.0, 0.0])),
+        dtype=float,
+    )
+    ki = k_mag * (y_raw / np.linalg.norm(y_raw))
+    ki_sq = float(np.dot(ki, ki))
+
+    # Build baseline angles: all stages at their current positions
+    all_stages = list(geometry._stages.values())  # noqa: SLF001
+    angles_base: dict[str, float] = {s.name: s.angle for s in all_stages}
+
+    # Apply fixed sample constraints (mu=0, eta=0, etc.)
+    for sc in mode.fixed_sample_constraints:
+        if sc.name in geometry._stages:  # noqa: SLF001  # pragma: no branch
+            angles_base[sc.name] = float(sc.value)
+
+    # Apply fixed detector constraints (nu=0, delta=0, etc.)
+    det_c = mode.detector_constraint
+    if det_c is not None and not det_c.is_qaz:
+        angles_base[det_c.name] = det_c.value
+
+    # The 4 free stages are taken from the mode's ``computed`` field,
+    # which explicitly lists the writable axes.  The BisectConstraint
+    # stages ARE included (they are seeding hints, not hard constraints
+    # in the 4D solver).
+    free_names = list(mode.computed)
+
+    if len(free_names) != 4:  # pragma: no cover
+        logger.warning(
+            "double_diffraction expects 4 free stages, got %d: %s",
+            len(free_names),
+            free_names,
+        )
+        return []
+
+    # Ordered list of ALL stages (for building the sample rotation matrix Z)
+    sample_stages = geometry.sample_stages
+
+    from .orientation import angles_to_phi_vector as _a2phi
+
+    def _build_Z(angles: dict[str, float]) -> np.ndarray:
+        """Compute sample rotation matrix from angle values (no mutation)."""
+        Z = np.eye(3)
+        for s in sample_stages:
+            Z = Z @ rotation_matrix(s.axis, angles[s.name])
+        return Z
+
+    def _residual_4d(x: np.ndarray) -> np.ndarray:
+        """4-component residual: 3 Bragg + 1 Ewald sphere."""
+        trial = dict(angles_base)
+        for i, name in enumerate(free_names):
+            trial[name] = float(x[i])
+
+        # Bragg residual for primary hkl₁ (3 components)
+        Q_computed = _a2phi(geometry, **trial)
+        bragg_res = Q_computed - Q_phi
+
+        # Ewald sphere residual for secondary hkl₂
+        Z = _build_Z(trial)
+        Q2_lab = Z @ Q2_phi
+        kf2 = ki + Q2_lab
+        ewald_res = float(np.dot(kf2, kf2)) - ki_sq
+
+        return np.array([bragg_res[0], bragg_res[1], bragg_res[2], ewald_res])
+
+    def _jacobian_fd(x: np.ndarray, r0: np.ndarray, h: float = 1e-4) -> np.ndarray:
+        """Finite-difference Jacobian (4 × 4)."""
+        J = np.zeros((4, 4))
+        for i in range(4):
+            xp = x.copy()
+            xp[i] += h
+            J[:, i] = (_residual_4d(xp) - r0) / h
+        return J
+
+    # Seed from bisecting solutions + coarse grid.
+    # The bisecting solution satisfies the primary Bragg condition and is
+    # a good starting point for the Newton-Raphson solver.  We build a
+    # temporary bisecting mode from the first sample and last detector stage
+    # in the computed list, then run _solve_bisecting().
+    seeds: list[np.ndarray] = []
+
+    # Find sample and detector stages among the 4 free stages
+    sample_names = {s.name for s in geometry.sample_stages}
+    det_names = {s.name for s in geometry.detector_stages}
+    free_sample = [n for n in free_names if n in sample_names]
+    free_det = [n for n in free_names if n in det_names]
+
+    if free_sample and free_det:  # pragma: no branch
+        from .mode import BisectConstraint as _BC
+        from .mode import ConstraintSet as _CS
+
+        bisect_sample = free_sample[0]
+        bisect_det = free_det[-1]
+        other_constraints = list(mode.constraints)  # frozen stages
+        synth = _CS(
+            [_BC(bisect_sample, bisect_det)] + other_constraints,
+            computed=mode.computed,
+        )
+        try:
+            bisect_sols = _solve_bisecting(geometry, Q_phi, ttheta_deg, synth)
+            for sol in bisect_sols:
+                seeds.append(np.array([sol[n] for n in free_names], dtype=float))
+        except Exception:  # pragma: no cover
+            pass  # pragma: no cover
+
+    # Coarse grid seeds
+    half_tth = ttheta_deg / 2.0
+    for a0 in (half_tth, -half_tth, 0.0):
+        for a1 in (0.0, 45.0, 90.0, -90.0):
+            for a2 in (0.0, 90.0, 180.0, -90.0):
+                seeds.append(np.array([a0, a1, a2, ttheta_deg], dtype=float))
+
+    # Newton-Raphson over all seeds
+    found_solutions: list[dict[str, float]] = []
+    seen_keys: list[np.ndarray] = []
+
+    for seed in seeds:
+        x = seed.copy()
+        for _ in range(300):  # pragma: no branch
+            r = _residual_4d(x)
+            if np.linalg.norm(r) < 1e-9:
+                break
+            J = _jacobian_fd(x, r)
+            try:
+                dx = np.linalg.solve(J, -r)
+            except np.linalg.LinAlgError:  # pragma: no cover
+                break  # pragma: no cover
+            step = np.linalg.norm(dx)
+            if step > 30.0:
+                dx = dx * (30.0 / step)
+            x = x + dx
+
+        r = _residual_4d(x)
+        if np.linalg.norm(r) > 1e-5:  # pragma: no cover
+            continue  # pragma: no cover
+
+        # De-duplicate
+        duplicate = any(np.allclose(x, sk, atol=1e-3) for sk in seen_keys)
+        if duplicate:
+            continue
+        seen_keys.append(x.copy())
+
+        # Build solution dict
+        sol = dict(angles_base)
+        for i, name in enumerate(free_names):
+            sol[name] = float(x[i])
+
+        _apply_cut_points(sol, mode, geometry)
+        if _check_limits(geometry, sol):
+            found_solutions.append(sol)
+
+    return found_solutions
 
 
 # ---------------------------------------------------------------------------

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -711,21 +711,27 @@ class ReferenceConstraint:
         Return True when the required reference vector is set on the geometry
         and a forward solver is available for this constraint name.
 
-        Implemented constraints (surface normal / incidence / exit angle):
+        Implemented constraints:
 
         - ``"alpha_i"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
         - ``"beta_out"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
         - ``"a_eq_b"`` — requires :attr:`~geometry.AdHocDiffractometer.surface_normal`
+        - ``"psi"`` — requires :attr:`~geometry.AdHocDiffractometer.azimuthal_reference`.
+          The forward solver treats ψ as a **validation filter**: for a given
+          (h,k,l) and UB, ψ is a pure phi-frame quantity that is the same for
+          every Bragg solution.  The solver computes the natural ψ from UB and
+          the reference direction; if it matches the stored target the bisecting
+          solutions are returned, otherwise an empty list is returned.  See
+          issue #176 for the full analysis.
 
         Not yet implemented:
 
-        - ``"psi"`` — the You (1999) azimuthal angle ψ is constant for all Bragg
-          solutions of a given (h,k,l); ``psi_constant`` as a forward-problem
-          constraint for fixed (h,k,l) is not physically meaningful.  See issue #176.
         - ``"naz"`` — no forward solver yet.
         """
-        if self._name in {"psi", "naz"}:
+        if self._name == "naz":
             return False
+        if self._name == "psi":
+            return geometry.azimuthal_reference is not None
         # alpha_i, beta_out, a_eq_b — implemented when surface_normal is set
         return geometry.surface_normal is not None
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -290,7 +290,7 @@ def test_kappa4cv_bisecting_round_trip():
 # Issue #151 — kappa4cv and kappa4ch: mode counts, stubs, fixed_kphi
 # ---------------------------------------------------------------------------
 
-_KAPPA4_ALL_MODES = {
+_KAPPA4_BASE_MODES = {
     "bisecting",
     "fixed_kphi",
     "constant_omega",
@@ -298,16 +298,19 @@ _KAPPA4_ALL_MODES = {
     "constant_phi",
     "psi_constant",
 }
+_KAPPA4CV_ALL_MODES = _KAPPA4_BASE_MODES | {"double_diffraction"}
+_KAPPA4CH_ALL_MODES = _KAPPA4_BASE_MODES
 _KAPPA4_STUB_MODES = {"psi_constant"}
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
-)
-def test_kappa4_has_all_six_modes(factory):
-    """kappa4cv and kappa4ch both expose all 6 declared modes."""
-    assert set(factory().modes.keys()) == _KAPPA4_ALL_MODES
+def test_kappa4cv_has_all_modes():
+    """kappa4cv exposes all declared modes including double_diffraction."""
+    assert set(kappa4cv().modes.keys()) == _KAPPA4CV_ALL_MODES
+
+
+def test_kappa4ch_has_all_modes():
+    """kappa4ch exposes all declared modes (no double_diffraction)."""
+    assert set(kappa4ch().modes.keys()) == _KAPPA4CH_ALL_MODES
 
 
 @pytest.mark.parametrize(
@@ -1356,6 +1359,7 @@ _PSIC_MODES_ALL = {
     "bisecting_horizontal",
     "fixed_nu",
     "double_diffraction_vertical",
+    "double_diffraction_horizontal",
     "lifting_detector_mu",
     "lifting_detector_phi",
     "psi_constant_vertical",
@@ -1370,6 +1374,7 @@ _PSIC_MODES_IMPLEMENTED = {
     "bisecting_horizontal",
     "fixed_nu",
     "double_diffraction_vertical",
+    "double_diffraction_horizontal",
     "lifting_detector_mu",
     "lifting_detector_phi",
 }
@@ -1377,8 +1382,8 @@ _PSIC_MODES_IMPLEMENTED = {
 _PSIC_MODES_STUBS = _PSIC_MODES_ALL - _PSIC_MODES_IMPLEMENTED
 
 
-def test_psic_has_all_eleven_modes():
-    """psic exposes exactly 11 declared modes."""
+def test_psic_has_all_twelve_modes():
+    """psic exposes exactly 12 declared modes."""
     assert set(psic().modes.keys()) == _PSIC_MODES_ALL
 
 
@@ -1410,7 +1415,7 @@ def test_psic_mode_is_implemented(mode_name, expected_implemented):
         pytest.param("bisecting_horizontal", 1, 0, 1, id="bisecting_horiz-101"),
         pytest.param("fixed_nu", 1, 0, 0, id="fixed_nu-100"),
         pytest.param("fixed_nu", 1, 1, 1, id="fixed_nu-111"),
-        pytest.param("double_diffraction_vertical", 1, 0, 0, id="double_diff-100"),
+        # double_diffraction_vertical tested separately (requires extras h2/k2/l2)
         # lifting_detector_* modes: qaz=90 out-of-plane constraint
         pytest.param("lifting_detector_mu", 1, 0, 0, id="lifting_detector_mu-100"),
         pytest.param("lifting_detector_mu", 0, 0, 1, id="lifting_detector_mu-001"),
@@ -1540,6 +1545,8 @@ _KAPPA6C_ALL_MODES = {
     "lifting_detector_kphi",
     "psi_constant_vertical",
     "psi_constant_horizontal",
+    "double_diffraction_vertical",
+    "double_diffraction_horizontal",
 }
 _KAPPA6C_STUB_MODES = {
     "psi_constant_vertical",
@@ -2120,3 +2127,152 @@ def test_psi_constant_wraparound_tolerance():
     solutions = g.forward(1, 1, 0)
     # wrapped and natural differ by 360° — should still match
     assert len(solutions) > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #176 — double_diffraction forward solver (4D simultaneous)
+# ---------------------------------------------------------------------------
+
+
+def _setup_dd(factory, hkl2=(0, 1, 0), a=4.0, mode_name=None):
+    """Return a geometry with double_diffraction mode and h2/k2/l2 set."""
+    g = _setup_cubic(factory, a=a)
+    if mode_name is None:
+        # Pick the first double_diffraction mode available
+        for m in g.modes:
+            if "double_diffraction" in m:
+                mode_name = m
+                break
+    assert mode_name is not None, f"No double_diffraction mode found in {factory}"
+    g.mode_name = mode_name
+    cs = g.modes[mode_name]
+    cs.extras["h2"] = float(hkl2[0])
+    cs.extras["k2"] = float(hkl2[1])
+    cs.extras["l2"] = float(hkl2[2])
+    return g
+
+
+# --- ValueError when extras not set ---
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name",
+    [
+        pytest.param(fourcv, "double_diffraction", id="fourcv"),
+        pytest.param(fourch, "double_diffraction", id="fourch"),
+        pytest.param(psic, "double_diffraction_vertical", id="psic-vert"),
+        pytest.param(psic, "double_diffraction_horizontal", id="psic-horiz"),
+        pytest.param(kappa4cv, "double_diffraction", id="kappa4cv"),
+        pytest.param(kappa6c, "double_diffraction_vertical", id="kappa6c-vert"),
+        pytest.param(kappa6c, "double_diffraction_horizontal", id="kappa6c-horiz"),
+    ],
+)
+def test_double_diffraction_raises_without_extras(factory, mode_name):
+    """forward() raises ValueError when h2/k2/l2 are REQUIRED sentinels."""
+    g = _setup_cubic(factory, a=4.0)
+    g.mode_name = mode_name
+    with pytest.raises(ValueError, match="h2, k2, l2"):
+        g.forward(1, 0, 0)
+
+
+# --- Round-trip tests ---
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l, hkl2",
+    [
+        pytest.param(fourcv, "double_diffraction", 1, 0, 0, (0, 1, 0), id="fourcv-100"),
+        pytest.param(fourcv, "double_diffraction", 1, 1, 0, (0, 0, 1), id="fourcv-110"),
+        pytest.param(fourch, "double_diffraction", 1, 0, 0, (0, 1, 0), id="fourch-100"),
+        pytest.param(
+            psic,
+            "double_diffraction_vertical",
+            1,
+            0,
+            0,
+            (0, 1, 0),
+            id="psic-vert-100",
+        ),
+        pytest.param(
+            psic,
+            "double_diffraction_horizontal",
+            1,
+            0,
+            0,
+            (0, 1, 0),
+            id="psic-horiz-100",
+        ),
+    ],
+)
+def test_double_diffraction_round_trip(
+    factory,
+    mode_name,
+    h,
+    k,
+    l,  # noqa: E741
+    hkl2,
+):
+    """double_diffraction returns solutions that round-trip via inverse()."""
+    g = _setup_dd(factory, hkl2=hkl2, mode_name=mode_name)
+    solutions = g.forward(h, k, l)
+    # May return 0 solutions if no simultaneous diffraction exists
+    for sol in solutions:
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [h, k, l], atol=1e-6), (
+            f"Round-trip failed: {[h, k, l]} -> {sol} -> {hkl_back}"
+        )
+
+
+# --- Ewald sphere verification for secondary reflection ---
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l, hkl2",
+    [
+        pytest.param(fourcv, "double_diffraction", 1, 0, 0, (0, 1, 0), id="fourcv-100"),
+        pytest.param(
+            psic,
+            "double_diffraction_vertical",
+            1,
+            0,
+            0,
+            (0, 1, 0),
+            id="psic-vert-100",
+        ),
+    ],
+)
+def test_double_diffraction_secondary_on_ewald_sphere(
+    factory,
+    mode_name,
+    h,
+    k,
+    l,  # noqa: E741
+    hkl2,
+):
+    """In all solutions, the secondary reflection satisfies the Ewald sphere."""
+    import math
+
+    from ad_hoc_diffractometer.rotation import rotation_matrix
+
+    g = _setup_dd(factory, hkl2=hkl2, mode_name=mode_name)
+    solutions = g.forward(h, k, l)
+
+    hkl2_arr = np.array(hkl2, dtype=float)
+    Q2_phi = g.sample.UB @ hkl2_arr
+    k_mag = 2.0 * math.pi / g.wavelength
+    y_raw = np.asarray(g.basis.get("longitudinal", [0, 1, 0]), dtype=float)
+    ki = k_mag * (y_raw / np.linalg.norm(y_raw))
+    ki_sq = float(np.dot(ki, ki))
+
+    for sol in solutions:
+        # Build Z from solution angles
+        Z = np.eye(3)
+        for s in g.sample_stages:
+            Z = Z @ rotation_matrix(s.axis, sol[s.name])
+        Q2_lab = Z @ Q2_phi
+        kf2 = ki + Q2_lab
+        kf2_sq = float(np.dot(kf2, kf2))
+        residual = abs(kf2_sq - ki_sq)
+        assert residual < 1e-3, (  # noqa: PLR2004
+            f"Secondary reflection not on Ewald sphere: |kf2|²-|ki|² = {residual:.6f}"
+        )

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1762,3 +1762,361 @@ def test_kappa6c_lifting_detector_qaz_satisfied(mode_name, h, k, l):  # noqa: E7
             f"{mode_name}: expected qaz=90, got {qaz_computed:.6f} "
             f"(nu={nu_deg:.4f}, delta={delta_deg:.4f})"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #176 — psi_constant forward solver (validation filter)
+# ---------------------------------------------------------------------------
+
+
+def _setup_psi(factory, ref=(0, 0, 1), a=4.0):
+    """Return a geometry with wavelength, UB=B, and azimuthal_reference set."""
+    g = _setup_cubic(factory, a=a)
+    g.azimuthal_reference = ref
+    return g
+
+
+def _natural_psi(g, h, k, l):  # noqa: E741
+    """Compute the natural psi from the phi frame (motor-angle independent)."""
+    from ad_hoc_diffractometer.forward import _compute_natural_psi
+
+    Q_phi = g.sample.UB @ np.array([h, k, l], dtype=float)
+    return _compute_natural_psi(g, Q_phi)
+
+
+# --- _compute_natural_psi unit tests ---
+
+
+@pytest.mark.parametrize(
+    "factory, h, k, l, ref, expected_psi",
+    [
+        pytest.param(fourcv, 1, 0, 0, (0, 0, 1), 90.0, id="fourcv-100-ref001"),
+        pytest.param(fourcv, 1, 1, 1, (0, 0, 1), 120.0, id="fourcv-111-ref001"),
+        pytest.param(fourcv, 1, 0, 1, (0, 0, 1), 90.0, id="fourcv-101-ref001"),
+        pytest.param(psic, 1, 0, 0, (0, 0, 1), 90.0, id="psic-100-ref001"),
+        pytest.param(psic, 1, 1, 1, (0, 0, 1), 120.0, id="psic-111-ref001"),
+    ],
+)
+def test_compute_natural_psi(factory, h, k, l, ref, expected_psi):  # noqa: E741
+    """_compute_natural_psi returns the correct motor-angle-independent psi."""
+    g = _setup_psi(factory, ref=ref)
+    psi = _natural_psi(g, h, k, l)
+    assert psi is not None
+    assert psi == pytest.approx(expected_psi, abs=1e-4)
+
+
+def test_compute_natural_psi_undefined_when_ref_parallel_to_Q():
+    """_compute_natural_psi returns None when reference is parallel to Q."""
+    g = _setup_psi(fourcv, ref=(1, 0, 0))
+    psi = _natural_psi(g, 1, 0, 0)  # Q along x, ref along x -> parallel
+    assert psi is None
+
+
+def test_compute_natural_psi_undefined_when_Q_parallel_to_beam():
+    """_compute_natural_psi returns None when Q is parallel to incident beam."""
+    g = _setup_psi(fourcv, ref=(0, 0, 1))
+    psi = _natural_psi(g, 0, 1, 0)  # Q along y (longitudinal = beam direction)
+    assert psi is None
+
+
+# --- fourcv / fourch psi_constant round-trip tests (synthetic bisect path) ---
+
+
+@pytest.mark.parametrize(
+    "factory, h, k, l, ref",
+    [
+        pytest.param(fourcv, 1, 0, 0, (0, 0, 1), id="fourcv-100-ref001"),
+        pytest.param(fourcv, 1, 0, 1, (0, 0, 1), id="fourcv-101-ref001"),
+        pytest.param(fourcv, 1, 1, 1, (0, 0, 1), id="fourcv-111-ref001"),
+        pytest.param(fourch, 1, 0, 0, (0, 0, 1), id="fourch-100-ref001"),
+        pytest.param(fourch, 1, 1, 1, (0, 0, 1), id="fourch-111-ref001"),
+    ],
+)
+def test_four_circle_psi_constant_round_trip(factory, h, k, l, ref):  # noqa: E741
+    """psi_constant returns bisecting solutions when natural psi matches target."""
+    g = _setup_psi(factory, ref=ref)
+    natural = _natural_psi(g, h, k, l)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    g.modes["psi_constant"] = ConstraintSet(
+        [ReferenceConstraint("psi", natural)],
+        computed=g.modes["psi_constant"].computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant"
+    assert _round_trip_ok(g, h, k, l)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(fourcv, id="fourcv"),
+        pytest.param(fourch, id="fourch"),
+    ],
+)
+def test_four_circle_psi_constant_wrong_target_returns_empty(factory):
+    """psi_constant returns [] when natural psi does not match psi_target."""
+    g = _setup_psi(factory, ref=(0, 0, 1))
+    natural = _natural_psi(g, 1, 0, 0)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    wrong_target = natural + 45.0
+    g.modes["psi_constant"] = ConstraintSet(
+        [ReferenceConstraint("psi", wrong_target)],
+        computed=g.modes["psi_constant"].computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant"
+    solutions = g.forward(1, 0, 0)
+    assert solutions == []
+
+
+# --- psic psi_constant_vertical / horizontal round-trip tests (bisecting path) ---
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l, ref",
+    [
+        pytest.param(
+            "psi_constant_vertical", 1, 0, 0, (0, 0, 1), id="psic-psi_vert-100"
+        ),
+        pytest.param(
+            "psi_constant_vertical", 1, 0, 1, (0, 0, 1), id="psic-psi_vert-101"
+        ),
+        pytest.param(
+            "psi_constant_vertical", 1, 1, 1, (0, 0, 1), id="psic-psi_vert-111"
+        ),
+        pytest.param(
+            "psi_constant_horizontal", 1, 0, 0, (0, 0, 1), id="psic-psi_horiz-100"
+        ),
+    ],
+)
+def test_psic_psi_constant_round_trip(mode_name, h, k, l, ref):  # noqa: E741
+    """psic psi_constant modes return bisecting solutions when psi matches."""
+    g = _setup_psi(psic, ref=ref)
+    natural = _natural_psi(g, h, k, l)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    old_mode = g.modes[mode_name]
+    new_constraints = []
+    for c in old_mode.constraints:
+        if isinstance(c, ReferenceConstraint) and c.name == "psi":
+            new_constraints.append(ReferenceConstraint("psi", natural))
+        else:
+            new_constraints.append(c)
+    g.modes[mode_name] = ConstraintSet(
+        new_constraints,
+        computed=old_mode.computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+def test_psic_psi_constant_wrong_target_returns_empty():
+    """psic psi_constant_vertical returns [] when psi target is wrong."""
+    g = _setup_psi(psic, ref=(0, 0, 1))
+    natural = _natural_psi(g, 1, 0, 0)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import BisectConstraint
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+    from ad_hoc_diffractometer import SampleConstraint
+
+    g.modes["psi_constant_vertical"] = ConstraintSet(
+        [
+            BisectConstraint("eta", "delta"),
+            SampleConstraint("mu", 0.0),
+            ReferenceConstraint("psi", natural + 45.0),
+        ],
+        computed=["eta", "chi", "phi", "delta"],
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant_vertical"
+    solutions = g.forward(1, 0, 0)
+    assert solutions == []
+
+
+# --- psi_constant psi verification in solutions ---
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, h, k, l, ref",
+    [
+        pytest.param(fourcv, "psi_constant", 1, 0, 0, (0, 0, 1), id="fourcv-100"),
+        pytest.param(fourcv, "psi_constant", 1, 1, 1, (0, 0, 1), id="fourcv-111"),
+        pytest.param(
+            psic, "psi_constant_vertical", 1, 0, 0, (0, 0, 1), id="psic-vert-100"
+        ),
+        pytest.param(
+            psic, "psi_constant_vertical", 1, 1, 1, (0, 0, 1), id="psic-vert-111"
+        ),
+        pytest.param(
+            psic, "psi_constant_horizontal", 1, 0, 0, (0, 0, 1), id="psic-horiz-100"
+        ),
+    ],
+)
+def test_psi_constant_psi_verified_in_solutions(
+    factory,
+    mode_name,
+    h,
+    k,
+    l,  # noqa: E741
+    ref,
+):
+    """All psi_constant solutions have psi == natural_psi."""
+    g = _setup_psi(factory, ref=ref)
+    natural = _natural_psi(g, h, k, l)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    old_mode = g.modes[mode_name]
+    new_constraints = []
+    for c in old_mode.constraints:
+        if isinstance(c, ReferenceConstraint) and c.name == "psi":
+            new_constraints.append(ReferenceConstraint("psi", natural))
+        else:
+            new_constraints.append(c)
+    g.modes[mode_name] = ConstraintSet(
+        new_constraints,
+        computed=old_mode.computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = mode_name
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0, f"No solutions for {mode_name} ({h},{k},{l})"
+    for sol in solutions:
+        psi_check = g.psi(angles=sol)
+        assert psi_check == pytest.approx(natural, abs=1e-3), (
+            f"psi mismatch: expected {natural:.4f}, got {psi_check:.4f}"
+        )
+
+
+# --- kappa6c psi_constant (bisecting path with kappa stages) ---
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l, ref",
+    [
+        pytest.param(
+            "psi_constant_vertical", 1, 0, 0, (0, 0, 1), id="kappa6c-psi_vert-100"
+        ),
+        pytest.param(
+            "psi_constant_vertical", 1, 1, 0, (0, 0, 1), id="kappa6c-psi_vert-110"
+        ),
+    ],
+)
+def test_kappa6c_psi_constant_round_trip(mode_name, h, k, l, ref):  # noqa: E741
+    """kappa6c psi_constant modes return bisecting solutions when psi matches."""
+    g = _setup_psi(kappa6c, ref=ref)
+    natural = _natural_psi(g, h, k, l)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    old_mode = g.modes[mode_name]
+    new_constraints = []
+    for c in old_mode.constraints:
+        if isinstance(c, ReferenceConstraint) and c.name == "psi":
+            new_constraints.append(ReferenceConstraint("psi", natural))
+        else:
+            new_constraints.append(c)
+    g.modes[mode_name] = ConstraintSet(
+        new_constraints,
+        computed=old_mode.computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = mode_name
+    assert _round_trip_ok(g, h, k, l)
+
+
+# --- kappa4cv psi_constant (synthetic bisect path) ---
+
+
+def test_kappa4cv_psi_constant_round_trip():
+    """kappa4cv psi_constant returns bisecting solutions via synthetic bisect."""
+    g = _setup_psi(kappa4cv, ref=(0, 0, 1))
+    natural = _natural_psi(g, 1, 1, 0)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    g.modes["psi_constant"] = ConstraintSet(
+        [ReferenceConstraint("psi", natural)],
+        computed=g.modes["psi_constant"].computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant"
+    assert _round_trip_ok(g, 1, 1, 0)
+
+
+# --- psi undefined → empty solutions ---
+
+
+def test_psi_constant_undefined_psi_returns_empty():
+    """psi_constant returns [] when psi is undefined (Q ∥ incident beam)."""
+    g = _setup_psi(fourcv, ref=(0, 0, 1))
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    g.modes["psi_constant"] = ConstraintSet(
+        [ReferenceConstraint("psi", 0.0)],
+        computed=g.modes["psi_constant"].computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant"
+    # (0,1,0) has Q along y (longitudinal = incident beam direction) → psi undefined
+    solutions = g.forward(0, 1, 0)
+    assert solutions == []
+
+
+# --- wraparound tolerance test ---
+
+
+def test_psi_constant_wraparound_tolerance():
+    """psi_constant handles ±180° wraparound correctly."""
+    g = _setup_psi(fourcv, ref=(1, 0, 0))
+    natural = _natural_psi(g, 1, 1, 0)
+    assert natural is not None
+
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+
+    # Set target to the opposite wraparound side (shift by 360°)
+    if natural > 0:
+        wrapped = natural - 360.0
+    else:
+        wrapped = natural + 360.0
+
+    g.modes["psi_constant"] = ConstraintSet(
+        [ReferenceConstraint("psi", wrapped)],
+        computed=g.modes["psi_constant"].computed,
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "psi_constant"
+    solutions = g.forward(1, 1, 0)
+    # wrapped and natural differ by 360° — should still match
+    assert len(solutions) > 0

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1333,13 +1333,7 @@ def test_four_circle_factory_mode_names(factory, expected_modes):
         pytest.param(
             fourcv, "psi_constant", ReferenceConstraint, False, id="fourcv-psi_constant"
         ),
-        pytest.param(
-            fourcv,
-            "double_diffraction",
-            BisectConstraint,
-            True,
-            id="fourcv-double_diffraction",
-        ),
+        # double_diffraction has no explicit constraints (4D solver uses extras)
         pytest.param(
             fourch, "bisecting", BisectConstraint, True, id="fourch-bisecting"
         ),
@@ -1358,13 +1352,6 @@ def test_four_circle_factory_mode_names(factory, expected_modes):
         ),
         pytest.param(
             fourch, "psi_constant", ReferenceConstraint, False, id="fourch-psi_constant"
-        ),
-        pytest.param(
-            fourch,
-            "double_diffraction",
-            BisectConstraint,
-            True,
-            id="fourch-double_diffraction",
         ),
     ],
 )
@@ -1895,7 +1882,7 @@ def test_zaxis_s2d2_modes_round_trip(factory, expected_modes):
 # Issue #151 — kappa4cv and kappa4ch mode structure
 # ---------------------------------------------------------------------------
 
-_KAPPA4_MODES = {
+_KAPPA4_BASE_MODES = {
     "bisecting",
     "fixed_kphi",
     "constant_omega",
@@ -1903,24 +1890,30 @@ _KAPPA4_MODES = {
     "constant_phi",
     "psi_constant",
 }
+_KAPPA4CV_MODES = _KAPPA4_BASE_MODES | {"double_diffraction"}
+_KAPPA4CH_MODES = _KAPPA4_BASE_MODES
 
-_KAPPA4_IMPLEMENTED = {
+_KAPPA4_BASE_IMPLEMENTED = {
     "bisecting",
     "fixed_kphi",
     "constant_omega",
     "constant_chi",
     "constant_phi",
 }
-_KAPPA4_STUBS = _KAPPA4_MODES - _KAPPA4_IMPLEMENTED
+_KAPPA4CV_IMPLEMENTED = _KAPPA4_BASE_IMPLEMENTED | {"double_diffraction"}
+_KAPPA4CH_IMPLEMENTED = _KAPPA4_BASE_IMPLEMENTED
+_KAPPA4CV_STUBS = _KAPPA4CV_MODES - _KAPPA4CV_IMPLEMENTED
+_KAPPA4CH_STUBS = _KAPPA4CH_MODES - _KAPPA4CH_IMPLEMENTED
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
-)
-def test_kappa4_factory_mode_names(factory):
-    """kappa4cv and kappa4ch expose exactly the 6 declared mode names."""
-    assert set(factory().modes.keys()) == _KAPPA4_MODES
+def test_kappa4cv_factory_mode_names():
+    """kappa4cv exposes all declared mode names including double_diffraction."""
+    assert set(kappa4cv().modes.keys()) == _KAPPA4CV_MODES
+
+
+def test_kappa4ch_factory_mode_names():
+    """kappa4ch exposes all declared mode names (no double_diffraction)."""
+    assert set(kappa4ch().modes.keys()) == _KAPPA4CH_MODES
 
 
 @pytest.mark.parametrize(
@@ -1945,19 +1938,19 @@ def test_kappa4_default_mode(factory):
     "factory, mode_name, expected_implemented",
     [
         pytest.param(kappa4cv, m, True, id=f"kappa4cv-{m}-impl")
-        for m in sorted(_KAPPA4_IMPLEMENTED)
+        for m in sorted(_KAPPA4CV_IMPLEMENTED)
     ]
     + [
         pytest.param(kappa4cv, m, False, id=f"kappa4cv-{m}-stub")
-        for m in sorted(_KAPPA4_STUBS)
+        for m in sorted(_KAPPA4CV_STUBS)
     ]
     + [
         pytest.param(kappa4ch, m, True, id=f"kappa4ch-{m}-impl")
-        for m in sorted(_KAPPA4_IMPLEMENTED)
+        for m in sorted(_KAPPA4CH_IMPLEMENTED)
     ]
     + [
         pytest.param(kappa4ch, m, False, id=f"kappa4ch-{m}-stub")
-        for m in sorted(_KAPPA4_STUBS)
+        for m in sorted(_KAPPA4CH_STUBS)
     ],
 )
 def test_kappa4_mode_is_implemented(factory, mode_name, expected_implemented):
@@ -2030,19 +2023,22 @@ def test_kappa4_computed_stages(factory, mode_name, expected_computed):
 
 
 @pytest.mark.parametrize(
-    "factory",
-    [pytest.param(kappa4cv, id="kappa4cv"), pytest.param(kappa4ch, id="kappa4ch")],
+    "factory, expected_modes",
+    [
+        pytest.param(kappa4cv, _KAPPA4CV_MODES, id="kappa4cv"),
+        pytest.param(kappa4ch, _KAPPA4CH_MODES, id="kappa4ch"),
+    ],
 )
-def test_kappa4_modes_round_trip(factory):
-    """Full to_dict / from_dict round-trip preserves all 6 modes."""
+def test_kappa4_modes_round_trip(factory, expected_modes):
+    """Full to_dict / from_dict round-trip preserves all modes."""
     import json
 
     g = factory()
     d = g.to_dict()
     assert json.dumps(d)
-    assert set(d["modes"].keys()) == _KAPPA4_MODES
+    assert set(d["modes"].keys()) == expected_modes
     g2 = AdHocDiffractometer.from_dict(d)
-    assert set(g2.modes.keys()) == _KAPPA4_MODES
+    assert set(g2.modes.keys()) == expected_modes
     assert g2.mode_name == "bisecting"
 
 
@@ -2061,6 +2057,8 @@ _KAPPA6C_MODES = {
     "lifting_detector_kphi",
     "psi_constant_vertical",
     "psi_constant_horizontal",
+    "double_diffraction_vertical",
+    "double_diffraction_horizontal",
 }
 
 _KAPPA6C_IMPLEMENTED = {
@@ -2072,6 +2070,8 @@ _KAPPA6C_IMPLEMENTED = {
     "fixed_delta",
     "lifting_detector_mu",
     "lifting_detector_kphi",
+    "double_diffraction_vertical",
+    "double_diffraction_horizontal",
 }
 _KAPPA6C_STUBS = _KAPPA6C_MODES - _KAPPA6C_IMPLEMENTED  # psi_constant_*
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -224,15 +224,24 @@ def test_naz_angle_vertical_normal_returns_zero():
             "a_eq_b", True, "surface_normal", (0, 0, 1), True, id="a_eq_b-with-sn"
         ),
         pytest.param("a_eq_b", True, "surface_normal", None, False, id="a_eq_b-no-sn"),
-        # psi/naz: not yet implemented regardless of reference vector
+        # psi: implemented when azimuthal_reference is set
         pytest.param(
             "psi",
             0.0,
             "azimuthal_reference",
             (0, 0, 1),
-            False,
-            id="psi-not-implemented",
+            True,
+            id="psi-with-azref",
         ),
+        pytest.param(
+            "psi",
+            0.0,
+            "azimuthal_reference",
+            None,
+            False,
+            id="psi-no-azref",
+        ),
+        # naz: not yet implemented regardless of reference vector
         pytest.param(
             "naz",
             0.0,
@@ -336,25 +345,37 @@ def test_surface_normal_none_serialisation():
 # ---------------------------------------------------------------------------
 
 
-def test_psi_constant_not_yet_solvable():
-    """psi_constant is_implemented=False and forward() raises NotImplementedError.
+def test_psi_constant_implemented_with_azref():
+    """psi_constant is_implemented=True when azimuthal_reference is set.
 
-    Even with azimuthal_reference set, the forward solver for psi_constant
-    is not yet wired up — is_implemented stays False until the solver is
-    registered (Issue J).  has_reference_vector() returns True to indicate
-    the vector prerequisite is met.
+    With azimuthal_reference set, the psi_constant forward solver is available.
+    It acts as a validation filter: it returns bisecting solutions only when
+    the natural psi for (h,k,l) matches the stored target.
     """
     g = _setup_psic()
     g.azimuthal_reference = (0, 0, 1)
     g.mode_name = "psi_constant_vertical"
     cs = g.modes["psi_constant_vertical"]
-    # is_implemented is False — no solver yet
-    assert cs.is_implemented(g) is False
+    # is_implemented is True — solver available
+    assert cs.is_implemented(g) is True
     # has_reference_vector is True — the prerequisite is met
     rc = cs.reference_constraint
     assert rc is not None
     assert rc.has_reference_vector(g) is True
-    # forward() raises because is_implemented=False
+    # forward() with correct psi target returns solutions
+    # Natural psi for (1,0,0) with ref=(0,0,1) is 90.0 on psic with identity UB.
+    # The mode's default psi target is 0.0, which does NOT match → empty list.
+    solutions = g.forward(1, 0, 0)
+    assert solutions == []  # natural psi=90 != target psi=0
+
+
+def test_psi_constant_not_implemented_without_azref():
+    """psi_constant is_implemented=False when azimuthal_reference is not set."""
+    g = _setup_psic()
+    assert g.azimuthal_reference is None
+    g.mode_name = "psi_constant_vertical"
+    cs = g.modes["psi_constant_vertical"]
+    assert cs.is_implemented(g) is False
     with pytest.raises(NotImplementedError):
         g.forward(1, 0, 0)
 


### PR DESCRIPTION
## Summary

- Implements `psi_constant` forward solver as a **validation filter**: psi is a pure phi-frame quantity (motor-angle independent); the solver computes the natural psi from `UB@hkl` and `UB@n_hkl`, compares with the stored target, and returns bisecting solutions only when they match
- Implements `double_diffraction` forward solver as a **full 4D simultaneous Newton-Raphson**: 3 Bragg equations for the primary hkl plus 1 Ewald sphere condition (`|ki + Z@UB@hkl2|^2 = |ki|^2`) for the secondary reflection, matching the Hkl library's `_double_diffraction` function
- `ReferenceConstraint.is_implemented()` for `"psi"` now returns `True` when `azimuthal_reference` is set
- New modes added to match Hkl geometry engines: `double_diffraction_horizontal` (psic), `double_diffraction` (kappa4cv), `double_diffraction_vertical` + `double_diffraction_horizontal` (kappa6c)
- `forward()` raises `ValueError` when `h2/k2/l2` extras are not set for double_diffraction modes
- No `*(stub)*` markers remain in any geometry documentation

- closes #176
- closes #122

Contributed by: OpenCode (argo/claudesonnet46)