### PR TITLE
fix: correct arc arrow direction for all axes including kappa

### DIFF
--- a/src/ad_hoc_diffractometer/drawing.py
+++ b/src/ad_hoc_diffractometer/drawing.py
@@ -21,10 +21,14 @@ Plotly is an optional dependency.  Both classes raise
 """
 
 from __future__ import annotations
+import logging
 
 import numpy as np
 
 from .axes import axis_label
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 def _physical_label(axis_vec: np.ndarray, basis: dict | None) -> str:
@@ -321,13 +325,21 @@ class StageAxisFigure:  # pragma: no cover
     def _draw_axis(self) -> None:
         """Draw the axis vector and rotation arc."""
         axis_norm = self._draw_axis_vector()
+        logger.debug("----> _draw_axis: %r", self.stage.name)
+        logger.debug("stage.axis=%s", self.stage.axis)
+        logger.debug("geometry.basis=%s", self.geometry.basis)
+        logger.debug("axis_norm=%s", axis_norm)
 
         stage_axis = np.asarray(self.stage.axis, dtype=float)
         stage_norm = stage_axis / np.linalg.norm(stage_axis)
+        logger.debug("stage_norm=%s", stage_norm)
         # Arc sweep direction encodes handedness: +1 for right-handed
         # (stage axis parallel to drawn axis), -1 for left-handed
         # (stage axis anti-parallel, i.e. negated).
-        direction = +1 if np.dot(stage_norm, axis_norm) > 0 else -1
+        dot = np.dot(stage_norm, axis_norm)
+        logger.debug("dot=%s", dot)
+        direction = +1 if dot > 0 else -1
+        logger.debug("direction=%s", direction)
 
         self._draw_axis_arc(axis_norm, direction=direction)
 
@@ -365,6 +377,9 @@ class StageAxisFigure:  # pragma: no cover
             return
 
         axis_d = self.R @ axis_norm
+        logger.debug("  ->-> _draw_axis_arc:  direction=%s", direction)
+        logger.debug("R @ axis_norm=%s", axis_d)
+        logger.debug("R @ (direction * axis_norm)=%s", self.R @ (direction * axis_norm))
 
         eye = np.array([0.92, 1.18, -0.10])
         view_dir = -eye / np.linalg.norm(eye)
@@ -387,10 +402,17 @@ class StageAxisFigure:  # pragma: no cover
 
         if direction < 0:
             perp2_d = -perp2_d
+        logger.debug("perp1_d=%s", perp1_d)
+        logger.debug("perp2_d=%s", perp2_d)
 
         arc_radius = 0.1
         arc_center_d = axis_d * 0.45
-        arc_angles = np.linspace(-np.pi / 3, np.pi / 3, 60)
+        # FIXME: computed offset correct for all except kappa
+        # kappa direction=1 (correct) arrow expected CCW, drawn CW
+        offset = -direction * np.pi / 3
+        logger.debug("offset=%s", offset)
+        arc_angles = np.linspace(-offset, offset, 60)
+        logger.debug("arc_angles=%s", np.degrees(arc_angles))
         arc_pts_d = np.array(
             [
                 arc_center_d + arc_radius * (np.cos(a) * perp1_d + np.sin(a) * perp2_d)
@@ -519,6 +541,7 @@ class GeometryAxisFigure:  # pragma: no cover
 
         self._go = go
         self._fig = go.Figure(**kwargs)
+        logger.debug("===> geometry: %r", geometry_name)
 
         factory = getattr(_presets, geometry_name)
         geometry = factory()

--- a/src/ad_hoc_diffractometer/drawing.py
+++ b/src/ad_hoc_diffractometer/drawing.py
@@ -21,13 +21,13 @@ Plotly is an optional dependency.  Both classes raise
 """
 
 from __future__ import annotations
+
 import logging
 
 import numpy as np
 
 from .axes import axis_label
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
@@ -201,6 +201,7 @@ class StageAxisFigure:  # pragma: no cover
         self.geometry = factory()
         self.stage = self.geometry._stages[axis_name]
         self.R = None  # set in _draw_basis_vectors
+        logger.debug("StageAxisFigure: %s / %s", geometry_name, axis_name)
 
         self._draw_basis_vectors(axis_labels=axis_labels)
         self._draw_axis()
@@ -325,21 +326,20 @@ class StageAxisFigure:  # pragma: no cover
     def _draw_axis(self) -> None:
         """Draw the axis vector and rotation arc."""
         axis_norm = self._draw_axis_vector()
-        logger.debug("----> _draw_axis: %r", self.stage.name)
-        logger.debug("stage.axis=%s", self.stage.axis)
-        logger.debug("geometry.basis=%s", self.geometry.basis)
-        logger.debug("axis_norm=%s", axis_norm)
 
         stage_axis = np.asarray(self.stage.axis, dtype=float)
         stage_norm = stage_axis / np.linalg.norm(stage_axis)
-        logger.debug("stage_norm=%s", stage_norm)
         # Arc sweep direction encodes handedness: +1 for right-handed
         # (stage axis parallel to drawn axis), -1 for left-handed
         # (stage axis anti-parallel, i.e. negated).
-        dot = np.dot(stage_norm, axis_norm)
-        logger.debug("dot=%s", dot)
-        direction = +1 if dot > 0 else -1
-        logger.debug("direction=%s", direction)
+        direction = +1 if np.dot(stage_norm, axis_norm) > 0 else -1
+        logger.debug(
+            "%s: stage_axis=%s  axis_norm=%s  direction=%+d",
+            self.stage.name,
+            stage_axis,
+            axis_norm,
+            direction,
+        )
 
         self._draw_axis_arc(axis_norm, direction=direction)
 
@@ -377,9 +377,6 @@ class StageAxisFigure:  # pragma: no cover
             return
 
         axis_d = self.R @ axis_norm
-        logger.debug("  ->-> _draw_axis_arc:  direction=%s", direction)
-        logger.debug("R @ axis_norm=%s", axis_d)
-        logger.debug("R @ (direction * axis_norm)=%s", self.R @ (direction * axis_norm))
 
         eye = np.array([0.92, 1.18, -0.10])
         view_dir = -eye / np.linalg.norm(eye)
@@ -392,27 +389,26 @@ class StageAxisFigure:  # pragma: no cover
         if np.linalg.norm(perp1_d) < 1e-6:
             perp1_d = screen_up - np.dot(screen_up, axis_d) * axis_d
         perp1_d /= np.linalg.norm(perp1_d)
+
+        # Build a right-handed perpendicular frame: cross(axis_d, perp1_d)
+        # guarantees (perp1_d, perp2_d, axis_d) is right-handed, so
+        # sweeping from -π/3 to +π/3 draws a right-handed (CCW) arc.
+        # For left-handed stages (direction=-1), flip perp2_d to reverse
+        # the visual sweep sense.
         perp2_d = np.cross(axis_d, perp1_d)
-
-        r0 = np.array([np.dot(perp1_d, screen_right), np.dot(perp1_d, screen_up)])
-        r1 = np.array([np.dot(perp2_d, screen_right), np.dot(perp2_d, screen_up)])
-        cross_2d = r0[0] * r1[1] - r0[1] * r1[0]
-        if cross_2d > 0:
-            perp2_d = -perp2_d
-
         if direction < 0:
             perp2_d = -perp2_d
-        logger.debug("perp1_d=%s", perp1_d)
-        logger.debug("perp2_d=%s", perp2_d)
+        logger.debug(
+            "_draw_axis_arc: direction=%+d  axis_d=%s  perp1_d=%s  perp2_d=%s",
+            direction,
+            axis_d,
+            perp1_d,
+            perp2_d,
+        )
 
         arc_radius = 0.1
         arc_center_d = axis_d * 0.45
-        # FIXME: computed offset correct for all except kappa
-        # kappa direction=1 (correct) arrow expected CCW, drawn CW
-        offset = -direction * np.pi / 3
-        logger.debug("offset=%s", offset)
-        arc_angles = np.linspace(-offset, offset, 60)
-        logger.debug("arc_angles=%s", np.degrees(arc_angles))
+        arc_angles = np.linspace(-np.pi / 3, np.pi / 3, 60)
         arc_pts_d = np.array(
             [
                 arc_center_d + arc_radius * (np.cos(a) * perp1_d + np.sin(a) * perp2_d)
@@ -541,11 +537,15 @@ class GeometryAxisFigure:  # pragma: no cover
 
         self._go = go
         self._fig = go.Figure(**kwargs)
-        logger.debug("===> geometry: %r", geometry_name)
 
         factory = getattr(_presets, geometry_name)
         geometry = factory()
         stages = geometry._stages
+        logger.debug(
+            "GeometryAxisFigure: %s  stages=%s",
+            geometry_name,
+            list(stages),
+        )
 
         depth, x_pos, children, roots = _tree_layout(stages)
         max_depth = max(depth.values())

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -5,6 +5,7 @@ Unit tests for ad_hoc_diffractometer.drawing.
 
 Covers:
   - _physical_label() helper function
+  - arc direction handedness for all preset geometry stages
 """
 
 from contextlib import nullcontext as does_not_raise
@@ -12,6 +13,7 @@ from contextlib import nullcontext as does_not_raise
 import numpy as np
 import pytest
 
+import ad_hoc_diffractometer as ahd
 from ad_hoc_diffractometer.drawing import _physical_label
 from ad_hoc_diffractometer.factories import BASIS_BL
 from ad_hoc_diffractometer.factories import BASIS_YOU
@@ -73,3 +75,93 @@ def test_physical_label(axis_vec, basis, expected, context):
     with context:
         result = _physical_label(axis_vec, basis)
         assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Arc direction handedness — reproduces the math from _draw_axis and
+# _draw_axis_arc to verify the perpendicular frame has the correct
+# handedness for every stage of every preset geometry.
+#
+# The invariant:
+#   direction=+1 (right-handed stage) => dot(cross(perp1, perp2), axis_d) > 0
+#   direction=-1 (left-handed stage)  => dot(cross(perp1, perp2), axis_d) < 0
+#
+# This ensures a sweep from -π/3 to +π/3 draws the arc in the
+# physically correct rotation sense.  See issue #207.
+# ---------------------------------------------------------------------------
+
+
+def _build_arc_params():
+    """Generate (geometry_name, stage_name) pairs for all presets."""
+    params = []
+    for geom_name in ahd.list_geometries():
+        factory = getattr(ahd.presets, geom_name)
+        geometry = factory()
+        for stage_name in geometry._stages:
+            params.append(
+                pytest.param(
+                    geom_name,
+                    stage_name,
+                    does_not_raise(),
+                    id=f"{geom_name}-{stage_name}",
+                )
+            )
+    return params
+
+
+@pytest.mark.parametrize("geometry_name, stage_name, context", _build_arc_params())
+def test_arc_direction_handedness(geometry_name, stage_name, context):
+    """Perpendicular frame handedness matches stage rotation direction.
+
+    Reproduces the exact math from _draw_axis / _draw_axis_arc (without
+    Plotly) and checks the handedness invariant for every preset stage.
+    """
+    with context:
+        factory = getattr(ahd.presets, geometry_name)
+        geometry = factory()
+        stage = geometry._stages[stage_name]
+        basis = geometry.basis
+
+        # -- _draw_basis_vectors: compute display rotation R --
+        ver = np.asarray(basis["vertical"], dtype=float)
+        lon = np.asarray(basis["longitudinal"], dtype=float)
+        lat = np.asarray(basis["transverse"], dtype=float)
+        R = np.array([lat, -lon, ver])
+
+        # -- _draw_axis_vector: normalize and flip to positive --
+        stage_axis = np.asarray(stage.axis, dtype=float)
+        axis_norm = stage_axis / np.linalg.norm(stage_axis)
+        for component in axis_norm:
+            if abs(component) > 1e-9:
+                if component < 0:
+                    axis_norm = -axis_norm
+                break
+
+        # -- _draw_axis: compute direction --
+        stage_norm = stage_axis / np.linalg.norm(stage_axis)
+        direction = +1 if np.dot(stage_norm, axis_norm) > 0 else -1
+
+        # -- _draw_axis_arc: build perpendicular frame --
+        axis_d = R @ axis_norm
+
+        eye = np.array([0.92, 1.18, -0.10])
+        view_dir = -eye / np.linalg.norm(eye)
+        cam_up = np.array([0.0, 0.0, 1.0])
+        screen_right = np.cross(cam_up, view_dir)
+        screen_right /= np.linalg.norm(screen_right)
+        screen_up = np.cross(view_dir, screen_right)
+
+        perp1_d = screen_right - np.dot(screen_right, axis_d) * axis_d
+        if np.linalg.norm(perp1_d) < 1e-6:
+            perp1_d = screen_up - np.dot(screen_up, axis_d) * axis_d
+        perp1_d /= np.linalg.norm(perp1_d)
+
+        perp2_d = np.cross(axis_d, perp1_d)
+        if direction < 0:
+            perp2_d = -perp2_d
+
+        # -- invariant: frame handedness must match direction --
+        handedness = np.dot(np.cross(perp1_d, perp2_d), axis_d)
+        assert handedness == pytest.approx(float(direction), abs=1e-10), (
+            f"{geometry_name}/{stage_name}: expected {direction}, got {handedness}"
+        )


### PR DESCRIPTION
## Summary

- closes #207
- Fixes rotation-arc arrow direction in geometry drawings for all axis types (cardinal and oblique/kappa)
- Replaces the broken `cross_2d` screen-orientation correction in `_draw_axis_arc()` with a deterministic right-handed perpendicular frame via `np.cross(axis_d, perp1_d)`, flipped only for `direction=-1` (left-handed) stages
- Adds 47 parametrized tests verifying the handedness invariant for every stage of all 10 preset geometries
- Adds diagnostic `logger.debug()` calls to key drawing methods for future troubleshooting

Contributed by: OpenCode (argo/claudeopus46)