### PR TITLE
refactor: remove dead Q-recheck and dedup loop in kappa bisecting wrapper (#245)

### DIFF
--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -865,7 +865,6 @@ def _solve_bisecting_kappa_virtual(
     """
     from .kappa import kappa_to_eulerian_axes
     from .kappa import solve_kappa_virtual
-    from .orientation import angles_to_phi_vector as _a2phi
 
     Q_phi_arr = np.asarray(Q_phi, dtype=float)
 
@@ -874,40 +873,28 @@ def _solve_bisecting_kappa_virtual(
     convention = geometry.kappa_pseudo_angle_convention
     omega_target = ttheta_deg / 2.0
 
+    # ``solve_kappa_virtual`` returns analytic, deduplicated kappa
+    # motor triples (the geometry-aware decomposition introduced by
+    # issue #241 is exact, and the inner solver deduplicates at 1e-6).
+    # The wrapper therefore only needs to:
+    #   1. enforce the virtual-bisect omega = ttheta/2 condition (the
+    #      equivalent Eulerian solver returns both chi branches, only
+    #      one of which is bisecting);
+    #   2. apply mode cut-points; and
+    #   3. drop solutions outside the hardware stage limits.
+    # No residual Q-recheck or wrapper-side dedup is needed; both were
+    # removed in issue #245 cleanup as unreachable post-#241 code.
     solutions: list[dict[str, float]] = []
     for sol in raw:
         merged = dict(angles)
         merged.update(sol)
-        # Enforce the virtual-bisect constraint: the equivalent
-        # Eulerian solver returns both analytic chi branches, but
-        # only one (the principal +chi branch) satisfies
-        # ``omega_virtual = ttheta/2``.  The other branch differs by
-        # 180° in omega and must be filtered out before validation.
         om_v, _, _ = kappa_to_eulerian_axes(
             merged["komega"], merged["kappa"], merged["kphi"], convention
         )
         residual = (om_v - omega_target + 180.0) % 360.0 - 180.0
         if abs(residual) > 1e-6:
             continue
-        # Final correctness check: ensure the kappa stack actually
-        # produces the target Q vector.
-        Q_check = _a2phi(geometry, **merged)
-        if float(np.linalg.norm(Q_check - Q_phi_arr)) > 1e-6:  # pragma: no cover
-            continue
         _apply_cut_points(merged, mode, geometry)
-        # Deduplicate on the kappa motor triple (the equivalent
-        # Eulerian solver may return both the +chi and −chi solutions
-        # which can collapse to the same kappa triple).
-        duplicate = False
-        for existing in solutions:
-            if all(
-                abs(existing.get(name, 0.0) - merged.get(name, 0.0)) < 1e-4
-                for name in ("komega", "kappa", "kphi")
-            ):  # pragma: no cover
-                duplicate = True
-                break
-        if duplicate:  # pragma: no cover
-            continue
         if not _check_limits(geometry, merged):
             continue
         solutions.append(merged)

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -2743,27 +2743,23 @@ def test_solve_bisecting_analytic_dedup_branch(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_kappa_bisecting_post_processing_dedup_and_limits(monkeypatch):
-    """Cover the dedup-loop fall-through and limits-rejection branch
-    of the kappa bisecting wrapper.
+def test_kappa_bisecting_post_processing_limits_rejection(monkeypatch):
+    """Cover the limits-rejection branch of the kappa bisecting wrapper.
 
     After issue #241 the wrapper
     :func:`~ad_hoc_diffractometer.forward._solve_bisecting_kappa_virtual`
     is a thin shell around
     :func:`~ad_hoc_diffractometer.kappa.solve_kappa_virtual` that
-    applies cut-points, the ``_check_limits`` filter, and final
-    deduplication on ``(komega, kappa, kphi)``.  The natural solver
-    returns at most a single solution for every reachable HKL in our
-    test geometries, so this test injects two synthetic candidates by
-    monkeypatching ``solve_kappa_virtual`` and the module-level
-    helpers in the wrapper:
+    enforces the virtual-bisect ``omega = ttheta/2`` condition,
+    applies cut-points, and drops solutions outside the hardware
+    stage limits.  Issue #245 removed the unreachable Q-residual
+    recheck and the wrapper-side dedup loop (the inner solver already
+    deduplicates at 1e-6, tighter than the previous 1e-4 wrapper
+    check), so this test now covers only the surviving filters.
 
-    * the dedup loop ``for existing in solutions:`` must traverse
-      without matching either candidate against the other;
-    * the limits-rejection ``continue`` must drop one of the two.
-
-    The wrapper's residual safety check is bypassed by patching
-    ``angles_to_phi_vector`` to return the target Q exactly.
+    Two synthetic candidates are injected via a monkeypatch of
+    ``solve_kappa_virtual``; the limits stub accepts one and rejects
+    the other.
 
     Validates the geometry-aware infrastructure introduced by issue
     #241; the legacy Walko ``kappa_to_eulerian`` /
@@ -2772,33 +2768,22 @@ def test_kappa_bisecting_post_processing_dedup_and_limits(monkeypatch):
     """
     from ad_hoc_diffractometer import forward as fmod
     from ad_hoc_diffractometer import kappa as kmod
-    from ad_hoc_diffractometer import orientation as omod
 
     g = _setup_cubic(kappa4cv, a=4.0)
     assert g.mode_name == "bisecting"
 
-    # Two distinct, non-duplicate candidate motor triples.  They differ
-    # by far more than the 1e-4 dedup tolerance, so the dedup loop
-    # iterates without finding a match.
+    # Two distinct candidate motor triples.
     candidate_a = {"komega": 10.0, "kappa": 5.0, "kphi": 30.0}
     candidate_b = {"komega": 20.0, "kappa": -5.0, "kphi": 60.0}
 
     def _fake_solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode):
         return [dict(candidate_a), dict(candidate_b)]
 
-    # The wrapper uses ``angles_to_phi_vector`` for its residual
-    # safety check.  Force it to return the target Q exactly.
-    def _fake_a2phi(geometry, **angles):
-        return np.asarray(_fake_a2phi.target, dtype=float)
-
-    _fake_a2phi.target = g.sample.UB @ np.array([0.0, 1.0, 0.0])
-
     # Limits-check stub: accept candidate_a, reject candidate_b.
     def _fake_check_limits(geometry, angles):
         return abs(angles.get("kphi", 0.0) - candidate_b["kphi"]) > 1e-6
 
     monkeypatch.setattr(kmod, "solve_kappa_virtual", _fake_solve_kappa_virtual)
-    monkeypatch.setattr(omod, "angles_to_phi_vector", _fake_a2phi)
     monkeypatch.setattr(fmod, "_check_limits", _fake_check_limits)
 
     # The wrapper validates virtual omega against ttheta/2 by inverting


### PR DESCRIPTION
- closes #245

After #247 (geometry-aware kappa decomposition for #241) the kappa
bisecting wrapper `_solve_bisecting_kappa_virtual` carried two
unreachable code paths, both marked `# pragma: no cover`:

* a Q-residual recheck against `angles_to_phi_vector` that never fires
  because the analytic Eulerian solver plus the exact
  `eulerian_to_kappa_axes` decomposition agree to machine precision
  on every reachable reflection;
* a 1e-4 wrapper-side dedup loop that never finds a duplicate because
  the inner solver `solve_kappa_virtual` already deduplicates at the
  tighter 1e-6 tolerance.

This PR deletes the dead code outright (and the now-unused
`angles_to_phi_vector` import in that function) rather than keeping
the pragma markers, leaving the wrapper as a focused three-step
filter: virtual-bisect residual, cut-points, hardware limits.

The monkeypatched coverage test from #239 is renamed to
`test_kappa_bisecting_post_processing_limits_rejection` and trimmed
to exercise only the surviving filters.

Net change: -28 lines.

Verification:
* `python3 -m pytest -q` -> 2141 passed, 100% total coverage.
* `python3 -m pytest -m slow_benchmark --no-cov -q` -> 3 passed
  (kappa is on the hot path).

Note: the bulk of #245's original scope (deleting `_newton_solve`,
`_polish`, `_MAX_STALE`, etc.) was already completed by #247.  Only
the residual unreachable branches identified above remained.

Contributed by: OpenCode (argo/claudeopus47)