### PR TITLE
docs: publish private functions and methods in API reference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,7 @@ autoapi_options = [
     "undoc-members",
     "show-inheritance",
     "show-module-summary",
+    "private-members",
     # "imported-members" is intentionally omitted: including it causes
     # "more than one target" cross-reference warnings for every symbol
     # re-exported via __init__.py.
@@ -112,11 +113,31 @@ suppress_warnings = ["autoapi.python_import_resolution"]
 
 
 def autoapi_skip_member(app, what, name, obj, skip, options):
-    """Skip logger instances and private _version from the autoapi output."""
+    """Skip logger instances, _version, and private non-callable members.
+
+    Private *functions* and *methods* (``_name``) are kept because they
+    contain the most valuable algorithm documentation in the codebase.
+    Private *attributes*, *data*, and *properties* are suppressed because
+    they are property-backing fields, cache slots, internal storage, or
+    module-level constants that duplicate the public API.
+
+    This rule is self-maintaining: new private functions are automatically
+    published, and new private attributes are automatically suppressed,
+    with no manual list to update.
+    """
     if what == "data" and name.endswith(".logger"):
         return True
     if "_version" in name:
         return True
+
+    # Suppress private attributes, data, and properties — these are
+    # implementation details (backing fields, caches, constants).
+    # Private functions and methods are kept (algorithm documentation).
+    if what in ("attribute", "data", "property"):
+        short = name.rsplit(".", 1)[-1]
+        if short.startswith("_"):
+            return True
+
     return skip
 
 

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -565,8 +565,11 @@ def _solve_bisecting_analytic(
         \begin{pmatrix} \cos\chi \\ \sin\chi \end{pmatrix}
         = \begin{pmatrix} C \\ E \end{pmatrix}
 
-    where :math:`A = \hat n_\phi \cdot q`, :math:`B = \hat n_\phi \cdot (\hat n_\chi \times q)`,
-    :math:`C = \hat n_\phi \cdot v`, :math:`E = \hat n_3 \cdot v`.
+    where
+    :math:`A = \hat n_\phi \cdot q`,
+    :math:`B = \hat n_\phi \cdot (\hat n_\chi \times q)`,
+    :math:`C = \hat n_\phi \cdot v`,
+    :math:`E = \hat n_3 \cdot v`.
     This yields a unique :math:`\chi` via ``atan2``.
 
     Phi is then solved from the :math:`\hat n_\chi` component:
@@ -782,9 +785,9 @@ def _solve_bisecting(
     that stage at its declared value.  Any fixed ``SampleConstraint`` values
     are applied before solving for the remaining free stages.
 
-    Two solutions are returned corresponding to:
-        - "positive chi" branch: chi ∈ [0°, 180°]
-        - "negative chi" branch: chi ∈ (-180°, 0°)
+    Two solutions are returned corresponding to the "positive chi"
+    branch (chi in [0, 180]) and the "negative chi" branch
+    (chi in (-180, 0)).
 
     Both solutions are validated against stage limits; those that fail are
     dropped.  Cut-points from the mode are applied to each angle.
@@ -1508,10 +1511,10 @@ def _solve_double_diffraction(
 
     Four equations, four unknowns:
 
-    1-3. Bragg condition for primary hkl₁:
-         ``Q_phi_computed - Q_phi_target = 0``  (3 components)
-    4.   Ewald sphere for secondary hkl₂:
-         ``|ki + Z @ UB @ hkl₂|² - |ki|² = 0``
+    - Equations 1-3: Bragg condition for primary hkl₁ --
+      ``Q_phi_computed - Q_phi_target = 0`` (3 components).
+    - Equation 4: Ewald sphere for secondary hkl₂ --
+      ``|ki + Z @ UB @ hkl₂|² - |ki|² = 0``.
 
     where ``Z`` is the sample rotation matrix and ``ki = (2π/λ) ŷ``.
 


### PR DESCRIPTION
## Summary

- closes #231
- Add `"private-members"` to `autoapi_options` so private functions and methods with docstrings appear in the Sphinx API reference
- Filter by object type in `autoapi_skip_member`: private functions/methods are published, private attributes/data/properties are suppressed
- The type-based rule is self-maintaining — no manual skip list to update when the codebase changes

## What gets published

~60 private functions and methods across 16 modules, including:
- Forward solvers: `_solve_bisecting_analytic`, `_solve_bisecting`, `_solve_two_angles`, `_solve_psi_mode`, `_solve_double_diffraction`, `_solve_surface`, `_solve_qaz_mode`
- Core computation: `_compute_q_phi`, `_compute_q_phi_cached`, `_rotation_matrix_normalized`, `_rotation_matrix_and_derivative_normalized`
- Crystallography: `_deduce_system_and_params`, `_gram_schmidt_triple`, `_validate_params`
- Scan internals: `_euler_from_Z_standard`, `_kappa_from_Z`, `_psi_candidates`
- Refinement: `_nelder_mead_numpy`, `_full_params_from_free`, `_dB_dp_finite_diff`

## What stays hidden

All private attributes, data, and properties — backing fields (`_wavelength`, `_a`, `_name`), caches (`_cached_Z_prefix`), internal storage (`_data`), constants (`_ANGLE_MIN`, `_TWO_PI`), drawing internals (`_go`, `_fig`).

## Maintenance

The filter uses `what in ("attribute", "data", "property")` + `short.startswith("_")` — a structural rule, not an explicit name list. New private functions are auto-published; new private attributes are auto-suppressed.

## Also included

Two minor docstring formatting fixes in `forward.py` that prevented clean RST rendering when the private docstrings became visible.

Contributed by: OpenCode (argo/claudeopus46)