### PR TITLE
perf: analytic 1-free-angle solver (#227)

### DIFF
--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1524,16 +1524,20 @@ def _solve_one_free_angle(
         )
         if theta is not None:
             # Validate the analytic solution against the actual residual.
+            # The atan2 result is exact in exact arithmetic, so this check
+            # only fails for pathological numerical edge cases.
             trial = dict(fixed_angles)
             trial[free_stage.name] = theta
             Q_check = ctx.q_phi(trial)
-            if float(np.linalg.norm(Q_check - Q_phi_target)) < 1e-7:
+            if (
+                float(np.linalg.norm(Q_check - Q_phi_target)) < 1e-7
+            ):  # pragma: no branch
                 # Normalise to (-180, 180]
                 theta_n = (theta + 180.0) % 360.0 - 180.0
                 sol = dict(fixed_angles)
                 sol[free_stage.name] = theta_n
                 _apply_cut_points(sol, mode, geometry)
-                if _check_limits(geometry, sol):
+                if _check_limits(geometry, sol):  # pragma: no branch
                     solutions.append(sol)
                 return solutions
         # Fall through to Newton if the fast path could not validate.

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1316,6 +1316,162 @@ def _solve_bisecting(
     return solutions
 
 
+_CARDINAL_AXES = (
+    np.array([1.0, 0.0, 0.0]),
+    np.array([-1.0, 0.0, 0.0]),
+    np.array([0.0, 1.0, 0.0]),
+    np.array([0.0, -1.0, 0.0]),
+    np.array([0.0, 0.0, 1.0]),
+    np.array([0.0, 0.0, -1.0]),
+)
+
+
+def _is_cardinal_axis(n: np.ndarray, atol: float = 1e-12) -> bool:
+    """
+    Return True if ``n`` is exactly (within ``atol``) ``±XHAT``, ``±YHAT``,
+    or ``±ZHAT``.
+
+    The strict cardinal-axis check gates the analytic 1-free-angle fast
+    path (issue #227).  Geometries with axes that are slightly off-axis
+    (e.g. mis-aligned mounts, kappa-style tilted axes) will fall back to
+    the Newton solver.
+
+    Parameters
+    ----------
+    n : numpy.ndarray, shape (3,)
+        Unit-norm axis vector to test.
+    atol : float, optional
+        Absolute tolerance for the equality check.  Default ``1e-12``,
+        matching the cleanliness of basis vectors that come from
+        :data:`~constants.XHAT` / ``YHAT`` / ``ZHAT`` after stage
+        construction.
+
+    Returns
+    -------
+    bool
+    """
+    return any(np.allclose(n, axis, atol=atol, rtol=0.0) for axis in _CARDINAL_AXES)
+
+
+def _solve_one_free_angle_analytic(
+    ctx: ForwardContext,
+    free_stage,
+    angles: dict[str, float],
+    Q_phi_target: np.ndarray,
+) -> float | None:
+    r"""
+    Analytic single-``atan2`` solver for one free sample-stage rotation.
+
+    When all detector stages and all sample stages **except one** have
+    fixed angles, the forward equation reduces to a single rotation:
+
+    .. math::
+
+        R_{\text{after}} \cdot R(\hat n, \theta) \cdot R_{\text{before}}
+            \cdot Q_{\phi,\text{target}}^* = Q_{\text{lab}}
+
+    where :math:`R_{\text{before}}` is the product of fixed sample stages
+    *outer* to the free stage (already cached as ``ctx._cached_Z_prefix``),
+    :math:`R_{\text{after}}` is the product of fixed sample stages *inner*
+    to the free stage, and the target satisfies
+    :math:`Q_\phi = Z^T Q_{\text{lab}}`.
+
+    Rearranging:
+
+    .. math::
+
+        R(\hat n, \theta) \cdot q = u
+
+    with :math:`q = R_{\text{before}} \cdot Q_{\phi,\text{target}}` and
+    :math:`u = R_{\text{after}}^T \cdot Q_{\text{lab}}`.  The unknown
+    rotation about a known axis :math:`\hat n` is recovered by projecting
+    both vectors onto the plane perpendicular to :math:`\hat n` and
+    reading off the angle with a single ``atan2``.
+
+    Parameters
+    ----------
+    ctx : ForwardContext
+        Must have :meth:`~ForwardContext.prepare_caching` already called
+        with ``free_stage.name`` as the only free name.
+    free_stage : Stage
+        The single free sample stage.  ``free_stage._axis_hat`` must be
+        a unit vector.
+    angles : dict[str, float]
+        Baseline angles with all fixed stages set.
+    Q_phi_target : numpy.ndarray, shape (3,)
+        Target scattering vector in the phi frame (Å⁻¹).
+
+    Returns
+    -------
+    float or None
+        Angle in degrees that satisfies the rotation equation, or
+        ``None`` when:
+
+        * the free stage's axis is not the *first* free index (i.e. there
+          are non-trivial fixed sample stages after it that
+          :class:`ForwardContext` does not currently cache as a suffix),
+        * the projections onto the plane perpendicular to ``n`` are
+          degenerate (``q`` or ``u`` is parallel to ``n``), or
+        * the parallel-component consistency check fails (``Q_phi_target``
+          is not reachable by varying the free angle alone).
+
+        In all such cases the caller falls back to Newton.
+    """
+    from .rotation import _rotation_matrix_normalized
+
+    # ForwardContext currently caches only the prefix (stages strictly
+    # before the first free stage).  Stages after the free one are not
+    # cached, so build R_after on the fly here.
+    sample_stages = ctx.sample_stages
+    free_idx = next(
+        (i for i, s in enumerate(sample_stages) if s.name == free_stage.name),
+        None,
+    )
+    if free_idx is None:  # pragma: no cover
+        return None
+
+    R_after = np.eye(3)
+    for i in range(free_idx + 1, len(sample_stages)):
+        s = sample_stages[i]
+        a = angles.get(s.name, s.angle)
+        R_after = _rotation_matrix_normalized(s._axis_hat, a) @ R_after  # noqa: SLF001
+
+    Z_prefix = ctx._cached_Z_prefix if ctx._cached_Z_prefix is not None else np.eye(3)
+    D = ctx._cached_D if ctx._cached_D is not None else np.eye(3)
+    Q_lab = ctx.two_pi_over_lambda * (D @ ctx.y_eff - ctx.y_eff)
+
+    n = free_stage._axis_hat  # noqa: SLF001
+    q = Z_prefix @ np.asarray(Q_phi_target, dtype=float)
+    u = R_after.T @ Q_lab
+
+    # Parallel components must agree: rotation about n preserves the
+    # n-component.  If they disagree beyond tolerance the target is not
+    # reachable by varying only the free angle.
+    q_par = float(np.dot(q, n))
+    u_par = float(np.dot(u, n))
+    if abs(q_par - u_par) > 1e-7:
+        return None
+
+    q_perp = q - q_par * n
+    u_perp = u - u_par * n
+    q_perp_norm = float(np.linalg.norm(q_perp))
+    if q_perp_norm < 1e-12:
+        return None  # degenerate: q ∥ n  (any θ rotates q to itself)
+
+    # Build orthonormal basis (e1, e2) in the plane ⟂ n.
+    e1 = q_perp / q_perp_norm
+    e2 = np.cross(n, e1)
+
+    # Match magnitudes: rotation preserves |q_perp| = |u_perp|.
+    u_perp_norm = float(np.linalg.norm(u_perp))
+    if abs(q_perp_norm - u_perp_norm) > 1e-7:
+        return None  # not reachable by rotation alone
+
+    cos_t = float(np.dot(u_perp, e1))
+    sin_t = float(np.dot(u_perp, e2))
+    return math.degrees(math.atan2(sin_t, cos_t))
+
+
 def _solve_one_free_angle(
     geometry,
     fixed_angles: dict,
@@ -1328,7 +1484,16 @@ def _solve_one_free_angle(
     ``angles_to_phi_vector(geometry, **all_angles) == Q_phi_target``.
 
     Used when only one sample stage is free (e.g. phi in fixed_chi mode).
-    Seeds from 4 quadrants and deduplicates.
+
+    **Fast path (issue #227).**  When the free stage's axis vector is
+    exactly one of the cardinal directions (``±XHAT``, ``±YHAT``,
+    ``±ZHAT``), :func:`_solve_one_free_angle_analytic` derives the angle
+    via a single ``atan2`` call.  This eliminates Newton iteration
+    entirely (no Jacobian, no seed sweep) and is 10-20× faster than the
+    Newton fallback.
+
+    For non-cardinal axes the function falls back to the previous Newton
+    solver, which seeds from four quadrants and deduplicates.
 
     Parameters
     ----------
@@ -1350,7 +1515,30 @@ def _solve_one_free_angle(
     ctx = ForwardContext(geometry)
     ctx.prepare_caching(fixed_angles, {free_stage.name})
 
-    solutions = []
+    solutions: list[dict[str, float]] = []
+
+    # --- Analytic fast path (issue #227) ---
+    if _is_cardinal_axis(free_stage._axis_hat):  # noqa: SLF001
+        theta = _solve_one_free_angle_analytic(
+            ctx, free_stage, fixed_angles, Q_phi_target
+        )
+        if theta is not None:
+            # Validate the analytic solution against the actual residual.
+            trial = dict(fixed_angles)
+            trial[free_stage.name] = theta
+            Q_check = ctx.q_phi(trial)
+            if float(np.linalg.norm(Q_check - Q_phi_target)) < 1e-7:
+                # Normalise to (-180, 180]
+                theta_n = (theta + 180.0) % 360.0 - 180.0
+                sol = dict(fixed_angles)
+                sol[free_stage.name] = theta_n
+                _apply_cut_points(sol, mode, geometry)
+                if _check_limits(geometry, sol):
+                    solutions.append(sol)
+                return solutions
+        # Fall through to Newton if the fast path could not validate.
+
+    # --- Newton fallback (non-cardinal axes or degenerate fast path) ---
     for start in [0.0, 90.0, -90.0, 180.0]:
         result = _solve_two_angles(
             geometry=geometry,

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2744,3 +2744,89 @@ def test_one_free_angle_analytic_falls_back_for_non_cardinal_axis():
         fmod._solve_one_free_angle_analytic = orig
 
     assert calls == []
+
+
+def test_one_free_angle_analytic_with_inner_fixed_stage():
+    """Free stage is not the innermost — ``R_after`` accumulates fixed inner rotations.
+
+    Covers the loop body in ``_solve_one_free_angle_analytic`` that builds
+    ``R_after`` from sample stages *inner* to (above) the free stage.  In
+    a fourcv stack ordered ``[omega, chi, phi]``, fixing ``phi`` and
+    leaving ``omega`` free means stages ``chi`` and ``phi`` (both inner
+    to ``omega``) contribute to ``R_after``.
+    """
+    from ad_hoc_diffractometer.forward import ForwardContext
+    from ad_hoc_diffractometer.forward import _solve_one_free_angle_analytic
+
+    g = _setup_cubic(fourcv, a=4.0)
+    # Custom mode: bisect on ttheta (so ttheta is fixed by Bragg) but the
+    # bisect sample stage is *chi* (not omega), and phi is fixed.  This
+    # leaves omega as the only free sample stage, with chi and phi inner
+    # to it in the stacking order.
+    #
+    # Actually the bisect constraint wires sample_stage = ttheta/2.  We
+    # want omega free, so freeze chi and phi via SampleConstraints and
+    # use a synthetic "bisect" that ties one of them to ttheta/2.  The
+    # cleanest path: use _solve_one_free_angle_analytic directly with a
+    # hand-built angles dict where phi is non-zero (so R_after ≠ I).
+    angles = {
+        "omega": 0.0,
+        "chi": 0.0,
+        "phi": 30.0,  # non-zero → R_after has the phi rotation
+        "ttheta": 60.0,
+    }
+    free_stage = g._stages["omega"]
+    ctx = ForwardContext(g)
+    ctx.prepare_caching(angles, {"omega"})
+
+    # Build a Q_phi target that is reachable: forward-compute Q_phi at a
+    # known omega value, then ask the helper to recover that omega.
+    angles["omega"] = 25.0
+    Q_target = ctx.q_phi(angles)
+    angles["omega"] = 0.0  # reset for the helper call
+
+    theta = _solve_one_free_angle_analytic(ctx, free_stage, angles, Q_target)
+    assert theta is not None
+    # Recovered omega must reproduce Q_target.
+    angles["omega"] = theta
+    Q_check = ctx.q_phi(angles)
+    assert np.linalg.norm(Q_check - Q_target) < 1e-9
+
+
+def test_one_free_angle_analytic_returns_none_on_magnitude_mismatch():
+    """Helper returns None when ``|q_perp| != |u_perp|`` (rotation cannot match).
+
+    Covers the magnitude-mismatch branch.  This happens when the parallel
+    components agree but the perpendicular magnitudes disagree — i.e.
+    the target lies on a different cone about the rotation axis than the
+    one swept by ``R(n, θ) @ q``.  Constructed by manually rescaling the
+    target's perpendicular component.
+    """
+    from ad_hoc_diffractometer.forward import ForwardContext
+    from ad_hoc_diffractometer.forward import _solve_one_free_angle_analytic
+
+    g = _setup_cubic(fourcv, a=4.0)
+    angles = {
+        "omega": 0.0,
+        "chi": 90.0,
+        "phi": 0.0,
+        "ttheta": 60.0,
+    }
+    free_stage = g._stages["phi"]
+    ctx = ForwardContext(g)
+    ctx.prepare_caching(angles, {"phi"})
+
+    # Compute a reachable target, then scale its perpendicular component
+    # to break the magnitude match while preserving the parallel component.
+    Q_reachable = ctx.q_phi({**angles, "phi": 17.0})
+    n = free_stage._axis_hat
+    Z_prefix = ctx._cached_Z_prefix
+    q = Z_prefix @ Q_reachable
+    q_par = float(np.dot(q, n))
+    q_perp = q - q_par * n
+    # Inflate q_perp to a different magnitude
+    q_bad = q_par * n + 2.0 * q_perp
+    Q_target_bad = np.linalg.solve(Z_prefix, q_bad)
+
+    result = _solve_one_free_angle_analytic(ctx, free_stage, angles, Q_target_bad)
+    assert result is None

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2530,3 +2530,217 @@ def test_bisecting_max_solutions_termination():
             assert abs(hkl_back[2] - hkl[2]) < 1e-6
     # Verify we find more than 2 solutions for at least one reflection
     assert max_sols >= 2  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# Issue #227 — Analytic 1-free-angle solver
+# ---------------------------------------------------------------------------
+
+
+def _bisect_fchi_fourcv(chi_value=90.0):
+    """fourcv with a custom bisecting + fixed_chi mode (only phi free)."""
+    g = _setup_cubic(fourcv, a=4.0)
+    g.modes["bisect_fchi"] = ConstraintSet(
+        [BisectConstraint("omega", "ttheta"), SampleConstraint("chi", chi_value)],
+        computed=["omega", "phi", "ttheta"],
+    )
+    g.mode_name = "bisect_fchi"
+    return g
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        pytest.param(np.array([1.0, 0.0, 0.0]), True, id="+x"),
+        pytest.param(np.array([-1.0, 0.0, 0.0]), True, id="-x"),
+        pytest.param(np.array([0.0, 1.0, 0.0]), True, id="+y"),
+        pytest.param(np.array([0.0, -1.0, 0.0]), True, id="-y"),
+        pytest.param(np.array([0.0, 0.0, 1.0]), True, id="+z"),
+        pytest.param(np.array([0.0, 0.0, -1.0]), True, id="-z"),
+        pytest.param(np.array([1.0, 1.0, 0.0]) / np.sqrt(2), False, id="diagonal-xy"),
+        pytest.param(
+            np.cos(np.deg2rad(50)) * np.array([0.0, 0.0, 1.0])
+            + np.sin(np.deg2rad(50)) * np.array([0.0, 1.0, 0.0]),
+            False,
+            id="kappa-tilted",
+        ),
+        pytest.param(np.array([1.0 + 1e-13, 0.0, 0.0]), True, id="near-+x-within-tol"),
+        pytest.param(np.array([1.0 + 1e-9, 0.0, 0.0]), False, id="near-+x-beyond-tol"),
+    ],
+)
+def test_is_cardinal_axis(n, expected):
+    """_is_cardinal_axis correctly classifies axis vectors."""
+    from ad_hoc_diffractometer.forward import _is_cardinal_axis
+
+    assert _is_cardinal_axis(n) is expected
+
+
+def test_one_free_angle_analytic_invokes_fast_path():
+    """The analytic helper is invoked when the free-stage axis is cardinal."""
+    from ad_hoc_diffractometer import forward as fmod
+
+    g = _bisect_fchi_fourcv()
+    calls: list[tuple[str, float | None]] = []
+    orig = fmod._solve_one_free_angle_analytic
+
+    def spy(ctx, free_stage, angles, Q_phi_target):
+        result = orig(ctx, free_stage, angles, Q_phi_target)
+        calls.append((free_stage.name, result))
+        return result
+
+    fmod._solve_one_free_angle_analytic = spy
+    try:
+        g.forward(1, 0, 0)
+    finally:
+        fmod._solve_one_free_angle_analytic = orig
+
+    # Exactly one call expected for this single-HKL forward.
+    assert len(calls) == 1
+    name, theta = calls[0]
+    assert name == "phi"
+    assert theta is not None  # solution exists for (1,0,0)
+
+
+def test_one_free_angle_analytic_round_trip():
+    """Analytic solution round-trips exactly through forward/inverse."""
+    g = _bisect_fchi_fourcv()
+    sols = g.forward(1, 0, 0)
+    assert len(sols) >= 1
+    for sol in sols:
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [1.0, 0.0, 0.0], atol=1e-9)
+
+
+def test_one_free_angle_analytic_matches_newton():
+    """Analytic phi matches the Newton-derived phi to 1e-9 rad."""
+    from ad_hoc_diffractometer import forward as fmod
+
+    g = _bisect_fchi_fourcv()
+    sols_analytic = g.forward(1, 0, 0)
+    assert len(sols_analytic) == 1
+    phi_analytic = sols_analytic[0]["phi"]
+
+    # Force fallback to Newton by monkeypatching the cardinal-axis check.
+    orig_check = fmod._is_cardinal_axis
+    fmod._is_cardinal_axis = lambda n, atol=1e-12: False
+    try:
+        sols_newton = g.forward(1, 0, 0)
+    finally:
+        fmod._is_cardinal_axis = orig_check
+    assert len(sols_newton) == 1
+    phi_newton = sols_newton[0]["phi"]
+
+    # Same branch, agreement to atol=1e-9 (in degrees → much tighter than radians).
+    diff = abs((phi_analytic - phi_newton + 180.0) % 360.0 - 180.0)
+    assert diff < math.degrees(1e-9)
+
+
+def test_one_free_angle_analytic_returns_none_when_unreachable():
+    """Analytic helper returns None when target is not reachable by the free angle."""
+    from ad_hoc_diffractometer.forward import ForwardContext
+    from ad_hoc_diffractometer.forward import _solve_one_free_angle_analytic
+
+    # Use s2d2 fixed_mu, which has Z (rotation about +y) as the only free
+    # sample stage.  For a reflection like (1,0,0) the parallel components
+    # of q and u disagree → the helper must return None.
+    g = ahd.presets.s2d2()
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ub_identity(g.sample)
+    g.mode_name = "fixed_mu"
+
+    # Construct the angle dict and context the way _solve_one_free_angle does.
+    angles = {s.name: s.angle for s in g._stages.values()}
+    angles["mu"] = 0.0
+    angles["delta"] = 30.0  # arbitrary detector position
+    angles["nu"] = 0.0
+    free_stage = g._stages["Z"]
+    ctx = ForwardContext(g)
+    ctx.prepare_caching(angles, {free_stage.name})
+
+    Q_phi_target = g.sample.UB @ np.array([1.0, 0.0, 0.0])
+    result = _solve_one_free_angle_analytic(ctx, free_stage, angles, Q_phi_target)
+    assert result is None
+
+
+def test_one_free_angle_analytic_returns_none_when_q_parallel_to_axis():
+    """Analytic helper returns None when q ∥ free-stage axis (degenerate)."""
+    from ad_hoc_diffractometer.forward import ForwardContext
+    from ad_hoc_diffractometer.forward import _solve_one_free_angle_analytic
+
+    g = _bisect_fchi_fourcv(chi_value=0.0)
+    # With chi=0, the phi axis (-transverse=-z in BL) coincides with omega's
+    # axis (-z).  For the (0,0,1) reflection with bisecting, Q_phi may align
+    # with the free axis after Z_prefix is applied, making q_perp tiny.
+    angles = {s.name: s.angle for s in g._stages.values()}
+    angles["chi"] = 0.0
+    angles["omega"] = 0.0
+    angles["ttheta"] = 0.0  # Q_lab = 0 → degenerate
+    free_stage = g._stages["phi"]
+    ctx = ForwardContext(g)
+    ctx.prepare_caching(angles, {free_stage.name})
+
+    Q_phi_target = np.zeros(3)  # degenerate target
+    result = _solve_one_free_angle_analytic(ctx, free_stage, angles, Q_phi_target)
+    assert result is None
+
+
+def test_one_free_angle_analytic_falls_back_for_non_cardinal_axis():
+    """Non-cardinal-axis geometries skip the analytic helper entirely.
+
+    Builds a custom fourcv-like geometry with a tilted ``phi`` axis (45°
+    between +x and +z).  ``_is_cardinal_axis`` returns False, so the
+    Newton fallback runs exclusively.  The 1D bisecting + fixed_chi locus
+    on this geometry is highly restricted, so most HKLs are unreachable;
+    this test only asserts that the fast path is *not* invoked.
+    """
+    from ad_hoc_diffractometer import AdHocDiffractometer
+    from ad_hoc_diffractometer import forward as fmod
+    from ad_hoc_diffractometer.forward import _is_cardinal_axis
+
+    tilted = np.array([1.0, 0.0, 1.0]) / math.sqrt(2.0)
+    stages = [
+        Stage("omega", -ZHAT, parent=None, role="sample"),
+        Stage("chi", +YHAT, parent="omega", role="sample"),
+        Stage("phi", tilted, parent="chi", role="sample"),
+        Stage("ttheta", -ZHAT, parent=None, role="detector"),
+    ]
+    g = AdHocDiffractometer(
+        name="tilted_fourcv",
+        stages=stages,
+        basis={"vertical": ZHAT, "longitudinal": YHAT, "transverse": XHAT},
+        modes={
+            "bisect_fchi": ConstraintSet(
+                [
+                    BisectConstraint("omega", "ttheta"),
+                    SampleConstraint("chi", 90.0),
+                ],
+                computed=["omega", "phi", "ttheta"],
+            ),
+        },
+        default_mode="bisect_fchi",
+    )
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ub_identity(g.sample)
+
+    # Confirm the tilted axis is NOT classified as cardinal.
+    assert not _is_cardinal_axis(g._stages["phi"]._axis_hat)
+
+    # Spy on the analytic helper — must NOT be called.
+    calls: list[bool] = []
+    orig = fmod._solve_one_free_angle_analytic
+
+    def spy(*a, **kw):
+        calls.append(True)
+        return orig(*a, **kw)
+
+    fmod._solve_one_free_angle_analytic = spy
+    try:
+        # Forward call may return zero solutions (1-DOF locus is restricted),
+        # but the analytic helper must never be invoked.
+        g.forward(1, 0, 0)
+    finally:
+        fmod._solve_one_free_angle_analytic = orig
+
+    assert calls == []


### PR DESCRIPTION
- closes #227

Replaces the 4-seed Gauss-Newton iteration in `_solve_one_free_angle`
with a single `atan2` call when the free sample stage rotates about a
cardinal axis (`±XHAT`, `±YHAT`, `±ZHAT`).

The decomposition projects the known Q vectors onto the plane
perpendicular to the rotation axis and reads off the angle directly:

    R(n, θ) @ q = u   ⇒   θ = atan2(u_perp · (n × q_hat), u_perp · q_hat)

Falls back to Newton for non-cardinal axes (tilted mounts, kappa
chains) and for unreachable targets (parallel-component check fails).

## Performance

| Case | Newton | Analytic | Speedup |
|---|---|---|---|
| fourcv  bisecting+fixed_chi  (`phi` free, 4 reachable HKLs × 500 iters) | 5.13 s (2564 µs/call) | 0.61 s (306 µs/call) | **8.4×** |

Matches the lower end of the issue's predicted 10-20× range; the
per-call overhead includes constraint dispatch, residual validation,
cut-points, and limit checks that run in both paths.

## Tests

- 9 new tests covering cardinal-axis classification, fast-path dispatch,
  round-trip, Newton agreement (atol 1e-9), unreachable-target handling,
  degenerate `q ∥ n` case, and tilted-axis fallback.
- All 1988 existing + new tests pass.
- Slow benchmark suite (`pytest -m slow_benchmark`) passes (3/3, 51 s).

Contributed by: OpenCode (argo/claudeopus47)