### PR TITLE
fix: psic fixed_chi_horizontal default chi=0; psic modes audit (#259)

### DIFF
--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -191,9 +191,17 @@ The scattering plane is locked horizontal by `eta = 0` and `delta = 0`;
 
 ### `fixed_chi_horizontal`
 
-`chi` held at declared value (default 90°), `eta = 0`, `delta = 0`.
+`chi` held at declared value (default 0°), `eta = 0`, `delta = 0`.
 The scattering plane is locked horizontal by `eta = 0` and `delta = 0`;
 `mu`, `phi`, and `nu` are solved from the hkl equations.
+
+The default chi value differs from the vertical counterpart
+(`fixed_chi_vertical`, default 90°): with `eta = 0` the residual
+psic sub-geometry places the chi-circle axis along the longitudinal
+(beam) direction, so `chi = 0` is the value that keeps the phi axis
+in the horizontal scattering plane.  The four-circle "spinning Q"
+value `chi = 90°` tilts the phi axis out of the horizontal plane and
+is kinematically infeasible in this mode.
 
 | | |
 |---|---|

--- a/src/ad_hoc_diffractometer/presets.py
+++ b/src/ad_hoc_diffractometer/presets.py
@@ -461,8 +461,17 @@ def psic(basis: dict = BASIS_YOU) -> AdHocDiffractometer:
             computed=["mu", "chi", "nu"],
         ),
         "fixed_chi_horizontal": ConstraintSet(
+            # Default chi = 0 (issue #259).  In the horizontal scattering
+            # plane (eta = 0, delta = 0) the residual psic sub-geometry
+            # places the chi-circle axis along the longitudinal (beam)
+            # direction; chi = 0 keeps the phi axis along that same
+            # direction so phi rotations stay in the horizontal plane.
+            # chi = 90 (the four-circle "spinning Q" symmetry value used
+            # in fourcv/fourch and in the *vertical* counterpart
+            # fixed_chi_vertical) tilts the phi axis out of the
+            # horizontal plane and is kinematically infeasible here.
             [
-                SampleConstraint("chi", 90.0),
+                SampleConstraint("chi", 0.0),
                 SampleConstraint("eta", 0.0),
                 DetectorConstraint("delta", 0.0),
             ],

--- a/tests/test_regression_issue_243.py
+++ b/tests/test_regression_issue_243.py
@@ -45,18 +45,24 @@ These four modes were removed in the same PR.  See
 Note on ``fixed_chi_horizontal``
 --------------------------------
 
-After the fix, ``fixed_chi_horizontal`` (chi held at 90°, eta = 0,
-delta = 0) is kinematically infeasible on the cubic ``UB = B`` test
-crystal: ``chi = 90`` rotates Q out of the horizontal scattering
-plane, conflicting with ``delta = 0``.  This is a separate concern
-from the bisect-vs-plane-lock fix in #243 (the constraint structure
-is now correct; only the *value* of chi appears wrong, suggesting
-the SPEC convention is ``chi = 0``).  Resolution of the correct
-default chi value (and the full audit of psic modes against SPEC
-``psic`` and Hkl/Soleil ``E6C``) is tracked in **issue #259**.  This
-file therefore does not parametrise ``fixed_chi_horizontal`` for
-the round-trip / plane-lock value tests; the test row will be added
-when #259 lands the corrected default.
+After the #243 fix the constraint *structure* of
+``fixed_chi_horizontal`` was correct (``eta = 0``, ``delta = 0``,
+``chi`` fixed) but the *value* of chi was wrong: it carried over the
+``chi = 90`` default from ``fixed_chi_vertical`` and from the
+four-circle ``fixed_chi`` modes, where 90° is the canonical
+"spinning Q" symmetry value.  In the horizontal-scattering psic
+sub-geometry ``chi = 90`` instead tilts the phi axis out of the
+horizontal plane, conflicting with ``delta = 0`` and rendering every
+low-index hkl unreachable on a cubic ``UB = B`` crystal.
+
+Issue #259 audited the psic modes against SPEC ``psic`` and Hkl/Soleil
+``E6C`` and resolved the default to ``chi = 0`` — the value that keeps
+the phi axis in the horizontal scattering plane (the chi-circle axis
+in the residual sub-geometry lies along the longitudinal/beam
+direction with ``eta = 0``).  This file now parametrises
+``fixed_chi_horizontal`` for the eta-lock, round-trip and full
+plane-lock invariant tests using hkl that are reachable with the new
+default.
 
 This file lives at the cross-module regression level rather than in
 ``tests/test_presets.py`` because the symptom is visible only after
@@ -160,9 +166,7 @@ _HKL_VERTICAL = [
     pytest.param(1, 1, 1, id="111"),
 ]
 
-# fixed_phi_horizontal is reachable on cubic UB=B for the hkl below;
-# fixed_chi_horizontal is *not* reachable for any low-index hkl on this
-# crystal (see module docstring for why).
+# fixed_phi_horizontal is reachable on cubic UB=B for the hkl below.
 _HKL_HORIZONTAL = [
     pytest.param(0, 1, 0, id="010"),
     pytest.param(0, 0, 1, id="001"),
@@ -170,6 +174,19 @@ _HKL_HORIZONTAL = [
     pytest.param(1, 0, 1, id="101"),
     pytest.param(1, 1, 0, id="110"),
     pytest.param(1, 1, 1, id="111"),
+]
+
+# fixed_chi_horizontal at the new (#259) default chi = 0 is reachable
+# only for hkl with h = 0 on cubic UB = B, because chi = 0 leaves the
+# phi-circle axis along the longitudinal (beam) direction so phi
+# rotations cannot move the h-component of Q out of the beam plane.
+_HKL_FIXED_CHI_HORIZONTAL = [
+    pytest.param(0, 1, 0, id="010"),
+    pytest.param(0, 0, 1, id="001"),
+    pytest.param(0, 1, 1, id="011"),
+    pytest.param(0, 0, 2, id="002"),
+    pytest.param(0, 2, 1, id="021"),
+    pytest.param(0, 1, 2, id="012"),
 ]
 
 
@@ -202,12 +219,7 @@ def test_fixed_vertical_modes_lock_mu(mode_name, locked_stage, h, k, l):  # noqa
 
 @pytest.mark.parametrize("h, k, l", _HKL_HORIZONTAL)
 def test_fixed_phi_horizontal_locks_eta(h, k, l):  # noqa: E741
-    """``eta`` is exactly zero in every forward solution for fixed_phi_horizontal.
-
-    fixed_chi_horizontal is omitted: see module docstring (chi=90 is
-    kinematically infeasible on cubic UB=B; deferred to the audit
-    follow-up issue).
-    """
+    """``eta`` is exactly zero in every forward solution for fixed_phi_horizontal."""
     g = _setup_psic_cubic()
     g.mode_name = "fixed_phi_horizontal"
     solutions = g.forward(h, k, l)
@@ -217,6 +229,28 @@ def test_fixed_phi_horizontal_locks_eta(h, k, l):  # noqa: E741
     for sol in solutions:
         assert sol["eta"] == pytest.approx(0.0, abs=1e-8), (
             f"fixed_phi_horizontal: eta={sol['eta']!r} (expected 0)"
+        )
+
+
+@pytest.mark.parametrize("h, k, l", _HKL_FIXED_CHI_HORIZONTAL)
+def test_fixed_chi_horizontal_locks_eta(h, k, l):  # noqa: E741
+    """``eta`` is exactly zero in every forward solution for fixed_chi_horizontal.
+
+    Resolved in issue #259: the default chi value was corrected from
+    90° (the four-circle "spinning Q" value, kinematically infeasible
+    here) to 0° (which keeps the phi axis in the horizontal scattering
+    plane).  Reachable hkl on cubic UB = B all have h = 0; see the
+    ``_HKL_FIXED_CHI_HORIZONTAL`` list.
+    """
+    g = _setup_psic_cubic()
+    g.mode_name = "fixed_chi_horizontal"
+    solutions = g.forward(h, k, l)
+    assert len(solutions) > 0, (
+        f"forward({h},{k},{l}) returned no solutions for fixed_chi_horizontal"
+    )
+    for sol in solutions:
+        assert sol["eta"] == pytest.approx(0.0, abs=1e-8), (
+            f"fixed_chi_horizontal: eta={sol['eta']!r} (expected 0)"
         )
 
 
@@ -235,6 +269,9 @@ def test_fixed_phi_horizontal_locks_eta(h, k, l):  # noqa: E741
         pytest.param("fixed_phi_horizontal", 0, 0, 1, id="fixed_phi_horizontal-001"),
         pytest.param("fixed_phi_horizontal", 0, 1, 1, id="fixed_phi_horizontal-011"),
         pytest.param("fixed_phi_horizontal", 1, 1, 1, id="fixed_phi_horizontal-111"),
+        pytest.param("fixed_chi_horizontal", 0, 1, 0, id="fixed_chi_horizontal-010"),
+        pytest.param("fixed_chi_horizontal", 0, 0, 1, id="fixed_chi_horizontal-001"),
+        pytest.param("fixed_chi_horizontal", 0, 1, 1, id="fixed_chi_horizontal-011"),
     ],
 )
 def test_round_trip_forward_inverse(mode_name, h, k, l):  # noqa: E741
@@ -291,6 +328,17 @@ def test_round_trip_forward_inverse(mode_name, h, k, l):  # noqa: E741
             0,
             1,
             id="fixed_phi_horizontal-001",
+        ),
+        pytest.param(
+            "fixed_chi_horizontal",
+            "eta",
+            "delta",
+            "chi",
+            0.0,
+            0,
+            0,
+            1,
+            id="fixed_chi_horizontal-001",
         ),
     ],
 )


### PR DESCRIPTION
- closes #259

Audit of all 18 psic modes against SPEC `psic`, Hkl/Soleil E6C `hkl`
engine, and You (1999) §5–§6.  Resolves the open question carried
forward from #243: the `fixed_chi_horizontal` default chi value was
`90°` (kinematically infeasible on cubic `UB = B`) and is corrected to
`0°`.  The previously-skipped `fixed_chi_horizontal` rows in
`tests/test_regression_issue_243.py` are now parametrised across the
eta-lock, round-trip, and full plane-lock invariant tests.

The full audit (cross-reference table mapping every ad_hoc psic mode
to its SPEC `setmode` tuple, Hkl E6C `hkl`-engine analogue, and You
1999 section, plus gaps and extras) is posted as a comment on issue
#259.

Three follow-up issues for missing modes (`omega_fixed_*`, `zone`,
`laue`) are drafted and will be filed separately.

Per AGENTS.md: `CHANGES.md` intentionally not updated in this PR.

Contributed by: OpenCode (argo/claudeopus47)