### PR TITLE
feat: add benchmark tool with fast/slow test split (#194)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,63 @@
+name: Benchmark Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/ad_hoc_diffractometer/forward.py"
+      - "src/ad_hoc_diffractometer/kappa.py"
+      - "src/ad_hoc_diffractometer/mode.py"
+      - "src/ad_hoc_diffractometer/orientation.py"
+      - "src/ad_hoc_diffractometer/rotation.py"
+      - "src/ad_hoc_diffractometer/reference.py"
+      - "src/ad_hoc_diffractometer/presets.py"
+      - "src/ad_hoc_diffractometer/factories.py"
+      - "src/ad_hoc_diffractometer/geometry.py"
+      - "src/ad_hoc_diffractometer/stage.py"
+      - "src/ad_hoc_diffractometer/axes.py"
+      - "src/ad_hoc_diffractometer/constants.py"
+      - "src/ad_hoc_diffractometer/benchmark.py"
+      - "tests/test_benchmark.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/ad_hoc_diffractometer/forward.py"
+      - "src/ad_hoc_diffractometer/kappa.py"
+      - "src/ad_hoc_diffractometer/mode.py"
+      - "src/ad_hoc_diffractometer/orientation.py"
+      - "src/ad_hoc_diffractometer/rotation.py"
+      - "src/ad_hoc_diffractometer/reference.py"
+      - "src/ad_hoc_diffractometer/presets.py"
+      - "src/ad_hoc_diffractometer/factories.py"
+      - "src/ad_hoc_diffractometer/geometry.py"
+      - "src/ad_hoc_diffractometer/stage.py"
+      - "src/ad_hoc_diffractometer/axes.py"
+      - "src/ad_hoc_diffractometer/constants.py"
+      - "src/ad_hoc_diffractometer/benchmark.py"
+      - "tests/test_benchmark.py"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Full benchmark sweep
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package with dev dependencies
+        run: pip install -e .[dev]
+
+      - name: Run slow benchmark tests
+        run: python -m pytest -m slow_benchmark --no-cov -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,35 @@ python3 -m pre_commit run --all-files
 
 ---
 
+## Benchmark tests
+
+The benchmark test suite (`tests/test_benchmark.py`) includes slow tests
+that run `forward()`/`inverse()` across **all** registered geometries and
+modes.  These are marked `@pytest.mark.slow_benchmark` and are **excluded
+by default** from `pytest` via `addopts` in `pyproject.toml`.
+
+Fast replacement tests (using a single monkeypatched geometry) maintain
+100 % code coverage on `benchmark.py` during normal development.
+
+**When to run full benchmarks locally.**  If your changes touch any module
+in the hot path or geometry construction layer, run the full benchmark
+suite before committing:
+
+```bash
+python3 -m pytest -m slow_benchmark --no-cov -q
+```
+
+Hot path: `forward.py`, `kappa.py`, `mode.py`, `orientation.py`,
+`rotation.py`, `reference.py`
+
+Geometry construction: `presets.py`, `factories.py`, `geometry.py`,
+`stage.py`, `axes.py`, `constants.py`
+
+CI runs these automatically (via `.github/workflows/benchmark.yml`)
+when any of these files change on `main` or in a pull request.
+
+---
+
 ## Generated artefacts
 
 Several documentation files are **generated from source code or other

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -21,6 +21,7 @@ installed the package and are familiar with the
    refine_lattice
    serialize
    inclination
+   performance
    fourcv_alignment_howto
 
 .. icons: https://fonts.google.com/icons
@@ -104,6 +105,13 @@ installed the package and are familiar with the
 
       Account for a diffractometer mounted at a non-zero angle relative
       to the incident beam.
+
+   .. grid-item-card:: :material-outlined:`speed;3em` Measure Performance
+      :link: performance
+      :link-type: doc
+
+      Benchmark forward/inverse throughput and round-trip accuracy
+      across all geometries and modes.
 
    .. grid-item-card:: :material-outlined:`align_horizontal_center;3em` Align a Crystal
       :link: fourcv_alignment_howto

--- a/docs/source/howto/performance.md
+++ b/docs/source/howto/performance.md
@@ -1,0 +1,124 @@
+(howto-performance)=
+# Measure Forward/Inverse Performance
+
+The {mod}`~ad_hoc_diffractometer.benchmark` module measures the throughput
+(operations per second) and round-trip accuracy of
+{meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.forward` and
+{meth}`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.inverse` across
+all preset geometries and their declared diffraction modes.
+
+## Run the benchmark
+
+From the command line:
+
+```bash
+python -m ad_hoc_diffractometer.benchmark
+```
+
+From Python:
+
+```python
+from ad_hoc_diffractometer.benchmark import benchmark_all, benchmark_geometry
+
+# All geometries, all modes
+results = benchmark_all()
+
+# Single geometry
+results = benchmark_geometry("fourcv")
+```
+
+The output is a formatted table:
+
+```text
+geometry   mode                     status       fwd ops/s  inv ops/s  round-trip err  solns
+fourcv     bisecting                ok               3,241     18,502        4.70e-13     11
+fourcv     fixed_chi                ok               2,890     18,102        3.40e-14     21
+fourcv     psi_constant             no_solutions      8,780          -               -      0
+```
+
+## Output columns
+
+| Column | Description |
+|--------|-------------|
+| **geometry** | Preset geometry name |
+| **mode** | Diffraction mode name |
+| **status** | `ok`, `no_solutions`, `not_implemented`, or `error` |
+| **fwd ops/s** | `forward()` operations per second |
+| **inv ops/s** | `inverse()` operations per second |
+| **round-trip err** | Maximum ‖hkl − inverse(forward(hkl))‖∞ |
+| **solns** | Total solutions returned across all test reflections |
+
+## Status values
+
+- **ok** — `forward()` returned at least one solution; `inverse()` round-tripped
+  successfully.
+- **no_solutions** — `forward()` returned no solutions for any of the test
+  reflections.  This is expected for some geometry+mode+reflection combinations
+  (e.g. psi-constant modes where the target ψ does not match the natural value).
+- **not_implemented** — the mode's solver is not yet implemented for this
+  geometry.  `forward()` raises `NotImplementedError`.
+- **error** — an unexpected exception occurred during setup or computation.
+  The error message is included in the result dict.
+
+## Controlling the benchmark
+
+```python
+from ad_hoc_diffractometer.benchmark import benchmark_all
+
+# Fewer iterations (faster, noisier timing)
+results = benchmark_all(n_iter=10)
+
+# Custom reflections
+results = benchmark_all(reflections=[(1, 0, 0), (1, 1, 1)])
+
+# Suppress table output
+results = benchmark_all(verbose=False)
+```
+
+## Factors that affect performance
+
+**Number of solutions.**
+Some geometry+mode combinations produce many valid solutions (e.g.
+`double_diffraction` on a six-circle geometry can return dozens).  Each
+solution requires inverse verification, so modes with more solutions are
+slower per `forward()` call.
+
+**Geometry complexity.**
+Six-circle geometries have three free degrees of freedom after the Bragg
+condition, requiring a three-dimensional search.  Four-circle geometries
+have one free DOF and are correspondingly faster.
+
+**Kappa geometries.**
+The virtual-angle solver for kappa geometries uses a Newton–Raphson
+iteration that adds overhead compared to direct Eulerian solutions.
+
+**`inverse()` is fast.**
+`inverse()` performs a single matrix solve (`UB⁻¹ @ Q_phi`) regardless
+of geometry complexity — it does not enumerate solutions.  Typical
+throughput is 5,000–20,000 ops/sec.
+
+## Result dict structure
+
+Each result is a Python dict with the following keys:
+
+```python
+{
+    "geometry": "fourcv",
+    "mode": "bisecting",
+    "status": "ok",
+    "forward_ops_per_sec": 3241.0,
+    "inverse_ops_per_sec": 18502.0,
+    "round_trip_max_error": 4.7e-13,
+    "n_reflections": 5,
+    "n_solutions": 11,
+    "error_message": None,
+}
+```
+
+## See also
+
+- {func}`~ad_hoc_diffractometer.benchmark.benchmark_all`
+- {func}`~ad_hoc_diffractometer.benchmark.benchmark_geometry`
+- {func}`~ad_hoc_diffractometer.benchmark.benchmark_mode`
+- {doc}`forward` — how forward calculations work
+- {doc}`modes` — how to switch diffraction modes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,10 @@ known_first_party = ["ad_hoc_diffractometer"]
 pythonpath = ["tests"]
 testpaths = ["tests"]
 norecursedirs = ["references", "docs", ".git", ".tox", "dist", "build"]
-addopts = "--cov=ad_hoc_diffractometer --cov-report=term-missing"
+addopts = "--cov=ad_hoc_diffractometer --cov-report=term-missing -m 'not slow_benchmark'"
+markers = [
+    "slow_benchmark: full benchmark sweep across all geometries (run with: pytest -m slow_benchmark)",
+]
 
 [tool.ruff]
 line-length = 88

--- a/src/ad_hoc_diffractometer/benchmark.py
+++ b/src/ad_hoc_diffractometer/benchmark.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+benchmark.py — forward/inverse performance measurement.
+
+Measures the throughput (operations per second) and round-trip accuracy
+of :meth:`~geometry.AdHocDiffractometer.forward` and
+:meth:`~geometry.AdHocDiffractometer.inverse` across all preset
+geometries and their declared diffraction modes.
+
+Usage from the command line::
+
+    python -m ad_hoc_diffractometer.benchmark
+
+Usage from Python::
+
+    from ad_hoc_diffractometer.benchmark import benchmark_all, benchmark_geometry
+
+    results = benchmark_all()
+    results = benchmark_geometry("fourcv")
+
+Each result is a dict with keys:
+
+- ``geometry`` (str): geometry name
+- ``mode`` (str): mode name
+- ``status`` (str): one of ``"ok"``, ``"no_solutions"``,
+  ``"not_implemented"``, ``"error"``
+- ``forward_ops_per_sec`` (float or None)
+- ``inverse_ops_per_sec`` (float or None)
+- ``round_trip_max_error`` (float or None)
+- ``n_reflections`` (int): number of reflections attempted
+- ``n_solutions`` (int): total solutions returned
+- ``error_message`` (str or None): exception text when status is ``"error"``
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from .factories import list_geometries
+from .factories import make_geometry
+from .lattice import Lattice
+from .mode import REQUIRED
+from .orientation import ub_identity
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default benchmark parameters
+# ---------------------------------------------------------------------------
+
+DEFAULT_WAVELENGTH: float = 1.5406
+"""Cu Kα wavelength in Å."""
+
+DEFAULT_LATTICE_A: float = 4.0
+"""Cubic lattice parameter in Å."""
+
+DEFAULT_REFLECTIONS: list[tuple[float, float, float]] = [
+    (1, 0, 0),
+    (0, 1, 0),
+    (0, 0, 1),
+    (1, 1, 0),
+    (1, 1, 1),
+]
+"""Reflections to benchmark.  All reachable with a=4 Å at Cu Kα."""
+
+DEFAULT_N_ITER: int = 100
+"""Number of timing iterations per operation."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_geometry(name: str):
+    """Create a geometry with a standard cubic sample and UB = B."""
+    g = make_geometry(name)
+    g.wavelength = DEFAULT_WAVELENGTH
+    g.sample.lattice = Lattice(a=DEFAULT_LATTICE_A)
+    ub_identity(g.sample)
+    return g
+
+
+def _prepare_mode(geometry, mode_name: str) -> None:
+    """Activate a mode and configure any special prerequisites.
+
+    Sets ``mode_name`` on the geometry and provides the minimum setup
+    required for modes that need extra configuration:
+
+    - psi_constant modes: sets ``azimuthal_reference``
+    - double_diffraction modes: sets h2/k2/l2 extras
+    - surface/reference modes (alpha_i, beta_out, a_eq_b):
+      sets ``surface_normal``
+    """
+    geometry.mode_name = mode_name
+    cs = geometry.modes[mode_name]
+
+    # Double-diffraction modes: replace REQUIRED sentinels with values
+    for key in ("h2", "k2", "l2"):
+        if key in cs.extras and cs.extras[key] is REQUIRED:
+            defaults = {"h2": 0.0, "k2": 1.0, "l2": 0.0}
+            cs.extras[key] = defaults[key]
+
+    # Reference-vector modes: set azimuthal_reference if needed
+    for c in cs._constraints:
+        cname = getattr(c, "_name", getattr(c, "name", ""))
+        if cname == "psi" and geometry.azimuthal_reference is None:
+            geometry.azimuthal_reference = (0, 0, 1)
+
+    # Surface modes: set surface_normal if needed
+    for c in cs._constraints:
+        cname = getattr(c, "_name", getattr(c, "name", ""))
+        if cname in ("alpha_i", "beta_out", "a_eq_b"):
+            if geometry.surface_normal is None:
+                geometry.surface_normal = (0, 0, 1)
+
+
+def _time_forward(geometry, reflections, n_iter: int) -> tuple[float, list]:
+    """Time forward() calls and collect solutions.
+
+    Returns (ops_per_sec, all_solutions) where all_solutions is a list
+    of (hkl, solutions) pairs from the final iteration.
+    """
+    all_solutions = []
+
+    start = time.perf_counter()
+    for _ in range(n_iter):
+        all_solutions.clear()
+        for hkl in reflections:
+            solutions = geometry.forward(*hkl)
+            all_solutions.append((hkl, solutions))
+    elapsed = time.perf_counter() - start
+
+    total_ops = n_iter * len(reflections)
+    ops_per_sec = total_ops / elapsed if elapsed > 0 else float("inf")
+    return ops_per_sec, all_solutions
+
+
+def _time_inverse(geometry, solutions_by_hkl, n_iter: int) -> tuple[float, float]:
+    """Time inverse() calls and measure round-trip error.
+
+    Parameters
+    ----------
+    solutions_by_hkl : list of (hkl, solutions)
+        Output from _time_forward.
+
+    Returns (ops_per_sec, max_error).
+    """
+    # Flatten to (hkl, angle_dict) pairs
+    pairs = []
+    for hkl, solutions in solutions_by_hkl:
+        for sol in solutions:
+            pairs.append((hkl, sol))
+
+    if not pairs:
+        return 0.0, 0.0
+
+    max_error = 0.0
+
+    start = time.perf_counter()
+    for _ in range(n_iter):
+        for hkl, angles in pairs:
+            hkl_back = geometry.inverse(angles)
+            err = max(abs(a - b) for a, b in zip(hkl, hkl_back, strict=False))
+            if err > max_error:
+                max_error = err
+    elapsed = time.perf_counter() - start
+
+    total_ops = n_iter * len(pairs)
+    ops_per_sec = total_ops / elapsed if elapsed > 0 else float("inf")
+    return ops_per_sec, max_error
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def benchmark_mode(
+    geometry_name: str,
+    mode_name: str,
+    *,
+    reflections: list[tuple[float, float, float]] | None = None,
+    n_iter: int = DEFAULT_N_ITER,
+) -> dict:
+    """Benchmark a single geometry + mode combination.
+
+    Parameters
+    ----------
+    geometry_name : str
+        Name of a registered geometry (e.g. ``"fourcv"``).
+    mode_name : str
+        Name of a mode declared on the geometry.
+    reflections : list of (h, k, l) or None
+        Reflections to use.  Defaults to :data:`DEFAULT_REFLECTIONS`.
+    n_iter : int
+        Number of timing iterations.  Defaults to :data:`DEFAULT_N_ITER`.
+
+    Returns
+    -------
+    dict
+        Result dict with keys: ``geometry``, ``mode``, ``status``,
+        ``forward_ops_per_sec``, ``inverse_ops_per_sec``,
+        ``round_trip_max_error``, ``n_reflections``, ``n_solutions``,
+        ``error_message``.
+    """
+    if reflections is None:
+        reflections = DEFAULT_REFLECTIONS
+
+    result = {
+        "geometry": geometry_name,
+        "mode": mode_name,
+        "status": "ok",
+        "forward_ops_per_sec": None,
+        "inverse_ops_per_sec": None,
+        "round_trip_max_error": None,
+        "n_reflections": len(reflections),
+        "n_solutions": 0,
+        "error_message": None,
+    }
+
+    try:
+        g = _setup_geometry(geometry_name)
+        _prepare_mode(g, mode_name)
+
+        fwd_ops, solutions_by_hkl = _time_forward(g, reflections, n_iter)
+        n_solutions = sum(len(sols) for _, sols in solutions_by_hkl)
+
+        result["forward_ops_per_sec"] = fwd_ops
+        result["n_solutions"] = n_solutions
+
+        if n_solutions == 0:
+            result["status"] = "no_solutions"
+            return result
+
+        inv_ops, max_err = _time_inverse(g, solutions_by_hkl, n_iter)
+        result["inverse_ops_per_sec"] = inv_ops
+        result["round_trip_max_error"] = max_err
+
+    except NotImplementedError as exc:
+        result["status"] = "not_implemented"
+        result["error_message"] = str(exc)
+    except Exception as exc:  # noqa: BLE001
+        result["status"] = "error"
+        result["error_message"] = str(exc)
+
+    return result
+
+
+def benchmark_geometry(
+    name: str,
+    *,
+    reflections: list[tuple[float, float, float]] | None = None,
+    n_iter: int = DEFAULT_N_ITER,
+    verbose: bool = True,
+) -> list[dict]:
+    """Benchmark all modes of a single geometry.
+
+    Parameters
+    ----------
+    name : str
+        Name of a registered geometry (e.g. ``"fourcv"``).
+    reflections : list of (h, k, l) or None
+        Reflections to use.  Defaults to :data:`DEFAULT_REFLECTIONS`.
+    n_iter : int
+        Number of timing iterations.
+    verbose : bool
+        If True, print a results table to stdout.
+
+    Returns
+    -------
+    list of dict
+        One result dict per mode.
+    """
+    g = make_geometry(name)
+    mode_names = sorted(g.modes.keys())
+
+    results = []
+    for mode_name in mode_names:
+        r = benchmark_mode(name, mode_name, reflections=reflections, n_iter=n_iter)
+        results.append(r)
+
+    if verbose:
+        _print_results(results)
+
+    return results
+
+
+def benchmark_all(
+    *,
+    reflections: list[tuple[float, float, float]] | None = None,
+    n_iter: int = DEFAULT_N_ITER,
+    verbose: bool = True,
+) -> list[dict]:
+    """Benchmark all modes of all registered geometries.
+
+    Parameters
+    ----------
+    reflections : list of (h, k, l) or None
+        Reflections to use.  Defaults to :data:`DEFAULT_REFLECTIONS`.
+    n_iter : int
+        Number of timing iterations.
+    verbose : bool
+        If True, print a results table to stdout.
+
+    Returns
+    -------
+    list of dict
+        One result dict per geometry+mode combination.
+    """
+    all_results = []
+    for name in sorted(list_geometries()):
+        results = benchmark_geometry(
+            name, reflections=reflections, n_iter=n_iter, verbose=False
+        )
+        all_results.extend(results)
+
+    if verbose:
+        _print_results(all_results)
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+_STATUS_WIDTH = 15
+_OPS_WIDTH = 10
+
+
+def _print_results(results: list[dict]) -> None:
+    """Print a formatted table of benchmark results to stdout."""
+    import builtins
+
+    header = (
+        f"{'geometry':<12s}  {'mode':<32s}  {'status':<{_STATUS_WIDTH}s}"
+        f"  {'fwd ops/s':>{_OPS_WIDTH}s}  {'inv ops/s':>{_OPS_WIDTH}s}"
+        f"  {'round-trip err':>14s}  {'solns':>5s}"
+    )
+    separator = "-" * len(header)
+
+    builtins.print(separator)
+    builtins.print(header)
+    builtins.print(separator)
+
+    for r in results:
+        fwd = (
+            f"{r['forward_ops_per_sec']:>{_OPS_WIDTH},.0f}"
+            if r["forward_ops_per_sec"] is not None
+            else f"{'-':>{_OPS_WIDTH}s}"
+        )
+        inv = (
+            f"{r['inverse_ops_per_sec']:>{_OPS_WIDTH},.0f}"
+            if r["inverse_ops_per_sec"] is not None
+            else f"{'-':>{_OPS_WIDTH}s}"
+        )
+        err = (
+            f"{r['round_trip_max_error']:>14.2e}"
+            if r["round_trip_max_error"] is not None
+            else f"{'-':>14s}"
+        )
+        builtins.print(
+            f"{r['geometry']:<12s}  {r['mode']:<32s}  {r['status']:<{_STATUS_WIDTH}s}"
+            f"  {fwd}  {inv}  {err}  {r['n_solutions']:>5d}"
+        )
+
+    builtins.print(separator)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point: python -m ad_hoc_diffractometer.benchmark
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":  # pragma: no cover
+    benchmark_all()

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Tests for the benchmark module.
+
+Corresponds to ``src/ad_hoc_diffractometer/benchmark.py``.
+Uses ``n_iter=1`` throughout to keep test duration short.
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ad_hoc_diffractometer.benchmark import DEFAULT_REFLECTIONS
+from ad_hoc_diffractometer.benchmark import _prepare_mode
+from ad_hoc_diffractometer.benchmark import _setup_geometry
+from ad_hoc_diffractometer.benchmark import _time_forward
+from ad_hoc_diffractometer.benchmark import _time_inverse
+from ad_hoc_diffractometer.benchmark import benchmark_all
+from ad_hoc_diffractometer.benchmark import benchmark_geometry
+from ad_hoc_diffractometer.benchmark import benchmark_mode
+from ad_hoc_diffractometer.factories import list_geometries
+
+REQUIRED_KEYS = {
+    "geometry",
+    "mode",
+    "status",
+    "forward_ops_per_sec",
+    "inverse_ops_per_sec",
+    "round_trip_max_error",
+    "n_reflections",
+    "n_solutions",
+    "error_message",
+}
+
+VALID_STATUSES = {"ok", "no_solutions", "not_implemented", "error"}
+
+
+# ---------------------------------------------------------------------------
+# _setup_geometry
+# ---------------------------------------------------------------------------
+
+
+class TestSetupGeometry:
+    """Tests for the _setup_geometry helper."""
+
+    @pytest.mark.parametrize(
+        "name, context",
+        [
+            pytest.param("fourcv", does_not_raise(), id="fourcv"),
+            pytest.param("psic", does_not_raise(), id="psic"),
+            pytest.param("kappa4cv", does_not_raise(), id="kappa4cv"),
+            pytest.param(
+                "nonexistent",
+                pytest.raises(
+                    ValueError,
+                    match=re.escape("No geometry named 'nonexistent'"),
+                ),
+                id="nonexistent-raises",
+            ),
+        ],
+    )
+    def test_setup_geometry(self, name, context):
+        with context:
+            g = _setup_geometry(name)
+            assert g.name == name
+            assert g.wavelength == pytest.approx(1.5406)
+            assert g.sample.UB is not None
+
+
+# ---------------------------------------------------------------------------
+# _prepare_mode
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareMode:
+    """Tests for the _prepare_mode helper."""
+
+    def test_standard_mode(self):
+        """A standard bisecting mode needs no special setup."""
+        g = _setup_geometry("fourcv")
+        _prepare_mode(g, "bisecting")
+        assert g.mode_name == "bisecting"
+
+    @pytest.mark.parametrize(
+        "geometry_name, mode_name, context",
+        [
+            pytest.param(
+                "fourcv",
+                "double_diffraction",
+                does_not_raise(),
+                id="fourcv-dd",
+            ),
+            pytest.param(
+                "psic",
+                "double_diffraction_vertical",
+                does_not_raise(),
+                id="psic-dd-vert",
+            ),
+        ],
+    )
+    def test_double_diffraction_extras(self, geometry_name, mode_name, context):
+        """Double-diffraction modes get h2/k2/l2 sentinels replaced."""
+        with context:
+            g = _setup_geometry(geometry_name)
+            _prepare_mode(g, mode_name)
+            cs = g.modes[mode_name]
+            for key in ("h2", "k2", "l2"):
+                assert isinstance(cs.extras[key], float)
+
+    def test_psi_constant_sets_reference(self):
+        """psi_constant modes get an azimuthal_reference if not set."""
+        g = _setup_geometry("fourcv")
+        assert g.azimuthal_reference is None
+        _prepare_mode(g, "psi_constant")
+        assert g.azimuthal_reference is not None
+
+    @pytest.mark.parametrize(
+        "geometry_name, mode_name",
+        [
+            pytest.param("sixc", "fixed_alpha_zaxis", id="sixc-alpha-zaxis"),
+            pytest.param("sixc", "fixed_beta_zaxis", id="sixc-beta-zaxis"),
+            pytest.param("sixc", "alpha_eq_beta_zaxis", id="sixc-a-eq-b"),
+        ],
+    )
+    def test_surface_modes_set_normal(self, geometry_name, mode_name):
+        """Surface/reference modes get a surface_normal if not set."""
+        g = _setup_geometry(geometry_name)
+        assert g.surface_normal is None
+        _prepare_mode(g, mode_name)
+        assert g.surface_normal is not None
+
+    def test_surface_mode_preserves_existing_normal(self):
+        """If surface_normal is already set, _prepare_mode leaves it."""
+        g = _setup_geometry("sixc")
+        g.surface_normal = (1, 0, 0)
+        _prepare_mode(g, "fixed_alpha_zaxis")
+        assert g.surface_normal == (1.0, 0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _time_forward / _time_inverse
+# ---------------------------------------------------------------------------
+
+
+class TestTimingHelpers:
+    """Tests for the internal timing functions."""
+
+    def test_time_forward_returns_solutions(self):
+        g = _setup_geometry("fourcv")
+        _prepare_mode(g, "bisecting")
+        ops, solutions = _time_forward(g, [(1, 0, 0)], n_iter=1)
+        assert ops > 0
+        assert len(solutions) == 1  # one reflection
+        hkl, sols = solutions[0]
+        assert hkl == (1, 0, 0)
+        assert len(sols) >= 1
+
+    def test_time_inverse_round_trip(self):
+        g = _setup_geometry("fourcv")
+        _prepare_mode(g, "bisecting")
+        _, solutions = _time_forward(g, [(1, 0, 0)], n_iter=1)
+        ops, max_err = _time_inverse(g, solutions, n_iter=1)
+        assert ops > 0
+        assert max_err < 1e-8
+
+    def test_time_inverse_empty_solutions(self):
+        """inverse timing with no solutions returns zero ops."""
+        g = _setup_geometry("fourcv")
+        _prepare_mode(g, "bisecting")
+        ops, max_err = _time_inverse(g, [], n_iter=1)
+        assert ops == 0.0
+        assert max_err == 0.0
+
+
+# ---------------------------------------------------------------------------
+# benchmark_mode
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkMode:
+    """Tests for the benchmark_mode function."""
+
+    def test_result_dict_keys(self):
+        """Result contains all required keys."""
+        r = benchmark_mode("fourcv", "bisecting", n_iter=1)
+        assert set(r.keys()) == REQUIRED_KEYS
+
+    def test_ok_status(self):
+        """A working mode returns status 'ok'."""
+        r = benchmark_mode("fourcv", "bisecting", reflections=[(1, 0, 0)], n_iter=1)
+        assert r["status"] == "ok"
+        assert r["forward_ops_per_sec"] is not None
+        assert r["forward_ops_per_sec"] > 0
+        assert r["inverse_ops_per_sec"] is not None
+        assert r["inverse_ops_per_sec"] > 0
+        assert r["round_trip_max_error"] is not None
+        assert r["round_trip_max_error"] < 1e-8
+        assert r["n_solutions"] > 0
+        assert r["error_message"] is None
+
+    def test_no_solutions_status(self):
+        """A mode that returns no solutions for the given reflections."""
+        # psi_constant on fourcv with default setup rarely matches
+        r = benchmark_mode("fourcv", "psi_constant", reflections=[(1, 0, 0)], n_iter=1)
+        assert r["status"] in ("no_solutions", "not_implemented", "ok")
+        # For psi_constant the likely outcome is no_solutions or not_implemented
+        if r["status"] == "no_solutions":
+            assert r["inverse_ops_per_sec"] is None
+            assert r["n_solutions"] == 0
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            pytest.param("ok", id="ok"),
+            pytest.param("no_solutions", id="no-solutions"),
+            pytest.param("not_implemented", id="not-implemented"),
+            pytest.param("error", id="error"),
+        ],
+    )
+    def test_valid_status_values(self, status):
+        """All status values are in the expected set."""
+        assert status in VALID_STATUSES
+
+    def test_not_implemented_status(self, monkeypatch):
+        """A mode that raises NotImplementedError gets status 'not_implemented'."""
+        from ad_hoc_diffractometer import benchmark as bm
+
+        def _raise_not_impl(*args, **kwargs):
+            raise NotImplementedError("solver not available")
+
+        monkeypatch.setattr(bm, "_time_forward", _raise_not_impl)
+
+        r = benchmark_mode("fourcv", "bisecting", reflections=[(1, 0, 0)], n_iter=1)
+        assert r["status"] == "not_implemented"
+        assert "solver not available" in r["error_message"]
+
+    def test_nonexistent_geometry(self):
+        """A nonexistent geometry returns error status."""
+        r = benchmark_mode("nonexistent", "bisecting", n_iter=1)
+        assert r["status"] == "error"
+        assert r["error_message"] is not None
+        assert "nonexistent" in r["error_message"]
+
+    def test_n_reflections_matches_input(self):
+        """n_reflections reflects how many reflections were passed in."""
+        refls = [(1, 0, 0), (0, 1, 0)]
+        r = benchmark_mode("fourcv", "bisecting", reflections=refls, n_iter=1)
+        assert r["n_reflections"] == 2
+
+    def test_default_reflections(self):
+        """Without explicit reflections, uses DEFAULT_REFLECTIONS."""
+        r = benchmark_mode("fourcv", "bisecting", n_iter=1)
+        assert r["n_reflections"] == len(DEFAULT_REFLECTIONS)
+
+
+# ---------------------------------------------------------------------------
+# benchmark_geometry
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkGeometry:
+    """Tests for the benchmark_geometry function."""
+
+    def test_returns_all_modes(self):
+        """Returns one result per declared mode."""
+        from ad_hoc_diffractometer import presets
+
+        g = presets.fourcv()
+        n_modes = len(g.modes)
+        results = benchmark_geometry(
+            "fourcv", reflections=[(1, 0, 0)], n_iter=1, verbose=False
+        )
+        assert len(results) == n_modes
+
+    def test_all_results_have_correct_geometry(self):
+        results = benchmark_geometry(
+            "fourch", reflections=[(1, 0, 0)], n_iter=1, verbose=False
+        )
+        for r in results:
+            assert r["geometry"] == "fourch"
+            assert set(r.keys()) == REQUIRED_KEYS
+            assert r["status"] in VALID_STATUSES
+
+    def test_verbose_prints_table(self, capsys):
+        """verbose=True prints a table to stdout."""
+        benchmark_geometry("fourcv", reflections=[(1, 0, 0)], n_iter=1, verbose=True)
+        captured = capsys.readouterr()
+        assert "fourcv" in captured.out
+        assert "bisecting" in captured.out
+        assert "fwd ops/s" in captured.out
+
+    def test_verbose_false_no_output(self, capsys):
+        """verbose=False produces no stdout output."""
+        benchmark_geometry("fourcv", reflections=[(1, 0, 0)], n_iter=1, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# benchmark_all
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkAll:
+    """Tests for the benchmark_all function."""
+
+    def test_covers_all_geometries(self):
+        """Results include every registered geometry."""
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=False)
+        geometry_names = {r["geometry"] for r in results}
+        registered = set(list_geometries().keys())
+        assert geometry_names == registered
+
+    def test_all_results_valid(self):
+        """Every result has valid keys and status."""
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=False)
+        for r in results:
+            assert set(r.keys()) == REQUIRED_KEYS
+            assert r["status"] in VALID_STATUSES
+
+    def test_verbose_prints_table(self, capsys):
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=True)
+        captured = capsys.readouterr()
+        assert "fwd ops/s" in captured.out
+        assert len(results) > 0

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -303,15 +303,29 @@ class TestBenchmarkGeometry:
 # ---------------------------------------------------------------------------
 
 
-class TestBenchmarkAll:
-    """Tests for the benchmark_all function."""
+class TestBenchmarkAllFast:
+    """Fast tests for benchmark_all using a single monkeypatched geometry.
 
-    def test_covers_all_geometries(self):
-        """Results include every registered geometry."""
+    These exercise 100 % of benchmark_all()'s code paths (loop, extend,
+    verbose branch) in ~1 second by limiting the geometry registry to a
+    single entry.  Full-sweep tests are in TestBenchmarkAll (marked
+    slow_benchmark).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _one_geometry(self, monkeypatch):
+        """Restrict list_geometries() to a single entry."""
+        full = list_geometries()
+        monkeypatch.setattr(
+            "ad_hoc_diffractometer.benchmark.list_geometries",
+            lambda: {"fourcv": full["fourcv"]},
+        )
+
+    def test_covers_requested_geometries(self):
+        """Result geometry names match the (monkeypatched) registry."""
         results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=False)
         geometry_names = {r["geometry"] for r in results}
-        registered = set(list_geometries().keys())
-        assert geometry_names == registered
+        assert geometry_names == {"fourcv"}
 
     def test_all_results_valid(self):
         """Every result has valid keys and status."""
@@ -320,6 +334,44 @@ class TestBenchmarkAll:
             assert set(r.keys()) == REQUIRED_KEYS
             assert r["status"] in VALID_STATUSES
 
+    def test_verbose_prints_table(self, capsys):
+        """verbose=True prints a formatted table to stdout."""
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=True)
+        captured = capsys.readouterr()
+        assert "fwd ops/s" in captured.out
+        assert "fourcv" in captured.out
+        assert len(results) > 0
+
+
+# ---------------------------------------------------------------------------
+# benchmark_all — full sweep (slow)
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkAll:
+    """Full-sweep tests for benchmark_all across all registered geometries.
+
+    These are marked slow_benchmark and excluded from the default pytest
+    run.  Run on demand with: ``pytest -m slow_benchmark``
+    """
+
+    @pytest.mark.slow_benchmark
+    def test_covers_all_geometries(self):
+        """Results include every registered geometry."""
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=False)
+        geometry_names = {r["geometry"] for r in results}
+        registered = set(list_geometries().keys())
+        assert geometry_names == registered
+
+    @pytest.mark.slow_benchmark
+    def test_all_results_valid(self):
+        """Every result has valid keys and status."""
+        results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=False)
+        for r in results:
+            assert set(r.keys()) == REQUIRED_KEYS
+            assert r["status"] in VALID_STATUSES
+
+    @pytest.mark.slow_benchmark
     def test_verbose_prints_table(self, capsys):
         results = benchmark_all(reflections=[(1, 0, 0)], n_iter=1, verbose=True)
         captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

- closes #194

- Add `benchmark` module with `benchmark_mode()`, `benchmark_geometry()`, and `benchmark_all()` for measuring forward/inverse throughput and round-trip accuracy across all geometries and modes
- HOWTO documentation page (`docs/source/howto/performance.md`) and index card
- CLI entry point: `python -m ad_hoc_diffractometer.benchmark`
- Mark full-sweep `benchmark_all` tests as `@pytest.mark.slow_benchmark`, excluded by default via `addopts` in `pyproject.toml`
- Fast replacement tests monkeypatch `list_geometries` to a single geometry, maintaining 100% coverage on `benchmark.py` while reducing default test time from ~3 minutes to ~26 seconds
- CI workflow (`.github/workflows/benchmark.yml`) runs full benchmark sweep automatically when hot-path or geometry-construction modules change
- Document local benchmark convention in `AGENTS.md`

### Test commands

| Command | What runs | Time |
|---|---|---|
| `pytest` | Fast tests only (slow_benchmark excluded) | ~26s |
| `pytest -m slow_benchmark --no-cov` | Full-sweep tests only | ~165s |
| `pytest -m ''` | All tests | ~182s |

Contributed by: OpenCode (argo/claudeopus46)