### PR TITLE
fix: update version switcher and prevent future regression

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,24 @@ jobs:
         run: |
           python3 -m sphinx -b html docs/source docs/build/html
 
+      - name: Preserve live switcher.json from gh-pages
+        # On main-push deploys, the build output contains the source-repo
+        # switcher.json which only lists versions known at commit time.
+        # The live gh-pages copy has been updated by tag-push CI to include
+        # all released versions.  Fetch it and overlay it into the build
+        # output so the deploy does not regress the version switcher.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          LIVE_URL="https://prjemian.github.io/ad_hoc_diffractometer/latest/_static/switcher.json"
+          TARGET="docs/build/html/_static/switcher.json"
+          if curl -fsSL "${LIVE_URL}" -o /tmp/live_switcher.json 2>/dev/null; then
+            cp /tmp/live_switcher.json "${TARGET}"
+            echo "Preserved live switcher.json from gh-pages"
+          else
+            echo "No live switcher.json found; using source-repo version"
+          fi
+
       - name: Upload docs as workflow artifact
         uses: actions/upload-artifact@v7
         with:

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -4,9 +4,21 @@
         "url": "https://prjemian.github.io/ad_hoc_diffractometer/latest/"
     },
     {
-        "version": "v0.3.1",
-        "url": "https://prjemian.github.io/ad_hoc_diffractometer/v0.3.1/",
+        "version": "v0.5.0",
+        "url": "https://prjemian.github.io/ad_hoc_diffractometer/v0.5.0/",
         "preferred": true
+    },
+    {
+        "version": "v0.4.1",
+        "url": "https://prjemian.github.io/ad_hoc_diffractometer/v0.4.1/"
+    },
+    {
+        "version": "v0.4.0",
+        "url": "https://prjemian.github.io/ad_hoc_diffractometer/v0.4.0/"
+    },
+    {
+        "version": "v0.3.1",
+        "url": "https://prjemian.github.io/ad_hoc_diffractometer/v0.3.1/"
     },
     {
         "version": "v0.3.0",


### PR DESCRIPTION
## Summary

- closes #216
- Adds missing versions (v0.4.0, v0.4.1, v0.5.0) to `switcher.json` and marks v0.5.0 as the preferred stable release
- Fixes the root cause: main-push deploys were overwriting the live `switcher.json` on gh-pages with the stale source-repo copy, erasing versions added by tag-push CI. A new workflow step now fetches the live `switcher.json` from gh-pages before deploying, preserving all tag-push updates.

Contributed by: OpenCode (argo/claudeopus46)