### PR TITLE
refactor: standardize mode names to fixed_AXIS pattern

### DIFF
--- a/docs/source/concepts.md
+++ b/docs/source/concepts.md
@@ -276,7 +276,7 @@ vectors may be set:
 - **`surface_normal`** — direction perpendicular to the sample surface;
   used by incidence/exit angle functions and surface diffraction modes.
 - **`azimuthal_reference`** — direction defining ψ = 0; used by
-  `psi_angle` and `psi_constant_*` modes.
+  `psi_angle` and `fixed_psi_*` modes.
 
 ```python
 g.surface_normal = (0, 0, 1)    # (001)-cut sample

--- a/docs/source/geometries/fivec.md
+++ b/docs/source/geometries/fivec.md
@@ -119,7 +119,7 @@ Intended for non-zero mu once the tilted-plane solver is implemented.
 | **Computed** | omega, chi, phi, ttheta |
 | **Constant during** `forward()` | mu |
 
-### `constant_omega_noncoplanar`
+### `fixed_omega_noncoplanar`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint` × 2:
 `mu = 0`.

--- a/docs/source/geometries/fourch.md
+++ b/docs/source/geometries/fourch.md
@@ -100,7 +100,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | omega, chi, ttheta |
 | **Constant during** `forward()` | phi |
 
-### `constant_omega`
+### `fixed_omega`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 `omega` is held at the value declared in the constraint (factory default: 0°).
@@ -111,7 +111,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | chi, phi, ttheta |
 | **Constant during** `forward()` | omega |
 
-### `psi_constant`
+### `fixed_psi`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 azimuthal angle ψ validation filter.

--- a/docs/source/geometries/fourcv.md
+++ b/docs/source/geometries/fourcv.md
@@ -100,7 +100,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | omega, chi, ttheta |
 | **Constant during** `forward()` | phi |
 
-### `constant_omega`
+### `fixed_omega`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 `omega` is held at the value declared in the constraint (factory default: 0°).
@@ -111,7 +111,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | chi, phi, ttheta |
 | **Constant during** `forward()` | omega |
 
-### `psi_constant`
+### `fixed_psi`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 azimuthal angle ψ validation filter.

--- a/docs/source/geometries/kappa4ch.md
+++ b/docs/source/geometries/kappa4ch.md
@@ -93,7 +93,7 @@ changing constraint values at run time.
 | **Computed** | komega, kappa, ttheta |
 | **Constant during** `forward()` | kphi |
 
-### `constant_omega`
+### `fixed_omega`
 
 Fix virtual Eulerian omega at declared value (default 0°) — see {doc}`kappa4cv` for details.
 
@@ -102,7 +102,7 @@ Fix virtual Eulerian omega at declared value (default 0°) — see {doc}`kappa4c
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | omega (virtual) |
 
-### `constant_chi`
+### `fixed_chi`
 
 Fix virtual Eulerian chi at declared value (default 90°).
 
@@ -111,7 +111,7 @@ Fix virtual Eulerian chi at declared value (default 90°).
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | chi (virtual) |
 
-### `constant_phi`
+### `fixed_phi`
 
 Fix virtual Eulerian phi at declared value (default 0°).
 
@@ -120,7 +120,7 @@ Fix virtual Eulerian phi at declared value (default 0°).
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | phi (virtual) |
 
-### `psi_constant`
+### `fixed_psi`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 azimuthal angle ψ validation filter.

--- a/docs/source/geometries/kappa4cv.md
+++ b/docs/source/geometries/kappa4cv.md
@@ -93,7 +93,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | komega, kappa, ttheta |
 | **Constant during** `forward()` | kphi |
 
-### `constant_omega`
+### `fixed_omega`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian omega at declared value (default 0°).
@@ -105,7 +105,7 @@ constructing a {class}`~ad_hoc_diffractometer.mode.ConstraintSet`.
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | omega (virtual) |
 
-### `constant_chi`
+### `fixed_chi`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian chi at declared value (default 90°).
@@ -116,7 +116,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | chi (virtual) |
 
-### `constant_phi`
+### `fixed_phi`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 Fix the virtual Eulerian phi at declared value (default 0°).
@@ -127,7 +127,7 @@ The caller chooses the value by constructing a {class}`~ad_hoc_diffractometer.mo
 | **Computed** | komega, kappa, kphi, ttheta |
 | **Constant during** `forward()` | phi (virtual) |
 
-### `psi_constant`
+### `fixed_psi`
 
 {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint`:
 azimuthal angle ψ validation filter.

--- a/docs/source/geometries/s2d2.md
+++ b/docs/source/geometries/s2d2.md
@@ -64,7 +64,7 @@ Each mode is a {class}`~ad_hoc_diffractometer.mode.ConstraintSet` of 1 constrain
 (N − 3 = 1 for N = 4 DOF).
 See {doc}`../howto/constraints` for the constraint framework.
 
-### `mu_fixed`
+### `fixed_mu`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
 `mu` held at declared value (default 0°) — the incidence angle when the

--- a/docs/source/howto/constraints.md
+++ b/docs/source/howto/constraints.md
@@ -204,8 +204,8 @@ and {data}`~ad_hoc_diffractometer.mode.OPTIONAL` sentinels:
 ```python
 from ad_hoc_diffractometer import REQUIRED, OPTIONAL, ConstraintSet, ReferenceConstraint
 
-# psi_constant mode on fourcv: requires a reference vector n̂
-cs = g.modes["psi_constant"]
+# fixed_psi mode on fourcv: requires a reference vector n̂
+cs = g.modes["fixed_psi"]
 print(cs.extras)
 # {'n_hat': <REQUIRED>, 'psi': None}
 # n_hat must be supplied; psi is an output populated by the solver
@@ -226,14 +226,14 @@ the prerequisite is met:
 
 ```python
 g = ahd.presets.fourcv()
-g.mode_name = "psi_constant"
+g.mode_name = "fixed_psi"
 
 # Without azimuthal_reference: not implemented
-print(g.modes["psi_constant"].is_implemented(g))  # False
+print(g.modes["fixed_psi"].is_implemented(g))  # False
 
 # With azimuthal_reference: implemented
 g.azimuthal_reference = (0, 0, 1)
-print(g.modes["psi_constant"].is_implemented(g))  # True
+print(g.modes["fixed_psi"].is_implemented(g))  # True
 ```
 
 ## Serialisation

--- a/docs/source/howto/forward.md
+++ b/docs/source/howto/forward.md
@@ -172,8 +172,8 @@ try:
 except NotImplementedError as e:
     print(e)
 
-# psi_constant requires azimuthal_reference to be set
-g.mode_name = "psi_constant"
+# fixed_psi requires azimuthal_reference to be set
+g.mode_name = "fixed_psi"
 g.azimuthal_reference = None
 try:
     g.forward(1, 0, 0)

--- a/docs/source/howto/modes.md
+++ b/docs/source/howto/modes.md
@@ -14,8 +14,8 @@ import ad_hoc_diffractometer as ahd
 
 g = ahd.presets.fourcv()
 print(list(g.modes.keys()))
-# ['bisecting', 'fixed_chi', 'fixed_phi', 'constant_omega',
-#  'psi_constant', 'double_diffraction']
+# ['bisecting', 'fixed_chi', 'fixed_phi', 'fixed_omega',
+#  'fixed_psi', 'double_diffraction']
 ```
 
 ## Get and set the active mode
@@ -78,12 +78,12 @@ sols_60 = g.forward(1, 0, 0)   # chi = 60° this call
 
 See {doc}`constraints` for the full run-time pattern.
 
-### constant_omega
+### fixed_omega
 
 Holds `omega` at 0° (any geometry where omega is a sample stage).
 
 ```python
-g.mode_name = "constant_omega"
+g.mode_name = "fixed_omega"
 solutions = g.forward(1, 0, 0)
 # sol["omega"] == 0.0 for every solution
 ```
@@ -113,14 +113,14 @@ print(cs.is_implemented(g))
 ## Check if a mode is implemented
 
 Some modes require a prerequisite on the geometry.  For example,
-`psi_constant` requires ``g.azimuthal_reference`` to be set:
+`fixed_psi` requires ``g.azimuthal_reference`` to be set:
 
 ```python
-g.mode_name = "psi_constant"
-print(g.modes["psi_constant"].is_implemented(g))  # False (no azimuthal_reference)
+g.mode_name = "fixed_psi"
+print(g.modes["fixed_psi"].is_implemented(g))  # False (no azimuthal_reference)
 
 g.azimuthal_reference = (0, 0, 1)
-print(g.modes["psi_constant"].is_implemented(g))  # True
+print(g.modes["fixed_psi"].is_implemented(g))  # True
 
 # forward() raises NotImplementedError for unimplemented modes
 ```

--- a/docs/source/howto/performance.md
+++ b/docs/source/howto/performance.md
@@ -33,7 +33,7 @@ The output is a formatted table:
 geometry   mode                     status       fwd ops/s  inv ops/s  fwd/inv  round-trip err  solns
 fourcv     bisecting                ok               3,241     18,502   0.1752        4.70e-13     11
 fourcv     fixed_chi                ok               2,890     18,102   0.1596        3.40e-14     21
-fourcv     psi_constant             no_solutions      8,780          -       -               -      0
+fourcv     fixed_psi                no_solutions      8,780          -       -               -      0
 ```
 
 ## Output columns

--- a/docs/source/howto/surface.md
+++ b/docs/source/howto/surface.md
@@ -19,7 +19,7 @@ Two separate reference vectors may be set:
   used by `alpha_i`, `alpha_f`, `incidence_angle`, `exit_angle`, and
   surface modes (`zaxis`, `reflectivity`, `alpha_eq_beta_zaxis`).
 - **`azimuthal_reference`** — the direction used to define ψ = 0, used by
-  `psi_angle` and `psi_constant_*` modes.
+  `psi_angle` and `fixed_psi_*` modes.
 
 They may be the same vector (e.g. the surface normal is also the azimuthal
 reference) or different.
@@ -161,7 +161,7 @@ print(g2.surface_normal)          # (0.0, 0.0, 1.0)
 ## Reference constraint modes
 
 Modes that use a ``ReferenceConstraint`` require the appropriate reference
-vector to be set on the geometry.  ``psi_constant_*`` modes require
+vector to be set on the geometry.  ``fixed_psi_*`` modes require
 ``azimuthal_reference``; surface modes (``zaxis``, ``reflectivity``) require
 ``surface_normal``.
 
@@ -179,7 +179,7 @@ print(rc.is_implemented(g))          # True  — solver available
 solutions = g.forward(1, 0, 0)
 ```
 
-The ``psi_constant`` solver acts as a **validation filter**: ψ is a pure
+The ``fixed_psi`` solver acts as a **validation filter**: ψ is a pure
 phi-frame quantity that is the same for every Bragg solution of a given
 (h,k,l) and UB.  The solver computes the natural ψ and returns solutions
 only if it matches the stored target — otherwise it returns an empty list.

--- a/src/ad_hoc_diffractometer/benchmark.py
+++ b/src/ad_hoc_diffractometer/benchmark.py
@@ -97,7 +97,7 @@ def _prepare_mode(geometry, mode_name: str) -> None:
     Sets ``mode_name`` on the geometry and provides the minimum setup
     required for modes that need extra configuration:
 
-    - psi_constant modes: sets ``azimuthal_reference``
+    - fixed_psi modes: sets ``azimuthal_reference``
     - double_diffraction modes: sets h2/k2/l2 extras
     - surface/reference modes (alpha_i, beta_out, a_eq_b):
       sets ``surface_normal``

--- a/src/ad_hoc_diffractometer/presets.py
+++ b/src/ad_hoc_diffractometer/presets.py
@@ -434,11 +434,11 @@ def fourcv(basis: dict = BASIS_BL) -> AdHocDiffractometer:
             [SampleConstraint("phi", 0.0)],
             computed=["omega", "chi", "ttheta"],
         ),
-        "constant_omega": ConstraintSet(
+        "fixed_omega": ConstraintSet(
             [SampleConstraint("omega", 0.0)],
             computed=["chi", "phi", "ttheta"],
         ),
-        "psi_constant": ConstraintSet(
+        "fixed_psi": ConstraintSet(
             [ReferenceConstraint("psi", 0.0)],
             computed=["omega", "chi", "phi", "ttheta"],
             extras={"n_hat": REQUIRED, "psi": None},
@@ -510,11 +510,11 @@ def fourch(basis: dict = BASIS_BL) -> AdHocDiffractometer:
             [SampleConstraint("phi", 0.0)],
             computed=["omega", "chi", "ttheta"],
         ),
-        "constant_omega": ConstraintSet(
+        "fixed_omega": ConstraintSet(
             [SampleConstraint("omega", 0.0)],
             computed=["chi", "phi", "ttheta"],
         ),
-        "psi_constant": ConstraintSet(
+        "fixed_psi": ConstraintSet(
             [ReferenceConstraint("psi", 0.0)],
             computed=["omega", "chi", "phi", "ttheta"],
             extras={"n_hat": REQUIRED, "psi": None},
@@ -714,19 +714,19 @@ def kappa4cv(
             [SampleConstraint("kphi", 0.0)],
             computed=["komega", "kappa", "ttheta"],
         ),
-        "constant_omega": ConstraintSet(
+        "fixed_omega": ConstraintSet(
             [SampleConstraint("omega", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "constant_chi": ConstraintSet(
+        "fixed_chi": ConstraintSet(
             [SampleConstraint("chi", 90.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "constant_phi": ConstraintSet(
+        "fixed_phi": ConstraintSet(
             [SampleConstraint("phi", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "psi_constant": ConstraintSet(
+        "fixed_psi": ConstraintSet(
             [ReferenceConstraint("psi", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
             extras={"n_hat": REQUIRED, "psi": None},
@@ -804,19 +804,19 @@ def kappa4ch(
             [SampleConstraint("kphi", 0.0)],
             computed=["komega", "kappa", "ttheta"],
         ),
-        "constant_omega": ConstraintSet(
+        "fixed_omega": ConstraintSet(
             [SampleConstraint("omega", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "constant_chi": ConstraintSet(
+        "fixed_chi": ConstraintSet(
             [SampleConstraint("chi", 90.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "constant_phi": ConstraintSet(
+        "fixed_phi": ConstraintSet(
             [SampleConstraint("phi", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
         ),
-        "psi_constant": ConstraintSet(
+        "fixed_psi": ConstraintSet(
             [ReferenceConstraint("psi", 0.0)],
             computed=["komega", "kappa", "kphi", "ttheta"],
             extras={"n_hat": REQUIRED, "psi": None},
@@ -1118,7 +1118,7 @@ def s2d2(basis: dict = BASIS_YOU) -> AdHocDiffractometer:
     ]
     # s2d2: 4 DOF, N-3=1 constraint needed per mode.
     modes = {
-        "mu_fixed": ConstraintSet(
+        "fixed_mu": ConstraintSet(
             [SampleConstraint("mu", 0.0)],
             computed=["Z", "nu", "delta"],
         ),
@@ -1209,7 +1209,7 @@ def fivec(basis: dict = BASIS_YOU) -> AdHocDiffractometer:
             ],
             computed=["omega", "chi", "phi", "ttheta"],
         ),
-        "constant_omega_noncoplanar": ConstraintSet(
+        "fixed_omega_noncoplanar": ConstraintSet(
             [
                 SampleConstraint("mu", 0.0),
                 SampleConstraint("omega", 0.0),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -110,11 +110,11 @@ class TestPrepareMode:
             for key in ("h2", "k2", "l2"):
                 assert isinstance(cs.extras[key], float)
 
-    def test_psi_constant_sets_reference(self):
-        """psi_constant modes get an azimuthal_reference if not set."""
+    def test_fixed_psi_sets_reference(self):
+        """fixed_psi modes get an azimuthal_reference if not set."""
         g = _setup_geometry("fourcv")
         assert g.azimuthal_reference is None
-        _prepare_mode(g, "psi_constant")
+        _prepare_mode(g, "fixed_psi")
         assert g.azimuthal_reference is not None
 
     @pytest.mark.parametrize(
@@ -205,10 +205,10 @@ class TestBenchmarkMode:
 
     def test_no_solutions_status(self):
         """A mode that returns no solutions for the given reflections."""
-        # psi_constant on fourcv with default setup rarely matches
-        r = benchmark_mode("fourcv", "psi_constant", reflections=[(1, 0, 0)], n_iter=1)
+        # fixed_psi on fourcv with default setup rarely matches
+        r = benchmark_mode("fourcv", "fixed_psi", reflections=[(1, 0, 0)], n_iter=1)
         assert r["status"] in ("no_solutions", "not_implemented", "ok")
-        # For psi_constant the likely outcome is no_solutions or not_implemented
+        # For fixed_psi the likely outcome is no_solutions or not_implemented
         if r["status"] == "no_solutions":
             assert r["inverse_ops_per_sec"] is None
             assert r["forward_inverse_ratio"] is None

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -293,14 +293,14 @@ def test_kappa4cv_bisecting_round_trip():
 _KAPPA4_BASE_MODES = {
     "bisecting",
     "fixed_kphi",
-    "constant_omega",
-    "constant_chi",
-    "constant_phi",
-    "psi_constant",
+    "fixed_omega",
+    "fixed_chi",
+    "fixed_phi",
+    "fixed_psi",
 }
 _KAPPA4CV_ALL_MODES = _KAPPA4_BASE_MODES | {"double_diffraction"}
 _KAPPA4CH_ALL_MODES = _KAPPA4_BASE_MODES
-_KAPPA4_STUB_MODES = {"psi_constant"}
+_KAPPA4_STUB_MODES = {"fixed_psi"}
 
 
 def test_kappa4cv_has_all_modes():
@@ -365,13 +365,13 @@ def test_kappa4_fixed_kphi_value_in_solution(factory):
     "factory, mode_name, h, k, l",
     [
         # kappa4cv (BL basis: transverse=x, longitudinal=y, vertical=z)
-        pytest.param(kappa4cv, "constant_omega", 0, 1, 0, id="kappa4cv-constant_omega"),
-        pytest.param(kappa4cv, "constant_chi", 0, 0, 1, id="kappa4cv-constant_chi"),
-        pytest.param(kappa4cv, "constant_phi", 0, 1, 0, id="kappa4cv-constant_phi"),
+        pytest.param(kappa4cv, "fixed_omega", 0, 1, 0, id="kappa4cv-fixed_omega"),
+        pytest.param(kappa4cv, "fixed_chi", 0, 0, 1, id="kappa4cv-fixed_chi"),
+        pytest.param(kappa4cv, "fixed_phi", 0, 1, 0, id="kappa4cv-fixed_phi"),
         # kappa4ch (horizontal scattering plane — different reachable reflections)
-        pytest.param(kappa4ch, "constant_omega", 0, 0, 1, id="kappa4ch-constant_omega"),
-        pytest.param(kappa4ch, "constant_chi", 0, 0, 1, id="kappa4ch-constant_chi"),
-        pytest.param(kappa4ch, "constant_phi", 0, 1, 0, id="kappa4ch-constant_phi"),
+        pytest.param(kappa4ch, "fixed_omega", 0, 0, 1, id="kappa4ch-fixed_omega"),
+        pytest.param(kappa4ch, "fixed_chi", 0, 0, 1, id="kappa4ch-fixed_chi"),
+        pytest.param(kappa4ch, "fixed_phi", 0, 1, 0, id="kappa4ch-fixed_phi"),
     ],
 )
 def test_kappa4_virtual_angle_round_trip(factory, mode_name, h, k, l):  # noqa: E741
@@ -387,14 +387,10 @@ def test_kappa4_virtual_angle_round_trip(factory, mode_name, h, k, l):  # noqa: 
     "factory, mode_name, virtual_angle, expected_value, h, k, l",
     [
         pytest.param(
-            kappa4cv, "constant_omega", "omega", 0.0, 0, 1, 0, id="kappa4cv-omega=0"
+            kappa4cv, "fixed_omega", "omega", 0.0, 0, 1, 0, id="kappa4cv-omega=0"
         ),
-        pytest.param(
-            kappa4cv, "constant_chi", "chi", 90.0, 0, 0, 1, id="kappa4cv-chi=90"
-        ),
-        pytest.param(
-            kappa4cv, "constant_phi", "phi", 0.0, 0, 1, 0, id="kappa4cv-phi=0"
-        ),
+        pytest.param(kappa4cv, "fixed_chi", "chi", 90.0, 0, 0, 1, id="kappa4cv-chi=90"),
+        pytest.param(kappa4cv, "fixed_phi", "phi", 0.0, 0, 1, 0, id="kappa4cv-phi=0"),
     ],
 )
 def test_kappa4_virtual_angle_constraint_satisfied(
@@ -478,8 +474,8 @@ def test_four_circle_has_all_six_modes(factory):
         "bisecting",
         "fixed_chi",
         "fixed_phi",
-        "constant_omega",
-        "psi_constant",
+        "fixed_omega",
+        "fixed_psi",
         "double_diffraction",
     }
     assert set(g.modes.keys()) == expected
@@ -490,12 +486,12 @@ def test_four_circle_has_all_six_modes(factory):
 @pytest.mark.parametrize(
     "factory, mode_name",
     [
-        pytest.param(fourcv, "psi_constant", id="fourcv-psi_constant"),
-        pytest.param(fourch, "psi_constant", id="fourch-psi_constant"),
+        pytest.param(fourcv, "fixed_psi", id="fourcv-fixed_psi"),
+        pytest.param(fourch, "fixed_psi", id="fourch-fixed_psi"),
     ],
 )
 def test_four_circle_stub_not_implemented(factory, mode_name):
-    """psi_constant requires reference infrastructure (Issue J) — not yet implemented."""
+    """fixed_psi requires reference infrastructure (Issue J) — not yet implemented."""
     g = _setup_cubic(factory, a=4.0)
     g.mode_name = mode_name
     assert not g.modes[mode_name].is_implemented(g)
@@ -513,11 +509,11 @@ def test_four_circle_stub_not_implemented(factory, mode_name):
         pytest.param(fourch, 1, 1, 1, id="fourch-111"),
     ],
 )
-def test_four_circle_constant_omega_round_trip(factory, h, k, l):  # noqa: E741
-    """constant_omega (omega=0) is implemented by the generic solver; round-trips correctly."""
+def test_four_circle_fixed_omega_round_trip(factory, h, k, l):  # noqa: E741
+    """fixed_omega (omega=0) is implemented by the generic solver; round-trips correctly."""
     g = _setup_cubic(factory, a=4.0)
-    g.mode_name = "constant_omega"
-    assert g.modes["constant_omega"].is_implemented(g)
+    g.mode_name = "fixed_omega"
+    assert g.modes["fixed_omega"].is_implemented(g)
     assert _round_trip_ok(g, h, k, l)
 
 
@@ -528,10 +524,10 @@ def test_four_circle_constant_omega_round_trip(factory, h, k, l):  # noqa: E741
         pytest.param(fourch, id="fourch"),
     ],
 )
-def test_four_circle_constant_omega_value_in_solution(factory):
-    """constant_omega: omega=0 in all returned solutions."""
+def test_four_circle_fixed_omega_value_in_solution(factory):
+    """fixed_omega: omega=0 in all returned solutions."""
     g = _setup_cubic(factory, a=4.0)
-    g.mode_name = "constant_omega"
+    g.mode_name = "fixed_omega"
     solutions = g.forward(1, 0, 0)
     assert len(solutions) > 0
     for sol in solutions:
@@ -636,16 +632,16 @@ def test_four_circle_fixed_angle_constraint_value_in_solution(
             id="fourch-double_diffraction-l2",
         ),
         pytest.param(
-            fourcv, "psi_constant", "n_hat", "REQUIRED", id="fourcv-psi_constant-n_hat"
+            fourcv, "fixed_psi", "n_hat", "REQUIRED", id="fourcv-fixed_psi-n_hat"
         ),
         pytest.param(
-            fourcv, "psi_constant", "psi", None, id="fourcv-psi_constant-psi-output"
+            fourcv, "fixed_psi", "psi", None, id="fourcv-fixed_psi-psi-output"
         ),
         pytest.param(
-            fourch, "psi_constant", "n_hat", "REQUIRED", id="fourch-psi_constant-n_hat"
+            fourch, "fixed_psi", "n_hat", "REQUIRED", id="fourch-fixed_psi-n_hat"
         ),
         pytest.param(
-            fourch, "psi_constant", "psi", None, id="fourch-psi_constant-psi-output"
+            fourch, "fixed_psi", "psi", None, id="fourch-fixed_psi-psi-output"
         ),
     ],
 )
@@ -1228,10 +1224,10 @@ def test_fixed_sample_with_detector_constraint():
         pytest.param("fixed_mu", 1, 0, 0, id="fixed_mu-100"),
         pytest.param("fixed_mu", 1, 1, 1, id="fixed_mu-111"),
         pytest.param(
-            "constant_omega_noncoplanar", 1, 0, 0, id="constant_omega_noncoplanar-100"
+            "fixed_omega_noncoplanar", 1, 0, 0, id="fixed_omega_noncoplanar-100"
         ),
         pytest.param(
-            "constant_omega_noncoplanar", 0, 1, 0, id="constant_omega_noncoplanar-010"
+            "fixed_omega_noncoplanar", 0, 1, 0, id="fixed_omega_noncoplanar-010"
         ),
     ],
 )
@@ -1252,7 +1248,7 @@ def test_fivec_round_trip(mode_name, h, k, l):  # noqa: E741
         pytest.param("fixed_phi", "phi", 0.0, id="fixed_phi-phi-value"),
         pytest.param("fixed_mu", "mu", 0.0, id="fixed_mu-mu-zero"),
         pytest.param(
-            "constant_omega_noncoplanar", "omega", 0.0, id="constant_omega-omega-zero"
+            "fixed_omega_noncoplanar", "omega", 0.0, id="fixed_omega-omega-zero"
         ),
     ],
 )
@@ -1806,7 +1802,7 @@ def test_kappa6c_lifting_detector_qaz_satisfied(mode_name, h, k, l):  # noqa: E7
 
 
 # ---------------------------------------------------------------------------
-# Issue #176 — psi_constant forward solver (validation filter)
+# Issue #176 — fixed_psi forward solver (validation filter)
 # ---------------------------------------------------------------------------
 
 
@@ -1860,7 +1856,7 @@ def test_compute_natural_psi_undefined_when_Q_parallel_to_beam():
     assert psi is None
 
 
-# --- fourcv / fourch psi_constant round-trip tests (synthetic bisect path) ---
+# --- fourcv / fourch fixed_psi round-trip tests (synthetic bisect path) ---
 
 
 @pytest.mark.parametrize(
@@ -1873,8 +1869,8 @@ def test_compute_natural_psi_undefined_when_Q_parallel_to_beam():
         pytest.param(fourch, 1, 1, 1, (0, 0, 1), id="fourch-111-ref001"),
     ],
 )
-def test_four_circle_psi_constant_round_trip(factory, h, k, l, ref):  # noqa: E741
-    """psi_constant returns bisecting solutions when natural psi matches target."""
+def test_four_circle_fixed_psi_round_trip(factory, h, k, l, ref):  # noqa: E741
+    """fixed_psi returns bisecting solutions when natural psi matches target."""
     g = _setup_psi(factory, ref=ref)
     natural = _natural_psi(g, h, k, l)
     assert natural is not None
@@ -1883,12 +1879,12 @@ def test_four_circle_psi_constant_round_trip(factory, h, k, l, ref):  # noqa: E7
     from ad_hoc_diffractometer import ConstraintSet
     from ad_hoc_diffractometer import ReferenceConstraint
 
-    g.modes["psi_constant"] = ConstraintSet(
+    g.modes["fixed_psi"] = ConstraintSet(
         [ReferenceConstraint("psi", natural)],
-        computed=g.modes["psi_constant"].computed,
+        computed=g.modes["fixed_psi"].computed,
         extras={"n_hat": REQUIRED, "psi": None},
     )
-    g.mode_name = "psi_constant"
+    g.mode_name = "fixed_psi"
     assert _round_trip_ok(g, h, k, l)
 
 
@@ -1899,8 +1895,8 @@ def test_four_circle_psi_constant_round_trip(factory, h, k, l, ref):  # noqa: E7
         pytest.param(fourch, id="fourch"),
     ],
 )
-def test_four_circle_psi_constant_wrong_target_returns_empty(factory):
-    """psi_constant returns [] when natural psi does not match psi_target."""
+def test_four_circle_fixed_psi_wrong_target_returns_empty(factory):
+    """fixed_psi returns [] when natural psi does not match psi_target."""
     g = _setup_psi(factory, ref=(0, 0, 1))
     natural = _natural_psi(g, 1, 0, 0)
     assert natural is not None
@@ -1910,12 +1906,12 @@ def test_four_circle_psi_constant_wrong_target_returns_empty(factory):
     from ad_hoc_diffractometer import ReferenceConstraint
 
     wrong_target = natural + 45.0
-    g.modes["psi_constant"] = ConstraintSet(
+    g.modes["fixed_psi"] = ConstraintSet(
         [ReferenceConstraint("psi", wrong_target)],
-        computed=g.modes["psi_constant"].computed,
+        computed=g.modes["fixed_psi"].computed,
         extras={"n_hat": REQUIRED, "psi": None},
     )
-    g.mode_name = "psi_constant"
+    g.mode_name = "fixed_psi"
     solutions = g.forward(1, 0, 0)
     assert solutions == []
 
@@ -1986,14 +1982,14 @@ def test_psic_fixed_psi_wrong_target_returns_empty():
     assert solutions == []
 
 
-# --- psi_constant psi verification in solutions ---
+# --- fixed_psi psi verification in solutions ---
 
 
 @pytest.mark.parametrize(
     "factory, mode_name, h, k, l, ref",
     [
-        pytest.param(fourcv, "psi_constant", 1, 0, 0, (0, 0, 1), id="fourcv-100"),
-        pytest.param(fourcv, "psi_constant", 1, 1, 1, (0, 0, 1), id="fourcv-111"),
+        pytest.param(fourcv, "fixed_psi", 1, 0, 0, (0, 0, 1), id="fourcv-100"),
+        pytest.param(fourcv, "fixed_psi", 1, 1, 1, (0, 0, 1), id="fourcv-111"),
         pytest.param(
             psic, "fixed_psi_vertical", 1, 0, 0, (0, 0, 1), id="psic-vert-100"
         ),
@@ -2005,7 +2001,7 @@ def test_psic_fixed_psi_wrong_target_returns_empty():
         ),
     ],
 )
-def test_psi_constant_psi_verified_in_solutions(
+def test_fixed_psi_psi_verified_in_solutions(
     factory,
     mode_name,
     h,
@@ -2013,7 +2009,7 @@ def test_psi_constant_psi_verified_in_solutions(
     l,  # noqa: E741
     ref,
 ):
-    """All psi_constant solutions have psi == natural_psi."""
+    """All fixed_psi solutions have psi == natural_psi."""
     g = _setup_psi(factory, ref=ref)
     natural = _natural_psi(g, h, k, l)
     assert natural is not None
@@ -2044,7 +2040,7 @@ def test_psi_constant_psi_verified_in_solutions(
         )
 
 
-# --- kappa6c psi_constant (bisecting path with kappa stages) ---
+# --- kappa6c fixed_psi (bisecting path with kappa stages) ---
 
 
 @pytest.mark.parametrize(
@@ -2084,11 +2080,11 @@ def test_kappa6c_fixed_psi_round_trip(mode_name, h, k, l, ref):  # noqa: E741
     assert _round_trip_ok(g, h, k, l)
 
 
-# --- kappa4cv psi_constant (synthetic bisect path) ---
+# --- kappa4cv fixed_psi (synthetic bisect path) ---
 
 
-def test_kappa4cv_psi_constant_round_trip():
-    """kappa4cv psi_constant returns bisecting solutions via synthetic bisect."""
+def test_kappa4cv_fixed_psi_round_trip():
+    """kappa4cv fixed_psi returns bisecting solutions via synthetic bisect."""
     g = _setup_psi(kappa4cv, ref=(0, 0, 1))
     natural = _natural_psi(g, 1, 1, 0)
     assert natural is not None
@@ -2097,31 +2093,31 @@ def test_kappa4cv_psi_constant_round_trip():
     from ad_hoc_diffractometer import ConstraintSet
     from ad_hoc_diffractometer import ReferenceConstraint
 
-    g.modes["psi_constant"] = ConstraintSet(
+    g.modes["fixed_psi"] = ConstraintSet(
         [ReferenceConstraint("psi", natural)],
-        computed=g.modes["psi_constant"].computed,
+        computed=g.modes["fixed_psi"].computed,
         extras={"n_hat": REQUIRED, "psi": None},
     )
-    g.mode_name = "psi_constant"
+    g.mode_name = "fixed_psi"
     assert _round_trip_ok(g, 1, 1, 0)
 
 
 # --- psi undefined → empty solutions ---
 
 
-def test_psi_constant_undefined_psi_returns_empty():
-    """psi_constant returns [] when psi is undefined (Q ∥ incident beam)."""
+def test_fixed_psi_undefined_psi_returns_empty():
+    """fixed_psi returns [] when psi is undefined (Q ∥ incident beam)."""
     g = _setup_psi(fourcv, ref=(0, 0, 1))
     from ad_hoc_diffractometer import REQUIRED
     from ad_hoc_diffractometer import ConstraintSet
     from ad_hoc_diffractometer import ReferenceConstraint
 
-    g.modes["psi_constant"] = ConstraintSet(
+    g.modes["fixed_psi"] = ConstraintSet(
         [ReferenceConstraint("psi", 0.0)],
-        computed=g.modes["psi_constant"].computed,
+        computed=g.modes["fixed_psi"].computed,
         extras={"n_hat": REQUIRED, "psi": None},
     )
-    g.mode_name = "psi_constant"
+    g.mode_name = "fixed_psi"
     # (0,1,0) has Q along y (longitudinal = incident beam direction) → psi undefined
     solutions = g.forward(0, 1, 0)
     assert solutions == []
@@ -2130,8 +2126,8 @@ def test_psi_constant_undefined_psi_returns_empty():
 # --- wraparound tolerance test ---
 
 
-def test_psi_constant_wraparound_tolerance():
-    """psi_constant handles ±180° wraparound correctly."""
+def test_fixed_psi_wraparound_tolerance():
+    """fixed_psi handles ±180° wraparound correctly."""
     g = _setup_psi(fourcv, ref=(1, 0, 0))
     natural = _natural_psi(g, 1, 1, 0)
     assert natural is not None
@@ -2146,12 +2142,12 @@ def test_psi_constant_wraparound_tolerance():
     else:
         wrapped = natural + 360.0
 
-    g.modes["psi_constant"] = ConstraintSet(
+    g.modes["fixed_psi"] = ConstraintSet(
         [ReferenceConstraint("psi", wrapped)],
-        computed=g.modes["psi_constant"].computed,
+        computed=g.modes["fixed_psi"].computed,
         extras={"n_hat": REQUIRED, "psi": None},
     )
-    g.mode_name = "psi_constant"
+    g.mode_name = "fixed_psi"
     solutions = g.forward(1, 1, 0)
     # wrapped and natural differ by 360° — should still match
     assert len(solutions) > 0

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1285,8 +1285,8 @@ def test_geometry_from_dict_old_bisecting_mode_raises():
                 "bisecting",
                 "fixed_chi",
                 "fixed_phi",
-                "constant_omega",
-                "psi_constant",
+                "fixed_omega",
+                "fixed_psi",
                 "double_diffraction",
             },
             id="fourcv-six-modes",
@@ -1297,8 +1297,8 @@ def test_geometry_from_dict_old_bisecting_mode_raises():
                 "bisecting",
                 "fixed_chi",
                 "fixed_phi",
-                "constant_omega",
-                "psi_constant",
+                "fixed_omega",
+                "fixed_psi",
                 "double_diffraction",
             },
             id="fourch-six-modes",
@@ -1325,13 +1325,13 @@ def test_four_circle_factory_mode_names(factory, expected_modes):
         ),
         pytest.param(
             fourcv,
-            "constant_omega",
+            "fixed_omega",
             SampleConstraint,
             False,
-            id="fourcv-constant_omega",
+            id="fourcv-fixed_omega",
         ),
         pytest.param(
-            fourcv, "psi_constant", ReferenceConstraint, False, id="fourcv-psi_constant"
+            fourcv, "fixed_psi", ReferenceConstraint, False, id="fourcv-fixed_psi"
         ),
         # double_diffraction has no explicit constraints (4D solver uses extras)
         pytest.param(
@@ -1345,13 +1345,13 @@ def test_four_circle_factory_mode_names(factory, expected_modes):
         ),
         pytest.param(
             fourch,
-            "constant_omega",
+            "fixed_omega",
             SampleConstraint,
             False,
-            id="fourch-constant_omega",
+            id="fourch-fixed_omega",
         ),
         pytest.param(
-            fourch, "psi_constant", ReferenceConstraint, False, id="fourch-psi_constant"
+            fourch, "fixed_psi", ReferenceConstraint, False, id="fourch-fixed_psi"
         ),
     ],
 )
@@ -1372,10 +1372,8 @@ def test_four_circle_mode_constraint_type(
         pytest.param(fourcv, "bisecting", True, id="fourcv-bisecting-implemented"),
         pytest.param(fourcv, "fixed_chi", True, id="fourcv-fixed_chi-implemented"),
         pytest.param(fourcv, "fixed_phi", True, id="fourcv-fixed_phi-implemented"),
-        pytest.param(
-            fourcv, "constant_omega", True, id="fourcv-constant_omega-implemented"
-        ),
-        pytest.param(fourcv, "psi_constant", False, id="fourcv-psi_constant-stub"),
+        pytest.param(fourcv, "fixed_omega", True, id="fourcv-fixed_omega-implemented"),
+        pytest.param(fourcv, "fixed_psi", False, id="fourcv-fixed_psi-stub"),
         pytest.param(
             fourcv,
             "double_diffraction",
@@ -1385,10 +1383,8 @@ def test_four_circle_mode_constraint_type(
         pytest.param(fourch, "bisecting", True, id="fourch-bisecting-implemented"),
         pytest.param(fourch, "fixed_chi", True, id="fourch-fixed_chi-implemented"),
         pytest.param(fourch, "fixed_phi", True, id="fourch-fixed_phi-implemented"),
-        pytest.param(
-            fourch, "constant_omega", True, id="fourch-constant_omega-implemented"
-        ),
-        pytest.param(fourch, "psi_constant", False, id="fourch-psi_constant-stub"),
+        pytest.param(fourch, "fixed_omega", True, id="fourch-fixed_omega-implemented"),
+        pytest.param(fourch, "fixed_psi", False, id="fourch-fixed_psi-stub"),
         pytest.param(
             fourch,
             "double_diffraction",
@@ -1439,9 +1435,9 @@ def test_four_circle_default_mode_is_bisecting(factory):
         ),
         pytest.param(
             fourcv,
-            "constant_omega",
+            "fixed_omega",
             ["chi", "phi", "ttheta"],
-            id="fourcv-constant_omega-computed",
+            id="fourcv-fixed_omega-computed",
         ),
     ],
 )
@@ -1483,8 +1479,8 @@ def test_four_circle_modes_round_trip_serialisation(factory):
         "bisecting",
         "fixed_chi",
         "fixed_phi",
-        "constant_omega",
-        "psi_constant",
+        "fixed_omega",
+        "fixed_psi",
         "double_diffraction",
     }
     g2 = AdHocDiffractometer.from_dict(d)
@@ -1501,7 +1497,7 @@ _FIVEC_MODES = {
     "fixed_chi",
     "fixed_phi",
     "fixed_mu",
-    "constant_omega_noncoplanar",
+    "fixed_omega_noncoplanar",
 }
 
 
@@ -1540,9 +1536,9 @@ def test_fivec_mode_is_constraint_set(mode_name):
         pytest.param("fixed_phi", True, id="fixed_phi-implemented"),
         pytest.param("fixed_mu", True, id="fixed_mu-implemented"),
         pytest.param(
-            "constant_omega_noncoplanar",
+            "fixed_omega_noncoplanar",
             True,
-            id="constant_omega_noncoplanar-implemented",
+            id="fixed_omega_noncoplanar-implemented",
         ),
     ],
 )
@@ -1559,9 +1555,7 @@ def test_fivec_mode_is_implemented(mode_name, expected_implemented):
         pytest.param("fixed_chi", False, id="fixed_chi-no-bisect"),
         pytest.param("fixed_phi", False, id="fixed_phi-no-bisect"),
         pytest.param("fixed_mu", True, id="fixed_mu-has-bisect"),
-        pytest.param(
-            "constant_omega_noncoplanar", False, id="constant_omega-no-bisect"
-        ),
+        pytest.param("fixed_omega_noncoplanar", False, id="fixed_omega-no-bisect"),
     ],
 )
 def test_fivec_mode_has_bisect(mode_name, expected_has_bisect):
@@ -1579,9 +1573,9 @@ def test_fivec_mode_has_bisect(mode_name, expected_has_bisect):
         pytest.param("fixed_chi", ["omega", "phi", "ttheta"], id="fixed_chi"),
         pytest.param("fixed_phi", ["omega", "chi", "ttheta"], id="fixed_phi"),
         pytest.param(
-            "constant_omega_noncoplanar",
+            "fixed_omega_noncoplanar",
             ["mu", "chi", "phi", "ttheta"],
-            id="constant_omega_noncoplanar",
+            id="fixed_omega_noncoplanar",
         ),
     ],
 )
@@ -1741,7 +1735,7 @@ def test_sixc_modes_round_trip_serialisation():
 # ---------------------------------------------------------------------------
 
 _ZAXIS_MODES = {"zaxis", "reflectivity"}
-_S2D2_MODES = {"mu_fixed", "reflectivity"}
+_S2D2_MODES = {"fixed_mu", "reflectivity"}
 
 
 @pytest.mark.parametrize(
@@ -1803,10 +1797,10 @@ def test_zaxis_s2d2_reference_modes_implemented_with_surface_normal(factory, mod
     assert g.modes[mode_name].is_implemented(g) is True
 
 
-def test_s2d2_mu_fixed_is_implemented():
-    """s2d2 mu_fixed uses a SampleConstraint — is_implemented returns True."""
+def test_s2d2_fixed_mu_is_implemented():
+    """s2d2 fixed_mu uses a SampleConstraint — is_implemented returns True."""
     g = s2d2()
-    cs = g.modes["mu_fixed"]
+    cs = g.modes["fixed_mu"]
     assert isinstance(cs, ConstraintSet)
     assert len(cs) == 1
     assert cs.is_implemented(g) is True
@@ -1845,7 +1839,7 @@ def test_zaxis_s2d2_extras_declared(factory, mode_name, extras_key, expected_val
             id="zaxis-refl-computed",
         ),
         pytest.param(
-            s2d2, "mu_fixed", ["Z", "nu", "delta"], id="s2d2-mu_fixed-computed"
+            s2d2, "fixed_mu", ["Z", "nu", "delta"], id="s2d2-fixed_mu-computed"
         ),
         pytest.param(
             s2d2, "reflectivity", ["mu", "Z", "nu", "delta"], id="s2d2-refl-computed"
@@ -1885,10 +1879,10 @@ def test_zaxis_s2d2_modes_round_trip(factory, expected_modes):
 _KAPPA4_BASE_MODES = {
     "bisecting",
     "fixed_kphi",
-    "constant_omega",
-    "constant_chi",
-    "constant_phi",
-    "psi_constant",
+    "fixed_omega",
+    "fixed_chi",
+    "fixed_phi",
+    "fixed_psi",
 }
 _KAPPA4CV_MODES = _KAPPA4_BASE_MODES | {"double_diffraction"}
 _KAPPA4CH_MODES = _KAPPA4_BASE_MODES
@@ -1896,9 +1890,9 @@ _KAPPA4CH_MODES = _KAPPA4_BASE_MODES
 _KAPPA4_BASE_IMPLEMENTED = {
     "bisecting",
     "fixed_kphi",
-    "constant_omega",
-    "constant_chi",
-    "constant_phi",
+    "fixed_omega",
+    "fixed_chi",
+    "fixed_phi",
 }
 _KAPPA4CV_IMPLEMENTED = _KAPPA4_BASE_IMPLEMENTED | {"double_diffraction"}
 _KAPPA4CH_IMPLEMENTED = _KAPPA4_BASE_IMPLEMENTED
@@ -1965,11 +1959,9 @@ def test_kappa4_mode_is_implemented(factory, mode_name, expected_implemented):
         pytest.param(kappa4cv, "bisecting", True, id="kappa4cv-bisecting-has-bisect"),
         pytest.param(kappa4cv, "fixed_kphi", False, id="kappa4cv-fixed_kphi-no-bisect"),
         pytest.param(
-            kappa4cv, "constant_omega", False, id="kappa4cv-constant_omega-no-bisect"
+            kappa4cv, "fixed_omega", False, id="kappa4cv-fixed_omega-no-bisect"
         ),
-        pytest.param(
-            kappa4cv, "psi_constant", False, id="kappa4cv-psi_constant-no-bisect"
-        ),
+        pytest.param(kappa4cv, "fixed_psi", False, id="kappa4cv-fixed_psi-no-bisect"),
     ],
 )
 def test_kappa4_mode_has_bisect(factory, mode_name, expected_has_bisect):
@@ -1980,12 +1972,12 @@ def test_kappa4_mode_has_bisect(factory, mode_name, expected_has_bisect):
 @pytest.mark.parametrize(
     "mode_name, extras_key, expected_value",
     [
-        pytest.param("psi_constant", "n_hat", "REQUIRED", id="psi_constant-n_hat"),
-        pytest.param("psi_constant", "psi", None, id="psi_constant-psi-output"),
+        pytest.param("fixed_psi", "n_hat", "REQUIRED", id="fixed_psi-n_hat"),
+        pytest.param("fixed_psi", "psi", None, id="fixed_psi-psi-output"),
     ],
 )
-def test_kappa4_psi_constant_extras(mode_name, extras_key, expected_value):
-    """psi_constant carries REQUIRED n_hat and None psi output extras."""
+def test_kappa4_fixed_psi_extras(mode_name, extras_key, expected_value):
+    """fixed_psi carries REQUIRED n_hat and None psi output extras."""
     for g in (kappa4cv(), kappa4ch()):
         actual = g.modes[mode_name].extras.get(extras_key)
         if expected_value == "REQUIRED":
@@ -2011,9 +2003,9 @@ def test_kappa4_psi_constant_extras(mode_name, extras_key, expected_value):
         ),
         pytest.param(
             kappa4cv,
-            "constant_chi",
+            "fixed_chi",
             ["komega", "kappa", "kphi", "ttheta"],
-            id="kappa4cv-constant_chi",
+            id="kappa4cv-fixed_chi",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- closes #219

Standardize all inconsistent mode naming patterns across preset
geometries to the `fixed_AXIS` convention established for psic in #190:

- `constant_omega` → `fixed_omega` (fourcv, fourch, kappa4cv, kappa4ch)
- `psi_constant` → `fixed_psi` (fourcv, fourch, kappa4cv, kappa4ch)
- `constant_chi` → `fixed_chi` (kappa4cv, kappa4ch)
- `constant_phi` → `fixed_phi` (kappa4cv, kappa4ch)
- `constant_omega_noncoplanar` → `fixed_omega_noncoplanar` (fivec)
- `mu_fixed` → `fixed_mu` (s2d2)

No backward-compatibility aliases — clean break for the 0.7.0 milestone.

Contributed by: OpenCode (argo/claudeopus46)