### PR TITLE
DOC: stage tables should show parent of each (#198)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,13 +82,15 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
    layout type.  This cannot currently be set via the `gh` CLI; it must be
    done in the GitHub web UI immediately after the project is created.
 
-4. **Create a feature branch before writing any code.**  All code changes
-   must be made on a feature branch, never directly on `main` — the only
-   exception is truly trivial changes (e.g. a one-word typo fix in a doc
-   comment).  The branch must be created **before** any files are modified
-   so that `main` is never left in a dirty state.  Branch names must start
-   with the issue number followed by a short, hyphen-separated description
-   of the topic:
+4. **Create a feature branch before making any file changes.**  This is the
+   very first step after reading the issue — create the branch **before**
+   editing, creating, or deleting any file.  All changes must be made on a
+   feature branch, never directly on `main` — the only exception is truly
+   trivial changes (e.g. a one-word typo fix in a doc comment).  If you
+   have already modified files on `main` by mistake, stash the changes,
+   create the branch, then pop the stash.  Branch names must start with the
+   issue number followed by a short, hyphen-separated description of the
+   topic:
    ```
    git checkout -b <issue-number>-<concise-topic>
    ```
@@ -343,6 +345,13 @@ way: every new algorithm must be implementable with NumPy alone.
 - **No `geometry_` prefix** on factory functions
 - **`display.fmt(value, digits)`** for all floating-point display;
   never use f-strings with hardcoded precision for user-facing output
+- **US English spellings** in all code, comments, docstrings, and
+  documentation.  Use American spellings such as `analyzer`, `polarizer`,
+  `color`, `center`, `normalized`, `minimize`, `optimize`, `generalize`,
+  `recognize`, `characterized`, `millimeters`, `honor` — not their British
+  equivalents (`analyser`, `polariser`, `colour`, `centre`, `normalised`,
+  `minimise`, `optimise`, `generalise`, `recognise`, `characterised`,
+  `millimetres`, `honour`)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,17 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
    Status field IDs are the same across all project boards:
    - Field ID: `PVTSSF_lAHOACLKMM4BULjAzhBVdT0` (P3), `PVTSSF_lAHOACLKMM4BUWg2zhBfRCE` (Documentation)
    - In Progress option ID: `47fc9ee4` (same on every board)
+   - In Review option ID: `df73e18b` (on boards that support it)
+
+   **Match the issue's boards.**  Before creating the PR, query the
+   issue's `projectItems` to discover every board it belongs to.  Add the
+   PR to **all** of those boards — not just the one implied by the domain
+   table above.
+
+   **Set "In review" when code is complete.**  Once the PR is pushed and
+   no further code changes are anticipated, set its project board status
+   to **"In review"** (on boards that have that status; leave "In
+   Progress" where only Todo / In Progress / Done exist).
 
    ```bash
    # Set milestone when creating the PR

--- a/docs/source/geometries/fivec.md
+++ b/docs/source/geometries/fivec.md
@@ -46,18 +46,18 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``mu`` | +vertical (+x) | right-handed, shared base |
-| ``omega`` | −transverse (−z) | left-handed |
-| ``chi`` | +longitudinal (+y) | right-handed |
-| ``phi`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed, shared base | base |
+| ``omega`` | −transverse (−z) | left-handed | ``mu`` |
+| ``chi`` | +longitudinal (+y) | right-handed | ``omega`` |
+| ``phi`` | −transverse (−z) | left-handed | ``chi`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``ttheta`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``ttheta`` | −transverse (−z) | left-handed | ``mu`` |
 
 **Shared stage:** mu (base stage shared between sample and detector stacks)
 

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``omega`` | −vertical (−z BL) | left-handed |
-| ``chi`` | +longitudinal (+y BL) | right-handed |
-| ``phi`` | −vertical (−z BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``omega`` | −vertical (−z BL) | left-handed | base |
+| ``chi`` | +longitudinal (+y BL) | right-handed | ``omega`` |
+| ``phi`` | −vertical (−z BL) | left-handed | ``chi`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``ttheta`` | −vertical (−z BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``ttheta`` | −vertical (−z BL) | left-handed | base |
 
 ## Diffraction modes
 

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``omega`` | −transverse (−x BL) | left-handed |
-| ``chi`` | +longitudinal (+y BL) | right-handed |
-| ``phi`` | −transverse (−x BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``omega`` | −transverse (−x BL) | left-handed | base |
+| ``chi`` | +longitudinal (+y BL) | right-handed | ``omega`` |
+| ``phi`` | −transverse (−x BL) | left-handed | ``chi`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``ttheta`` | −transverse (−x BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``ttheta`` | −transverse (−x BL) | left-handed | base |
 
 ## Diffraction modes
 

--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``komega`` | −vertical (−z BL) | left-handed |
-| ``kappa`` | tilted axis, α=50° | right-handed |
-| ``kphi`` | −vertical (−z BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``komega`` | −vertical (−z BL) | left-handed | base |
+| ``kappa`` | tilted axis, α=50° | right-handed | ``komega`` |
+| ``kphi`` | −vertical (−z BL) | left-handed | ``kappa`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``ttheta`` | −vertical (−z BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``ttheta`` | −vertical (−z BL) | left-handed | base |
 
 **Virtual Eulerian angles** (computed from real kappa angles via Walko 2016 eq. [16]):
 omega, chi, phi.  Used as constraint names for stub modes; converted back to

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``komega`` | −transverse (−x BL) | left-handed |
-| ``kappa`` | tilted axis, α=50° | right-handed |
-| ``kphi`` | −transverse (−x BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``komega`` | −transverse (−x BL) | left-handed | base |
+| ``kappa`` | tilted axis, α=50° | right-handed | ``komega`` |
+| ``kphi`` | −transverse (−x BL) | left-handed | ``kappa`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``ttheta`` | −transverse (−x BL) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``ttheta`` | −transverse (−x BL) | left-handed | base |
 
 **Virtual Eulerian angles** (computed from real kappa angles via Walko 2016 eq. [16]):
 omega, chi, phi.  Used as constraint names for stub modes; converted back to

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -44,19 +44,19 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``mu`` | +vertical (+x) | right-handed |
-| ``komega`` | −transverse (−z) | left-handed |
-| ``kappa`` | tilted axis, α=50° | right-handed |
-| ``kphi`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed | base |
+| ``komega`` | −transverse (−z) | left-handed | ``mu`` |
+| ``kappa`` | tilted axis, α=50° | right-handed | ``komega`` |
+| ``kphi`` | −transverse (−z) | left-handed | ``kappa`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``nu`` | +vertical (+x) | right-handed |
-| ``delta`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed | base |
+| ``delta`` | −transverse (−z) | left-handed | ``nu`` |
 
 **Virtual Eulerian angles** (computed from komega, kappa, kphi via Walko 2016 eq. [16]):
 omega, chi, phi.  Used in stub mode descriptions; kappa inversion required (Issue I / #153).

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -44,19 +44,19 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``mu`` | +vertical (+x) | right-handed |
-| ``eta`` | −transverse (−z) | left-handed |
-| ``chi`` | +longitudinal (+y) | right-handed |
-| ``phi`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed | base |
+| ``eta`` | −transverse (−z) | left-handed | ``mu`` |
+| ``chi`` | +longitudinal (+y) | right-handed | ``eta`` |
+| ``phi`` | −transverse (−z) | left-handed | ``chi`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``nu`` | +vertical (+x) | right-handed |
-| ``delta`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed | base |
+| ``delta`` | −transverse (−z) | left-handed | ``nu`` |
 
 ## Diffraction modes
 

--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``mu`` | +vertical (+x) | right-handed |
-| ``Z`` | +longitudinal (+y) | right-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``mu`` | +vertical (+x) | right-handed | base |
+| ``Z`` | +longitudinal (+y) | right-handed | ``mu`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``nu`` | +vertical (+x) | right-handed |
-| ``delta`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``nu`` | +vertical (+x) | right-handed | base |
+| ``delta`` | −transverse (−z) | left-handed | ``nu`` |
 
 ## Diffraction modes
 

--- a/docs/source/geometries/sixc.md
+++ b/docs/source/geometries/sixc.md
@@ -46,19 +46,19 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``alpha`` | +vertical (+x) | right-handed, shared base |
-| ``omega`` | −transverse (−z) | left-handed |
-| ``chi`` | +longitudinal (+y) | right-handed |
-| ``phi`` | −transverse (−z) | left-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``alpha`` | +vertical (+x) | right-handed, shared base | base |
+| ``omega`` | −transverse (−z) | left-handed | ``alpha`` |
+| ``chi`` | +longitudinal (+y) | right-handed | ``omega`` |
+| ``phi`` | −transverse (−z) | left-handed | ``chi`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``delta`` | −transverse (−z) | left-handed |
-| ``gamma`` | +vertical (+x) | right-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``delta`` | −transverse (−z) | left-handed | ``alpha`` |
+| ``gamma`` | +vertical (+x) | right-handed | ``delta`` |
 
 **Shared stage:** alpha (rotary table base shared between sample and detector stacks)
 

--- a/docs/source/geometries/zaxis.md
+++ b/docs/source/geometries/zaxis.md
@@ -46,17 +46,17 @@ and mode configuration.
 
 **Sample stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``alpha`` | +vertical (+x) | right-handed, shared base |
-| ``Z`` | +longitudinal (+y) | right-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``alpha`` | +vertical (+x) | right-handed, shared base | base |
+| ``Z`` | +longitudinal (+y) | right-handed | ``alpha`` |
 
 **Detector stages (base first):**
 
-| Stage | Axis | Handedness |
-|---|---|---|
-| ``delta`` | −transverse (−z) | left-handed |
-| ``gamma`` | +vertical (+x) | right-handed |
+| Stage | Axis | Handedness | Parent |
+|---|---|---|---|
+| ``delta`` | −transverse (−z) | left-handed | ``alpha`` |
+| ``gamma`` | +vertical (+x) | right-handed | ``delta`` |
 
 **Shared stage:** alpha (base stage shared between sample and detector stacks)
 

--- a/src/ad_hoc_diffractometer/axes.py
+++ b/src/ad_hoc_diffractometer/axes.py
@@ -95,7 +95,7 @@ def parse_axis(label: str, basis: dict | None = None) -> np.ndarray:
     Raises
     ------
     ValueError
-        If the label is not recognised, or if a physical direction name is
+        If the label is not recognized, or if a physical direction name is
         given but no basis dict is supplied, or if the direction name is
         not in the basis dict.
 
@@ -144,7 +144,7 @@ def axis_label(vector: np.ndarray) -> str:
     """
     Convert an internal axis numpy array to its caller-facing string label.
 
-    Only the six standard signed basis vectors are recognised.  For other
+    Only the six standard signed basis vectors are recognized.  For other
     vectors (e.g. a kappa-style tilted axis) the array is formatted
     numerically.
 

--- a/src/ad_hoc_diffractometer/display.py
+++ b/src/ad_hoc_diffractometer/display.py
@@ -5,7 +5,7 @@ display.py — display precision settings and numeric comparison helper.
 
 Provides a package-level default number of decimal places for displaying
 floating-point values.  Any class or function that formats numbers for
-display should use get_precision() to honour the current setting.
+display should use get_precision() to honor the current setting.
 
 The default precision can be changed at the package level:
 

--- a/src/ad_hoc_diffractometer/drawing.py
+++ b/src/ad_hoc_diffractometer/drawing.py
@@ -568,7 +568,7 @@ def _tree_layout(stages):  # pragma: no cover
         0 for roots (bottom), increasing toward leaves (top).
     x_pos : dict  stage_name -> float
         Leaf nodes get integer slots 0, 1, 2, …
-        Parent nodes are centred over their children (may be half-integer).
+        Parent nodes are centered over their children (may be half-integer).
     children : dict  stage_name -> list[str]
     roots : list[str]
     """
@@ -604,7 +604,7 @@ def _tree_layout(stages):  # pragma: no cover
     for r in roots:
         leaves.extend(subtree_leaves(r))
 
-    # x position: leaf nodes get integer slots; parents centre over children
+    # x position: leaf nodes get integer slots; parents center over children
     x_pos = {}
 
     def assign_x(name):
@@ -967,9 +967,9 @@ class GeometryAxisFigure:  # pragma: no cover
     Stages are arranged as a directed graph following parent relationships.
     The graph flows bottom-to-top: root stages (``parent=None``) are at the
     bottom; each child is one row above its parent.  Leaf nodes are assigned
-    integer column slots; parents are centred over their children.
+    integer column slots; parents are centered over their children.
 
-    Role is indicated by scene background colour:
+    Role is indicated by scene background color:
 
     - sample   → aliceblue
     - detector → seashell

--- a/src/ad_hoc_diffractometer/geometry.py
+++ b/src/ad_hoc_diffractometer/geometry.py
@@ -204,7 +204,7 @@ class AdHocDiffractometer:
         ValueError
             If the basis does not have exactly three entries, if any vector
             is not 3-dimensional or is zero, or if any two vectors are not
-            mutually orthogonal (normalised dot product exceeds tolerance).
+            mutually orthogonal (normalized dot product exceeds tolerance).
         """
         vecs = list(self.basis.values())
         names = list(self.basis.keys())
@@ -230,7 +230,7 @@ class AdHocDiffractometer:
                 if abs(dot) > atol:
                     raise ValueError(
                         f"Basis vectors {n1!r} and {n2!r} are not orthogonal "
-                        f"(normalised dot product = {dot:.6g}, tolerance {atol})."
+                        f"(normalized dot product = {dot:.6g}, tolerance {atol})."
                     )
 
     def _check_no_cycles(self) -> None:
@@ -282,7 +282,7 @@ class AdHocDiffractometer:
         which are also available as the :attr:`sample_stages` and
         :attr:`detector_stages` attributes.  This method accepts any
         arbitrary role string, making it useful for non-standard components
-        such as analysers, polarisers, slits, or azimuthal spinners.
+        such as analyzers, polarizers, slits, or azimuthal spinners.
 
         Parameters
         ----------
@@ -301,10 +301,10 @@ class AdHocDiffractometer:
         >>> import numpy as np
         >>> from ad_hoc_diffractometer import Stage
         >>> g = ahd.fourcv()
-        >>> analyser = Stage("analyser", np.array([1., 0., 0.]), role="analyser")
-        >>> g._stages["analyser"] = analyser
-        >>> [s.name for s in g.stages_by_role("analyser")]
-        ['analyser']
+        >>> analyzer = Stage("analyzer", np.array([1., 0., 0.]), role="analyzer")
+        >>> g._stages["analyzer"] = analyzer
+        >>> [s.name for s in g.stages_by_role("analyzer")]
+        ['analyzer']
         >>> g.stages_by_role("unknown")
         []
         """
@@ -1167,7 +1167,7 @@ class AdHocDiffractometer:
     @property
     def detector_distance(self) -> float | None:
         """
-        Sample-to-detector distance in millimetres, or ``None`` if not set.
+        Sample-to-detector distance in millimeters, or ``None`` if not set.
 
         Relevant primarily for area detectors, where the distance is needed
         to convert pixel positions to scattering angles (and thence to Q).
@@ -1234,12 +1234,12 @@ class AdHocDiffractometer:
     @property
     def detector_offset(self) -> tuple[float, float] | None:
         """
-        In-plane detector offset (dx, dy) in millimetres, or ``None`` if not set.
+        In-plane detector offset (dx, dy) in millimeters, or ``None`` if not set.
 
-        Describes the displacement of the beam centre from the detector
-        centre in the detector plane.  ``dx`` is the horizontal offset and
-        ``dy`` is the vertical offset, both in millimetres.  A zero offset
-        means the beam strikes the geometric centre of the detector.
+        Describes the displacement of the beam center from the detector
+        center in the detector plane.  ``dx`` is the horizontal offset and
+        ``dy`` is the vertical offset, both in millimeters.  A zero offset
+        means the beam strikes the geometric center of the detector.
 
         Must be a two-element sequence of real numbers.
 
@@ -1498,7 +1498,7 @@ class AdHocDiffractometer:
         Parameters
         ----------
         axis : array-like, shape (3,)
-            Rotation axis (need not be a unit vector; it is normalised
+            Rotation axis (need not be a unit vector; it is normalized
             internally).
         angle_deg : float
             Rotation angle in degrees.

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -823,7 +823,7 @@ class ConstraintSet:
     ValueError
         If more than one ``ReferenceConstraint`` is supplied.
     ValueError
-        If any constraint is not a recognised constraint type.
+        If any constraint is not a recognized constraint type.
 
     Examples
     --------

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -169,7 +169,7 @@ def angles_to_phi_vector(geometry, **motor_angles: float) -> np.ndarray:
         for name, angle in saved.items():
             geometry.set_angle(name, angle)
 
-    # Incident-beam direction: longitudinal basis vector (normalised)
+    # Incident-beam direction: longitudinal basis vector (normalized)
     y_hat = np.asarray(geometry.basis["longitudinal"], dtype=float)
     y_norm = np.linalg.norm(y_hat)
     y_hat = y_hat / y_norm
@@ -208,8 +208,8 @@ def ub_from_one_reflection(
     The algorithm:
 
     1. Compute the crystal-frame direction: ``Bh = B @ reference_hkl``
-       (normalised to ``Bh_hat``).
-    2. Extract the lab-frame direction from ``reference_stage`` (normalised
+       (normalized to ``Bh_hat``).
+    2. Extract the lab-frame direction from ``reference_stage`` (normalized
        to ``r_hat``).
     3. Find the minimal rotation (Rodrigues) that takes ``Bh_hat`` to
        ``r_hat``:

--- a/src/ad_hoc_diffractometer/refinement.py
+++ b/src/ad_hoc_diffractometer/refinement.py
@@ -92,7 +92,7 @@ def _full_params_from_free(free_vals: dict, system: str) -> dict:
 
     Constructs a temporary ``Lattice`` from the free values plus any
     system-specific hint parameters (e.g. ``gamma=120`` for hexagonal)
-    needed for the ``Lattice`` class to recognise the correct system, then
+    needed for the ``Lattice`` class to recognize the correct system, then
     reads back all six parameters.
 
     Parameters
@@ -378,8 +378,8 @@ def refine_lattice_bl1967(
 
     Uses the Busing & Levy (1967) least-squares approach (§"Refinement of
     lattice and orientation parameters").  Starting from the current
-    ``sample.UB`` and ``sample.lattice``, iteratively solves the linearised
-    normal equations to minimise the sum of squared residuals between
+    ``sample.UB`` and ``sample.lattice``, iteratively solves the linearized
+    normal equations to minimize the sum of squared residuals between
     observed and calculated phi-frame scattering vectors.
 
     Observed vector for reflection i:
@@ -689,7 +689,7 @@ def refine_lattice_simplex(
     Notes
     -----
     The default ``refine_orientation=False`` leaves U fixed; only the
-    cell parameters (and thus B, and thus UB = U @ B) are optimised.
+    cell parameters (and thus B, and thus UB = U @ B) are optimized.
     This is the typical use case: use ``ub_from_two_reflections_bl1967``
     to get U, then use the simplex to find the best cell parameters.
 

--- a/src/ad_hoc_diffractometer/rotation.py
+++ b/src/ad_hoc_diffractometer/rotation.py
@@ -37,7 +37,7 @@ def rotation_matrix(axis: np.ndarray, angle_deg: float) -> np.ndarray:
     Parameters
     ----------
     axis : numpy.ndarray, shape (3,)
-        Rotation axis vector.  Need not be normalised; it will be normalised
+        Rotation axis vector.  Need not be normalized; it will be normalized
         internally.
     angle_deg : float
         Rotation angle in degrees (right-handed sense about the given axis).

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -93,7 +93,7 @@ scan shape.  Supported types:
 ``"radial"``
     Scan ±extent from center along a reciprocal-space direction.
     Required keys: ``"center": (h, k, l)``, ``"direction": (dh, dk, dl)``,
-    ``"extent": delta``.  The direction is normalised; extent is in r.l.u.
+    ``"extent": delta``.  The direction is normalized; extent is in r.l.u.
 
 ``"transverse"``
     Scan ±extent from center perpendicular to a reference Q direction.
@@ -272,7 +272,7 @@ def _hkl_points(trajectory: dict, n_points: int) -> list[tuple[float, float, flo
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers — Euler decomposition  (BL1967, generalised)
+# Internal helpers — Euler decomposition  (BL1967, generalized)
 # ---------------------------------------------------------------------------
 
 
@@ -312,7 +312,7 @@ def _euler_from_Z_standard(
     ``geometry.sample_rotation_matrix()``: the outermost stage (omega/eta)
     is applied first (rightmost), the innermost (phi) last (leftmost).
 
-    The decomposition generalises Busing & Levy (1967) eqs. 14-17 to
+    The decomposition generalizes Busing & Levy (1967) eqs. 14-17 to
     arbitrary signed stage axes.  Two χ branches are returned
     (χ ∈ [0°, 180°] and χ ∈ [-180°, 0°]).
 

--- a/src/ad_hoc_diffractometer/stage.py
+++ b/src/ad_hoc_diffractometer/stage.py
@@ -21,7 +21,7 @@ class Stage:
     """
     One rotary stage of a diffractometer.
 
-    Each stage is characterised by:
+    Each stage is characterized by:
       - a name (e.g. 'mu', 'eta', 'chi')
       - a rotation axis expressed as a signed Cartesian vector in the lab
         frame (e.g. +XHAT for right-handed vertical, -ZHAT for left-handed
@@ -48,7 +48,7 @@ class Stage:
         An arbitrary string label for bookkeeping.  The two conventional
         values are ``"sample"`` and ``"detector"``; any other string is
         accepted and can be used to model additional components such as
-        analysers, polarisers, slits, or azimuthal spinners.
+        analyzers, polarizers, slits, or azimuthal spinners.
         Geometry methods ``sample_stages`` and ``detector_stages`` filter
         by these conventional values; use
         :meth:`~ad_hoc_diffractometer.geometry.AdHocDiffractometer.stages_by_role`

--- a/src/ad_hoc_diffractometer/surface.py
+++ b/src/ad_hoc_diffractometer/surface.py
@@ -161,7 +161,7 @@ def _surface_vectors(
         for name, val in saved.items():
             geometry.set_angle(name, val)
 
-    # Incident-beam direction: longitudinal basis vector (normalised)
+    # Incident-beam direction: longitudinal basis vector (normalized)
     y_raw = np.asarray(geometry.basis["longitudinal"], dtype=float)
     y_hat = y_raw / np.linalg.norm(y_raw)
 

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -5,7 +5,7 @@ Unit tests for ad_hoc_diffractometer.drawing.
 
 Covers:
   - geometry_dot() produces valid DOT source for all preset geometries
-  - DOT source contains expected node names, edges, and role colours
+  - DOT source contains expected node names, edges, and role colors
   - _physical_label() and _handedness() helper functions
   - draw_stage_axis() returns a matplotlib Figure (if matplotlib available)
   - draw_geometry_axes() returns a matplotlib Figure (if matplotlib available)
@@ -188,12 +188,12 @@ def test_geometry_dot_contains_edges(factory):
 
 
 @pytest.mark.parametrize("factory", ALL_PRESETS)
-def test_geometry_dot_contains_role_colours(factory):
+def test_geometry_dot_contains_role_colors(factory):
     """Sample nodes are blue, detector nodes are red."""
     g = factory()
     dot = geometry_dot(g)
-    assert "#a8d8ea" in dot  # sample colour
-    assert "#f8a5a5" in dot  # detector colour
+    assert "#a8d8ea" in dot  # sample color
+    assert "#f8a5a5" in dot  # detector color
 
 
 def test_geometry_dot_sixc_shared_base():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1295,12 +1295,12 @@ def test_stages_by_role_custom():
     from ad_hoc_diffractometer.stage import Stage
 
     g = fourcv()
-    analyser = Stage("analyser", np.array([1.0, 0.0, 0.0]), role="analyser")
-    g._stages["analyser"] = analyser
+    analyzer = Stage("analyzer", np.array([1.0, 0.0, 0.0]), role="analyzer")
+    g._stages["analyzer"] = analyzer
 
-    result = g.stages_by_role("analyser")
+    result = g.stages_by_role("analyzer")
     assert len(result) == 1
-    assert result[0].name == "analyser"
+    assert result[0].name == "analyzer"
 
 
 def test_stages_by_role_unknown_returns_empty():
@@ -1308,7 +1308,7 @@ def test_stages_by_role_unknown_returns_empty():
     from ad_hoc_diffractometer.presets import fourcv
 
     g = fourcv()
-    assert g.stages_by_role("polariser") == []
+    assert g.stages_by_role("polarizer") == []
 
 
 def test_stages_by_role_sample_matches_sample_stages():

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -101,7 +101,7 @@ def test_reflection_name_stored():
     assert r.name == "Si_111"
 
 
-def test_reflection_hkl_normalised_to_float():
+def test_reflection_hkl_normalized_to_float():
     r = Reflection(name="r1", hkl=(1, 2, 3), angles={})
     assert r.hkl == (1.0, 2.0, 3.0)
 

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -64,7 +64,7 @@ from ad_hoc_diffractometer.rotation import rotation_matrix
             id="negated-x-axis-equals-negated-angle",
         ),
         pytest.param(
-            2 * XHAT, 90.0, Rx(90), does_not_raise(), id="non-unit-axis-is-normalised"
+            2 * XHAT, 90.0, Rx(90), does_not_raise(), id="non-unit-axis-is-normalized"
         ),
         pytest.param(YHAT, 360.0, np.eye(3), does_not_raise(), id="360deg-is-identity"),
     ],

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -4,7 +4,7 @@
 Unit tests for ad_hoc_diffractometer.scan.
 
 Covers:
-  - NEAREST_ANGLES: scoring, previous=None, minimises distance
+  - NEAREST_ANGLES: scoring, previous=None, minimizes distance
   - _hkl_points: line, radial, transverse; n_points<2; unknown type; zero direction
   - _pick_solution: None key, custom key, empty list
   - _euler_from_Z_standard: round-trip decomposition for fourcv and psic


### PR DESCRIPTION
- closes #198

## Summary

- Add a **Parent** column to the stage-layout tables in all 10 geometry
  reference pages.  Floor-mounted stages show `base`; child stages show
  the parent name in code font.  Column order: Stage | Axis | Handedness | Parent.
- Replace British spellings with US English equivalents across all source
  and test files (analyzer, normalized, recognized, color, center, etc.).
- Update AGENTS.md: add US English spelling directive to Code style
  guidelines; strengthen step 4 to require creating a feature branch
  before making any file changes.

Contributed by: OpenCode (argo/claudeopus46)