### PR TITLE
feat: psic and kappa6c zone modes (You §6, SPEC setmode 5) (#262)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ Issues](https://github.com/prjemian/ad_hoc_diffractometer/issues) for the full
 issue tracker.  The initial project development roadmap is documented here:
 [roadmap](https://github.com/prjemian/ad_hoc_diffractometer/blob/main/roadmap.md).
 
+## Unreleased
+
+### Added
+
+- psic and kappa6c zone modes (You §6, SPEC `setmode 5`) (#262)
+
 ## Release v0.9.3
 
 Released 2026-05-04.

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -327,9 +327,6 @@ reference-angle constraint (0 = none, 4 = ψ-fixed), and
 
 —: no documented analog exists in that package.
 
-†: none of the kappa6c modes listed here trigger SPEC's not-working
-set (see the dagger note on the psic page).
-
 References:
 [SPEC `kappa6c` macros](https://certif.com/spec_help/kappa6c.html);
 [Hkl/Soleil K6C](https://people.debian.org/~picca/hkl/hkl.html);

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -136,17 +136,6 @@ Vertical scattering plane (psic-style).
 | **Computed** | komega, kappa, kphi, delta |
 | **Constant during** `forward()` | mu = 0, nu = 0 |
 
-### `bisecting_horizontal`
-
-{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
-`mu = nu/2`, `komega = 0`, `delta = 0`.
-Horizontal scattering plane.
-
-| | |
-|---|---|
-| **Computed** | mu, kappa, kphi, nu |
-| **Constant during** `forward()` | komega = 0, delta = 0 |
-
 ### `fixed_kphi`
 
 {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
@@ -178,39 +167,6 @@ Analogous to psic `fixed_nu`.
 | **Computed** | komega, kappa, kphi, delta |
 | **Constant during** `forward()` | nu, mu = 0 |
 
-### `fixed_delta`
-
-{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
-`delta` held at declared value (default 0°), `mu = nu/2`, `komega = 0`.
-Horizontal plane with delta frozen.
-
-| | |
-|---|---|
-| **Computed** | mu, kappa, kphi, nu |
-| **Constant during** `forward()` | delta, komega = 0 |
-
-### `lifting_detector_mu`
-
-Out-of-plane mode: mu and komega frozen, nu and delta solved via the qaz
-constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
-``qaz = 90°`` constrains the scattering to the vertical plane.
-
-| | |
-|---|---|
-| **Computed** | mu, nu, delta |
-| **Constant during** `forward()` | mu = 0, komega = 0 |
-
-### `lifting_detector_kphi`
-
-Out-of-plane mode: kphi and mu frozen, nu and delta solved via the qaz
-constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
-``qaz = 90°`` constrains the scattering to the vertical plane.
-
-| | |
-|---|---|
-| **Computed** | kphi, nu, delta |
-| **Constant during** `forward()` | kphi = 0, mu = 0 |
-
 ### `fixed_psi_vertical`
 
 Vertical bisecting with azimuthal angle ψ validation.
@@ -222,19 +178,6 @@ requested (h,k,l) matches the stored target.  See {doc}`../howto/surface`.
 |---|---|
 | **Computed** | komega, kappa, kphi, delta |
 | **Constant during** `forward()` | mu = 0, nu = 0 |
-| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
-| **Extras (output)** | psi (computed azimuth) |
-
-### `fixed_psi_horizontal`
-
-Horizontal bisecting with azimuthal angle ψ validation.
-Symmetric with `fixed_psi_vertical` in the horizontal plane.
-Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
-
-| | |
-|---|---|
-| **Computed** | mu, kappa, kphi, nu |
-| **Constant during** `forward()` | komega = 0, delta = 0 |
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
@@ -271,6 +214,41 @@ g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
 | **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
 | **Extras (output)** | in_plane_residual |
 
+### `bisecting_horizontal`
+
+{class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
+`mu = nu/2`, `komega = 0`, `delta = 0`.
+Horizontal scattering plane.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+
+### `fixed_delta`
+
+{class}`~ad_hoc_diffractometer.mode.DetectorConstraint` + {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint`:
+`delta` held at declared value (default 0°), `mu = nu/2`, `komega = 0`.
+Horizontal plane with delta frozen.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | delta, komega = 0 |
+
+### `fixed_psi_horizontal`
+
+Horizontal bisecting with azimuthal angle ψ validation.
+Symmetric with `fixed_psi_vertical` in the horizontal plane.
+Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+| **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
+| **Extras (output)** | psi (computed azimuth) |
+
 ### `double_diffraction_horizontal`
 
 Full 4D simultaneous solver in the horizontal scattering plane.
@@ -293,6 +271,28 @@ kappa motor pair solves any in-plane (h, k, l).
 | **Constant during** `forward()` | komega = 0, delta = 0 |
 | **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
 | **Extras (output)** | in_plane_residual |
+
+### `lifting_detector_mu`
+
+Out-of-plane mode: mu and komega frozen, nu and delta solved via the qaz
+constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
+``qaz = 90°`` constrains the scattering to the vertical plane.
+
+| | |
+|---|---|
+| **Computed** | mu, nu, delta |
+| **Constant during** `forward()` | mu = 0, komega = 0 |
+
+### `lifting_detector_kphi`
+
+Out-of-plane mode: kphi and mu frozen, nu and delta solved via the qaz
+constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
+``qaz = 90°`` constrains the scattering to the vertical plane.
+
+| | |
+|---|---|
+| **Computed** | kphi, nu, delta |
+| **Constant during** `forward()` | kphi = 0, mu = 0 |
 
 ## Mode cross-reference
 
@@ -324,9 +324,11 @@ where `g_mode1` selects the scattering plane (1 = horizontal,
 2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
 reference-angle constraint (0 = none, 4 = ψ-fixed), and
 `g_mode3`–`g_mode5` fix specific motor angles. A dash (—) means no
-documented analogue exists in that package; SPEC's not-working modes
-(see the dagger note on the psic page) do not affect any mode listed
-here. References:
+documented analogue exists in that package; none of the kappa6c modes
+listed here trigger SPEC's not-working set (see the dagger note on the
+psic page).
+
+References:
 [SPEC `kappa6c` macros](https://certif.com/spec_help/kappa6c.html);
 [Hkl/Soleil K6C](https://people.debian.org/~picca/hkl/hkl.html);
 [Hkl source](https://repo.or.cz/hkl.git).

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -260,6 +260,69 @@ Full 4D simultaneous solver in the horizontal scattering plane.
 | **Constant during** `forward()` | komega = 0, delta = 0 |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
+### `zone_vertical`
+
+Zone mode (You 1999 §6, SPEC `setmode 5`).  Q is confined to the plane
+spanned by two reciprocal-lattice vectors `z0` and `z1`.  Structurally
+identical to the psic `zone_vertical` mode, with the bisecting condition
+enforced on the **virtual** Eulerian omega pseudoangle (Walko 2016
+eq. [16]) rather than the literal `komega` motor.  Off-plane requests
+return an empty list with a warning.
+
+```python
+g.modes['zone_vertical'].extras['z0'] = (1, 0, 0)
+g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
+```
+
+| | |
+|---|---|
+| **Computed** | komega, kappa, kphi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
+### `zone_horizontal`
+
+Horizontal-plane analogue of `zone_vertical`.  Locks `komega = 0`,
+`delta = 0`; the bisecting condition `mu = nu/2` together with the
+kappa motor pair solves any in-plane (h, k, l).
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
+## Cross-reference table
+
+The table below maps each `kappa6c` mode to its closest analogue in
+SPEC's `kappa6c` macros and the Hkl/Soleil `K6C` `hkl` engine.  The
+psic mode column shows the equivalent psic mode (kappa6c shares the
+psic outer-axis ordering and most named modes correspond directly).
+
+| `ad_hoc_diffractometer` mode | Equivalent psic mode | SPEC `kappa6c` analogue | Hkl/Soleil K6C `hkl` engine |
+|---|---|---|---|
+| `bisecting_vertical` | `bisecting_vertical` | nu-fixed + omega=del/2 (virtual) | `bissector_vertical` |
+| `bisecting_horizontal` | `bisecting_horizontal` | delta-fixed + mu=nu/2 | `bissector_horizontal` |
+| `fixed_kphi` | `fixed_phi_vertical` (analogue) | nu-fixed + kphi-fixed + mu-fixed | `constant_phi_vertical` |
+| `fixed_mu` | (specific to kappa6c) | nu-fixed + omega=del/2 + mu-fixed | (no analogue) |
+| `fixed_nu` | (specific to kappa6c) | nu-fixed + omega=del/2 + mu-fixed | (no analogue) |
+| `fixed_delta` | (specific to kappa6c) | delta-fixed + mu=nu/2 + komega-fixed | (no analogue) |
+| `lifting_detector_mu` | `lifting_detector_mu` | qaz-fixed + mu-fixed + komega-fixed | `lifting_detector_mu` |
+| `lifting_detector_kphi` | `lifting_detector_phi` | qaz-fixed + kphi-fixed + mu-fixed | `lifting_detector_kphi` |
+| `fixed_psi_vertical` | `fixed_psi_vertical` | nu-fixed + psi-fixed + omega=del/2 | `psi_constant_vertical` |
+| `fixed_psi_horizontal` | `fixed_psi_horizontal` | delta-fixed + psi-fixed + mu=nu/2 | `psi_constant_horizontal` |
+| `double_diffraction_vertical` | `double_diffraction_vertical` | (no SPEC analogue) | `double_diffraction_vertical` |
+| `double_diffraction_horizontal` | `double_diffraction_horizontal` | (no SPEC analogue) | `double_diffraction_horizontal` |
+| `zone_vertical` | `zone_vertical` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) |
+| `zone_horizontal` | `zone_horizontal` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) |
+
+References:
+- SPEC `kappa6c` macros: <https://certif.com/spec_help/kappa6c.html>
+- Hkl/Soleil K6C: <https://people.debian.org/~picca/hkl/hkl.html>
+- Hkl source (`TODO HklEngine "zone"`): <https://repo.or.cz/hkl.git>
+
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.presets.kappa6c`

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -323,10 +323,12 @@ The SPEC tuple is `(g_mode1, g_mode2, g_mode3, g_mode4, g_mode5)`,
 where `g_mode1` selects the scattering plane (1 = horizontal,
 2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
 reference-angle constraint (0 = none, 4 = ψ-fixed), and
-`g_mode3`–`g_mode5` fix specific motor angles. A dash (—) means no
-documented analogue exists in that package; none of the kappa6c modes
-listed here trigger SPEC's not-working set (see the dagger note on the
-psic page).
+`g_mode3`–`g_mode5` fix specific motor angles.
+
+—: no documented analogue exists in that package.
+
+†: none of the kappa6c modes listed here trigger SPEC's not-working
+set (see the dagger note on the psic page).
 
 References:
 [SPEC `kappa6c` macros](https://certif.com/spec_help/kappa6c.html);

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -250,16 +250,6 @@ reflections satisfy the Ewald sphere condition.
 | **Constant during** `forward()` | mu = 0, nu = 0 |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
-### `double_diffraction_horizontal`
-
-Full 4D simultaneous solver in the horizontal scattering plane.
-
-| | |
-|---|---|
-| **Computed** | mu, kappa, kphi, nu |
-| **Constant during** `forward()` | komega = 0, delta = 0 |
-| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
-
 ### `zone_vertical`
 
 Zone mode (You 1999 §6, SPEC `setmode 5`).  Q is confined to the plane
@@ -281,6 +271,16 @@ g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
 | **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
 | **Extras (output)** | in_plane_residual |
 
+### `double_diffraction_horizontal`
+
+Full 4D simultaneous solver in the horizontal scattering plane.
+
+| | |
+|---|---|
+| **Computed** | mu, kappa, kphi, nu |
+| **Constant during** `forward()` | komega = 0, delta = 0 |
+| **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
+
 ### `zone_horizontal`
 
 Horizontal-plane analogue of `zone_vertical`.  Locks `komega = 0`,
@@ -298,31 +298,35 @@ kappa motor pair solves any in-plane (h, k, l).
 
 Each `kappa6c` mode mapped to its equivalent psic mode (the kappa6c
 geometry shares the psic outer-axis ordering), the closest analogue in
-SPEC's `kappa6c` macros, and the Hkl/Soleil `K6C` `hkl` engine.
+SPEC's `kappa6c` macros, and the Hkl/Soleil `K6C` `hkl` engine.  Modes
+are grouped by scattering plane: vertical first, then horizontal, then
+the out-of-plane lifting-detector family.
 
 | mode | psic equivalent | SPEC `kappa6c` | Hkl/Soleil K6C |
 |---|---|---|---|
 | `bisecting_vertical` | `bisecting_vertical` | `(2,0,5,0,0)` | `bissector_vertical` |
-| `bisecting_horizontal` | `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` |
 | `fixed_kphi` | `fixed_phi_vertical` | `(2,0,4,2,0)` | `constant_phi_vertical` |
 | `fixed_mu` | — | `(2,0,5,2,0)` | — |
 | `fixed_nu` | — | `(2,0,5,2,0)` | — |
+| `fixed_psi_vertical` | `fixed_psi_vertical` | `(2,4,5,0,0)` | `psi_constant_vertical` |
+| `double_diffraction_vertical` | `double_diffraction_vertical` | — | `double_diffraction_vertical` |
+| `zone_vertical` | `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) |
+| `bisecting_horizontal` | `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` |
 | `fixed_delta` | — | `(1,0,6,2,0)` | — |
+| `fixed_psi_horizontal` | `fixed_psi_horizontal` | `(1,4,6,0,0)` | `psi_constant_horizontal` |
+| `double_diffraction_horizontal` | `double_diffraction_horizontal` | — | `double_diffraction_horizontal` |
+| `zone_horizontal` | `zone_horizontal` | `setmode 5` | (TODO `HklEngine "zone"`) |
 | `lifting_detector_mu` | `lifting_detector_mu` | `(3,0,1,2,0)` | `lifting_detector_mu` |
 | `lifting_detector_kphi` | `lifting_detector_phi` | `(3,0,4,2,0)` | `lifting_detector_kphi` |
-| `fixed_psi_vertical` | `fixed_psi_vertical` | `(2,4,5,0,0)` | `psi_constant_vertical` |
-| `fixed_psi_horizontal` | `fixed_psi_horizontal` | `(1,4,6,0,0)` | `psi_constant_horizontal` |
-| `double_diffraction_vertical` | `double_diffraction_vertical` | — | `double_diffraction_vertical` |
-| `double_diffraction_horizontal` | `double_diffraction_horizontal` | — | `double_diffraction_horizontal` |
-| `zone_vertical` | `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) |
-| `zone_horizontal` | `zone_horizontal` | `setmode 5` | (TODO `HklEngine "zone"`) |
 
 The SPEC tuple is `(g_mode1, g_mode2, g_mode3, g_mode4, g_mode5)`,
 where `g_mode1` selects the scattering plane (1 = horizontal,
 2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
 reference-angle constraint (0 = none, 4 = ψ-fixed), and
 `g_mode3`–`g_mode5` fix specific motor angles. A dash (—) means no
-documented analogue exists in that package. References:
+documented analogue exists in that package; SPEC's not-working modes
+(see the dagger note on the psic page) do not affect any mode listed
+here. References:
 [SPEC `kappa6c` macros](https://certif.com/spec_help/kappa6c.html);
 [Hkl/Soleil K6C](https://people.debian.org/~picca/hkl/hkl.html);
 [Hkl source](https://repo.or.cz/hkl.git).

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -294,34 +294,38 @@ kappa motor pair solves any in-plane (h, k, l).
 | **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
 | **Extras (output)** | in_plane_residual |
 
-## Cross-reference table
+## Mode cross-reference
 
-The table below maps each `kappa6c` mode to its closest analogue in
-SPEC's `kappa6c` macros and the Hkl/Soleil `K6C` `hkl` engine.  The
-psic mode column shows the equivalent psic mode (kappa6c shares the
-psic outer-axis ordering and most named modes correspond directly).
+Each `kappa6c` mode mapped to its equivalent psic mode (the kappa6c
+geometry shares the psic outer-axis ordering), the closest analogue in
+SPEC's `kappa6c` macros, and the Hkl/Soleil `K6C` `hkl` engine.
 
-| `ad_hoc_diffractometer` mode | Equivalent psic mode | SPEC `kappa6c` analogue | Hkl/Soleil K6C `hkl` engine |
+| mode | psic equivalent | SPEC `kappa6c` | Hkl/Soleil K6C |
 |---|---|---|---|
-| `bisecting_vertical` | `bisecting_vertical` | nu-fixed + omega=del/2 (virtual) | `bissector_vertical` |
-| `bisecting_horizontal` | `bisecting_horizontal` | delta-fixed + mu=nu/2 | `bissector_horizontal` |
-| `fixed_kphi` | `fixed_phi_vertical` (analogue) | nu-fixed + kphi-fixed + mu-fixed | `constant_phi_vertical` |
-| `fixed_mu` | (specific to kappa6c) | nu-fixed + omega=del/2 + mu-fixed | (no analogue) |
-| `fixed_nu` | (specific to kappa6c) | nu-fixed + omega=del/2 + mu-fixed | (no analogue) |
-| `fixed_delta` | (specific to kappa6c) | delta-fixed + mu=nu/2 + komega-fixed | (no analogue) |
-| `lifting_detector_mu` | `lifting_detector_mu` | qaz-fixed + mu-fixed + komega-fixed | `lifting_detector_mu` |
-| `lifting_detector_kphi` | `lifting_detector_phi` | qaz-fixed + kphi-fixed + mu-fixed | `lifting_detector_kphi` |
-| `fixed_psi_vertical` | `fixed_psi_vertical` | nu-fixed + psi-fixed + omega=del/2 | `psi_constant_vertical` |
-| `fixed_psi_horizontal` | `fixed_psi_horizontal` | delta-fixed + psi-fixed + mu=nu/2 | `psi_constant_horizontal` |
-| `double_diffraction_vertical` | `double_diffraction_vertical` | (no SPEC analogue) | `double_diffraction_vertical` |
-| `double_diffraction_horizontal` | `double_diffraction_horizontal` | (no SPEC analogue) | `double_diffraction_horizontal` |
-| `zone_vertical` | `zone_vertical` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) |
-| `zone_horizontal` | `zone_horizontal` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) |
+| `bisecting_vertical` | `bisecting_vertical` | `(2,0,5,0,0)` | `bissector_vertical` |
+| `bisecting_horizontal` | `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` |
+| `fixed_kphi` | `fixed_phi_vertical` | `(2,0,4,2,0)` | `constant_phi_vertical` |
+| `fixed_mu` | — | `(2,0,5,2,0)` | — |
+| `fixed_nu` | — | `(2,0,5,2,0)` | — |
+| `fixed_delta` | — | `(1,0,6,2,0)` | — |
+| `lifting_detector_mu` | `lifting_detector_mu` | `(3,0,1,2,0)` | `lifting_detector_mu` |
+| `lifting_detector_kphi` | `lifting_detector_phi` | `(3,0,4,2,0)` | `lifting_detector_kphi` |
+| `fixed_psi_vertical` | `fixed_psi_vertical` | `(2,4,5,0,0)` | `psi_constant_vertical` |
+| `fixed_psi_horizontal` | `fixed_psi_horizontal` | `(1,4,6,0,0)` | `psi_constant_horizontal` |
+| `double_diffraction_vertical` | `double_diffraction_vertical` | — | `double_diffraction_vertical` |
+| `double_diffraction_horizontal` | `double_diffraction_horizontal` | — | `double_diffraction_horizontal` |
+| `zone_vertical` | `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) |
+| `zone_horizontal` | `zone_horizontal` | `setmode 5` | (TODO `HklEngine "zone"`) |
 
-References:
-- SPEC `kappa6c` macros: <https://certif.com/spec_help/kappa6c.html>
-- Hkl/Soleil K6C: <https://people.debian.org/~picca/hkl/hkl.html>
-- Hkl source (`TODO HklEngine "zone"`): <https://repo.or.cz/hkl.git>
+The SPEC tuple is `(g_mode1, g_mode2, g_mode3, g_mode4, g_mode5)`,
+where `g_mode1` selects the scattering plane (1 = horizontal,
+2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
+reference-angle constraint (0 = none, 4 = ψ-fixed), and
+`g_mode3`–`g_mode5` fix specific motor angles. A dash (—) means no
+documented analogue exists in that package. References:
+[SPEC `kappa6c` macros](https://certif.com/spec_help/kappa6c.html);
+[Hkl/Soleil K6C](https://people.debian.org/~picca/hkl/hkl.html);
+[Hkl source](https://repo.or.cz/hkl.git).
 
 ## API reference
 

--- a/docs/source/geometries/kappa6c.md
+++ b/docs/source/geometries/kappa6c.md
@@ -261,7 +261,7 @@ Full 4D simultaneous solver in the horizontal scattering plane.
 
 ### `zone_horizontal`
 
-Horizontal-plane analogue of `zone_vertical`.  Locks `komega = 0`,
+Horizontal-plane analog of `zone_vertical`.  Locks `komega = 0`,
 `delta = 0`; the bisecting condition `mu = nu/2` together with the
 kappa motor pair solves any in-plane (h, k, l).
 
@@ -297,7 +297,7 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 ## Mode cross-reference
 
 Each `kappa6c` mode mapped to its equivalent psic mode (the kappa6c
-geometry shares the psic outer-axis ordering), the closest analogue in
+geometry shares the psic outer-axis ordering), the closest analog in
 SPEC's `kappa6c` macros, and the Hkl/Soleil `K6C` `hkl` engine.  Modes
 are grouped by scattering plane: vertical first, then horizontal, then
 the out-of-plane lifting-detector family.
@@ -325,7 +325,7 @@ where `g_mode1` selects the scattering plane (1 = horizontal,
 reference-angle constraint (0 = none, 4 = ψ-fixed), and
 `g_mode3`–`g_mode5` fix specific motor angles.
 
-—: no documented analogue exists in that package.
+—: no documented analog exists in that package.
 
 †: none of the kappa6c modes listed here trigger SPEC's not-working
 set (see the dagger note on the psic page).

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -373,11 +373,15 @@ where `g_mode1` selects the scattering plane (1 = horizontal,
 reference-angle constraint (0 = none, 1 = α=β, 2 = α-fixed,
 3 = β-fixed, 4 = ψ-fixed), and `g_mode3`–`g_mode5` fix specific motor
 angles. A dash (—) means no documented analogue exists in that
-package. The dagger (†) marks SPEC mode tuples that the SPEC
-documentation lists as currently not working (the eta-fixed + chi-fixed
-and eta-fixed + phi-fixed combinations under `setmode d1 0 s1 s2`); the
+package.
+
+†: SPEC mode tuples flagged here are listed by the SPEC documentation
+as currently not working (the eta-fixed + chi-fixed and eta-fixed +
+phi-fixed combinations under `setmode d1 0 s1 s2`); the
 `ad_hoc_diffractometer` implementation of these modes is independent of
-SPEC and works as documented above. References:
+SPEC and works as documented above.
+
+References:
 [SPEC `psic` macros](https://certif.com/spec_help/psic.html);
 [Hkl/Soleil E6C](https://people.debian.org/~picca/hkl/hkl.html);
 [Hkl source](https://repo.or.cz/hkl.git).

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -287,6 +287,92 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 | **Computed** | mu, nu, delta |
 | **Constant during** `forward()` | mu = 0, eta = 0 |
 
+### `zone_vertical`
+
+Zone mode (You 1999 §6, SPEC `setmode 5`).  The scattering vector Q is
+confined to the plane spanned by two reciprocal-lattice vectors `z0`
+and `z1`.  A `forward(h, k, l)` call:
+
+1. Verifies the requested (h, k, l) lies in the zone plane (within
+   `1e-6 · |Q|`).  Off-plane requests return an empty solution list and
+   emit a warning.
+2. Records the in-plane residual ``|Q · n_zone|`` in
+   ``mode.extras['in_plane_residual']``.
+3. Returns the bisecting solutions for in-plane reflections (mu = 0,
+   nu = 0, eta = delta/2; chi and phi orient Q within the plane).
+
+The remaining azimuthal degree of freedom around Q is the canonical
+SPEC zone-mode scan (`cz`/`mz` macros) and is not exercised by a single
+`forward()` call.
+
+Set the zone-plane vectors before calling `forward()`:
+
+```python
+g.modes['zone_vertical'].extras['z0'] = (1, 0, 0)
+g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
+```
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
+### `zone_horizontal`
+
+Horizontal-plane analogue of `zone_vertical`.  Locks `eta = 0`,
+`delta = 0`; the bisecting condition `mu = nu/2` together with chi,
+phi solves any in-plane (h, k, l).
+
+Note that horizontal-plane reachability depends on the orientation of
+the zone plane relative to the lab frame.  The `(h, k, 0)` reciprocal
+plane (z0=(1,0,0), z1=(0,1,0)) is generally not reachable in the
+horizontal scattering geometry under the You (1999) basis convention;
+choose a plane that contains a vertical reciprocal direction
+(e.g. z0=(1,0,0), z1=(0,0,1)) for reachable horizontal-plane work.
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
+## Cross-reference table
+
+The table below maps each `psic` mode to the closest analogue in SPEC's
+`psic` macros and the Hkl/Soleil `E6C` `hkl` engine, together with the
+relevant section of You (1999).
+
+| `ad_hoc_diffractometer` mode | SPEC `psic` (`g_mode1`–`g_mode5`) | Hkl/Soleil E6C `hkl` engine | You (1999) section |
+|---|---|---|---|
+| `bisecting_vertical` | `(2, 0, 5, 0, 0)` nu-fixed + eta=del/2 | `bissector_vertical` | §5.1 |
+| `fixed_phi_vertical` | `(2, 0, 4, 2, 0)` nu-fixed + phi-fixed + mu-fixed | `constant_phi_vertical` | §5.2 |
+| `fixed_chi_vertical` | `(2, 0, 3, 2, 0)` nu-fixed + chi-fixed + mu-fixed | `constant_chi_vertical` | §5.2 |
+| `fixed_alpha_i_vertical` | `(2, 2, 5, 0, 0)` nu-fixed + alpha-fixed + eta=del/2 | (no analogue) | §6.1 |
+| `fixed_beta_out_vertical` | `(2, 3, 5, 0, 0)` nu-fixed + beta-fixed + eta=del/2 | (no analogue) | §6.2 |
+| `alpha_eq_beta_vertical` | `(2, 1, 5, 0, 0)` nu-fixed + alpha=beta + eta=del/2 | (no analogue) | §6.3 |
+| `fixed_psi_vertical` | `(2, 4, 5, 0, 0)` nu-fixed + psi-fixed + eta=del/2 | `psi_constant_vertical` | §6.4 |
+| `double_diffraction_vertical` | (no SPEC analogue) | `double_diffraction_vertical` | §6.5 |
+| `zone_vertical` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) | §6 |
+| `bisecting_horizontal` | `(1, 0, 6, 0, 0)` delta-fixed + mu=nu/2 | `bissector_horizontal` | §5.1 |
+| `fixed_phi_horizontal` | `(1, 0, 4, 1, 0)` delta-fixed + phi-fixed + eta-fixed | (no E6C analogue) | §5.2 |
+| `fixed_chi_horizontal` | `(1, 0, 3, 1, 0)` delta-fixed + chi-fixed + eta-fixed | (no E6C analogue) | §5.2 |
+| `fixed_alpha_i_horizontal` | `(1, 2, 6, 0, 0)` | (no analogue) | §6.1 |
+| `fixed_beta_out_horizontal` | `(1, 3, 6, 0, 0)` | (no analogue) | §6.2 |
+| `alpha_eq_beta_horizontal` | `(1, 1, 6, 0, 0)` | (no analogue) | §6.3 |
+| `fixed_psi_horizontal` | `(1, 4, 6, 0, 0)` | `psi_constant_horizontal` | §6.4 |
+| `double_diffraction_horizontal` | (no SPEC analogue) | `double_diffraction_horizontal` | §6.5 |
+| `zone_horizontal` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) | §6 |
+| `lifting_detector_phi` | `(3, 0, 4, 2, 0)` qaz-fixed + phi-fixed + mu-fixed | `lifting_detector_phi` | §5.4 |
+| `lifting_detector_mu` | `(3, 0, 1, 2, 0)` qaz-fixed + eta-fixed + mu-fixed | `lifting_detector_mu` | §5.4 |
+
+References:
+- SPEC `psic` macros: <https://certif.com/spec_help/psic.html>
+- Hkl/Soleil E6C: <https://people.debian.org/~picca/hkl/hkl.html>
+- Hkl source (`TODO HklEngine "zone"`): <https://repo.or.cz/hkl.git>
+
 ## API reference
 
 - {func}`~ad_hoc_diffractometer.presets.psic`

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -339,39 +339,44 @@ choose a plane that contains a vertical reciprocal direction
 | **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
 | **Extras (output)** | in_plane_residual |
 
-## Cross-reference table
+## Mode cross-reference
 
-The table below maps each `psic` mode to the closest analogue in SPEC's
-`psic` macros and the Hkl/Soleil `E6C` `hkl` engine, together with the
-relevant section of You (1999).
+Each `psic` mode mapped to its closest analogue in SPEC's `psic` macros,
+the Hkl/Soleil `E6C` `hkl` engine, and You (1999).
 
-| `ad_hoc_diffractometer` mode | SPEC `psic` (`g_mode1`–`g_mode5`) | Hkl/Soleil E6C `hkl` engine | You (1999) section |
+| mode | SPEC `psic` | Hkl/Soleil E6C | You (1999) |
 |---|---|---|---|
-| `bisecting_vertical` | `(2, 0, 5, 0, 0)` nu-fixed + eta=del/2 | `bissector_vertical` | §5.1 |
-| `fixed_phi_vertical` | `(2, 0, 4, 2, 0)` nu-fixed + phi-fixed + mu-fixed | `constant_phi_vertical` | §5.2 |
-| `fixed_chi_vertical` | `(2, 0, 3, 2, 0)` nu-fixed + chi-fixed + mu-fixed | `constant_chi_vertical` | §5.2 |
-| `fixed_alpha_i_vertical` | `(2, 2, 5, 0, 0)` nu-fixed + alpha-fixed + eta=del/2 | (no analogue) | §6.1 |
-| `fixed_beta_out_vertical` | `(2, 3, 5, 0, 0)` nu-fixed + beta-fixed + eta=del/2 | (no analogue) | §6.2 |
-| `alpha_eq_beta_vertical` | `(2, 1, 5, 0, 0)` nu-fixed + alpha=beta + eta=del/2 | (no analogue) | §6.3 |
-| `fixed_psi_vertical` | `(2, 4, 5, 0, 0)` nu-fixed + psi-fixed + eta=del/2 | `psi_constant_vertical` | §6.4 |
-| `double_diffraction_vertical` | (no SPEC analogue) | `double_diffraction_vertical` | §6.5 |
-| `zone_vertical` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) | §6 |
-| `bisecting_horizontal` | `(1, 0, 6, 0, 0)` delta-fixed + mu=nu/2 | `bissector_horizontal` | §5.1 |
-| `fixed_phi_horizontal` | `(1, 0, 4, 1, 0)` delta-fixed + phi-fixed + eta-fixed | (no E6C analogue) | §5.2 |
-| `fixed_chi_horizontal` | `(1, 0, 3, 1, 0)` delta-fixed + chi-fixed + eta-fixed | (no E6C analogue) | §5.2 |
-| `fixed_alpha_i_horizontal` | `(1, 2, 6, 0, 0)` | (no analogue) | §6.1 |
-| `fixed_beta_out_horizontal` | `(1, 3, 6, 0, 0)` | (no analogue) | §6.2 |
-| `alpha_eq_beta_horizontal` | `(1, 1, 6, 0, 0)` | (no analogue) | §6.3 |
-| `fixed_psi_horizontal` | `(1, 4, 6, 0, 0)` | `psi_constant_horizontal` | §6.4 |
-| `double_diffraction_horizontal` | (no SPEC analogue) | `double_diffraction_horizontal` | §6.5 |
-| `zone_horizontal` | `setmode 5` (zone) | (`HklEngine "zone"` — TODO) | §6 |
-| `lifting_detector_phi` | `(3, 0, 4, 2, 0)` qaz-fixed + phi-fixed + mu-fixed | `lifting_detector_phi` | §5.4 |
-| `lifting_detector_mu` | `(3, 0, 1, 2, 0)` qaz-fixed + eta-fixed + mu-fixed | `lifting_detector_mu` | §5.4 |
+| `bisecting_vertical` | `(2,0,5,0,0)` | `bissector_vertical` | §5.1 |
+| `fixed_phi_vertical` | `(2,0,4,2,0)` | `constant_phi_vertical` | §5.2 |
+| `fixed_chi_vertical` | `(2,0,3,2,0)` | `constant_chi_vertical` | §5.2 |
+| `fixed_alpha_i_vertical` | `(2,2,5,0,0)` | — | §6.1 |
+| `fixed_beta_out_vertical` | `(2,3,5,0,0)` | — | §6.2 |
+| `alpha_eq_beta_vertical` | `(2,1,5,0,0)` | — | §6.3 |
+| `fixed_psi_vertical` | `(2,4,5,0,0)` | `psi_constant_vertical` | §6.4 |
+| `double_diffraction_vertical` | — | `double_diffraction_vertical` | §6.5 |
+| `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) | §6 |
+| `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` | §5.1 |
+| `fixed_phi_horizontal` | `(1,0,4,1,0)` | — | §5.2 |
+| `fixed_chi_horizontal` | `(1,0,3,1,0)` | — | §5.2 |
+| `fixed_alpha_i_horizontal` | `(1,2,6,0,0)` | — | §6.1 |
+| `fixed_beta_out_horizontal` | `(1,3,6,0,0)` | — | §6.2 |
+| `alpha_eq_beta_horizontal` | `(1,1,6,0,0)` | — | §6.3 |
+| `fixed_psi_horizontal` | `(1,4,6,0,0)` | `psi_constant_horizontal` | §6.4 |
+| `double_diffraction_horizontal` | — | `double_diffraction_horizontal` | §6.5 |
+| `zone_horizontal` | `setmode 5` | (TODO `HklEngine "zone"`) | §6 |
+| `lifting_detector_phi` | `(3,0,4,2,0)` | `lifting_detector_phi` | §5.4 |
+| `lifting_detector_mu` | `(3,0,1,2,0)` | `lifting_detector_mu` | §5.4 |
 
-References:
-- SPEC `psic` macros: <https://certif.com/spec_help/psic.html>
-- Hkl/Soleil E6C: <https://people.debian.org/~picca/hkl/hkl.html>
-- Hkl source (`TODO HklEngine "zone"`): <https://repo.or.cz/hkl.git>
+The SPEC tuple is `(g_mode1, g_mode2, g_mode3, g_mode4, g_mode5)`,
+where `g_mode1` selects the scattering plane (1 = horizontal,
+2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
+reference-angle constraint (0 = none, 1 = α=β, 2 = α-fixed,
+3 = β-fixed, 4 = ψ-fixed), and `g_mode3`–`g_mode5` fix specific motor
+angles. A dash (—) means no documented analogue exists in that
+package. References:
+[SPEC `psic` macros](https://certif.com/spec_help/psic.html);
+[Hkl/Soleil E6C](https://people.debian.org/~picca/hkl/hkl.html);
+[Hkl source](https://repo.or.cz/hkl.git).
 
 ## API reference
 

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -299,7 +299,7 @@ Full 4D simultaneous solver in the horizontal scattering plane.
 
 ### `zone_horizontal`
 
-Horizontal-plane analogue of `zone_vertical`.  Locks `eta = 0`,
+Horizontal-plane analog of `zone_vertical`.  Locks `eta = 0`,
 `delta = 0`; the bisecting condition `mu = nu/2` together with chi,
 phi solves any in-plane (h, k, l).
 
@@ -341,7 +341,7 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 
 ## Mode cross-reference
 
-Each `psic` mode mapped to its closest analogue in SPEC's `psic` macros,
+Each `psic` mode mapped to its closest analog in SPEC's `psic` macros,
 the Hkl/Soleil `E6C` `hkl` engine, and You (1999).
 
 | mode | SPEC `psic` | Hkl/Soleil E6C | You (1999) |
@@ -374,7 +374,7 @@ reference-angle constraint (0 = none, 1 = α=β, 2 = α-fixed,
 3 = β-fixed, 4 = ψ-fixed), and `g_mode3`–`g_mode5` fix specific motor
 angles.
 
-—: no documented analogue exists in that package.
+—: no documented analog exists in that package.
 
 †: SPEC mode tuples flagged here are listed by the SPEC documentation
 as currently not working (the eta-fixed + chi-fixed and eta-fixed +

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -372,8 +372,9 @@ where `g_mode1` selects the scattering plane (1 = horizontal,
 2 = vertical, 3 = qaz/lifting-detector), `g_mode2` selects an optional
 reference-angle constraint (0 = none, 1 = α=β, 2 = α-fixed,
 3 = β-fixed, 4 = ψ-fixed), and `g_mode3`–`g_mode5` fix specific motor
-angles. A dash (—) means no documented analogue exists in that
-package.
+angles.
+
+—: no documented analogue exists in that package.
 
 †: SPEC mode tuples flagged here are listed by the SPEC documentation
 as currently not working (the eta-fixed + chi-fixed and eta-fixed +

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -167,6 +167,38 @@ reflections satisfy the Ewald sphere condition.  Set
 | **Constant during** `forward()` | mu = 0, nu = 0 |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
+### `zone_vertical`
+
+Zone mode (You 1999 §6, SPEC `setmode 5`).  The scattering vector Q is
+confined to the plane spanned by two reciprocal-lattice vectors `z0`
+and `z1`.  A `forward(h, k, l)` call:
+
+1. Verifies the requested (h, k, l) lies in the zone plane (within
+   `1e-6 · |Q|`).  Off-plane requests return an empty solution list and
+   emit a warning.
+2. Records the in-plane residual ``|Q · n_zone|`` in
+   ``mode.extras['in_plane_residual']``.
+3. Returns the bisecting solutions for in-plane reflections (mu = 0,
+   nu = 0, eta = delta/2; chi and phi orient Q within the plane).
+
+The remaining azimuthal degree of freedom around Q is the canonical
+SPEC zone-mode scan (`cz`/`mz` macros) and is not exercised by a single
+`forward()` call.
+
+Set the zone-plane vectors before calling `forward()`:
+
+```python
+g.modes['zone_vertical'].extras['z0'] = (1, 0, 0)
+g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
+```
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
 ### `bisecting_horizontal`
 
 {class}`~ad_hoc_diffractometer.mode.BisectConstraint` + {class}`~ad_hoc_diffractometer.mode.SampleConstraint` + {class}`~ad_hoc_diffractometer.mode.DetectorConstraint`:
@@ -265,6 +297,26 @@ Full 4D simultaneous solver in the horizontal scattering plane.
 | **Constant during** `forward()` | eta = 0, delta = 0 |
 | **Extras (input)** | h₂, k₂, l₂ (secondary reflection Miller indices) |
 
+### `zone_horizontal`
+
+Horizontal-plane analogue of `zone_vertical`.  Locks `eta = 0`,
+`delta = 0`; the bisecting condition `mu = nu/2` together with chi,
+phi solves any in-plane (h, k, l).
+
+Note that horizontal-plane reachability depends on the orientation of
+the zone plane relative to the lab frame.  The `(h, k, 0)` reciprocal
+plane (z0=(1,0,0), z1=(0,1,0)) is generally not reachable in the
+horizontal scattering geometry under the You (1999) basis convention;
+choose a plane that contains a vertical reciprocal direction
+(e.g. z0=(1,0,0), z1=(0,0,1)) for reachable horizontal-plane work.
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0 |
+| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
+| **Extras (output)** | in_plane_residual |
+
 ### `lifting_detector_phi`
 
 Out-of-plane mode: phi and mu frozen, nu and delta solved via the qaz
@@ -287,58 +339,6 @@ constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
 | **Computed** | mu, nu, delta |
 | **Constant during** `forward()` | mu = 0, eta = 0 |
 
-### `zone_vertical`
-
-Zone mode (You 1999 §6, SPEC `setmode 5`).  The scattering vector Q is
-confined to the plane spanned by two reciprocal-lattice vectors `z0`
-and `z1`.  A `forward(h, k, l)` call:
-
-1. Verifies the requested (h, k, l) lies in the zone plane (within
-   `1e-6 · |Q|`).  Off-plane requests return an empty solution list and
-   emit a warning.
-2. Records the in-plane residual ``|Q · n_zone|`` in
-   ``mode.extras['in_plane_residual']``.
-3. Returns the bisecting solutions for in-plane reflections (mu = 0,
-   nu = 0, eta = delta/2; chi and phi orient Q within the plane).
-
-The remaining azimuthal degree of freedom around Q is the canonical
-SPEC zone-mode scan (`cz`/`mz` macros) and is not exercised by a single
-`forward()` call.
-
-Set the zone-plane vectors before calling `forward()`:
-
-```python
-g.modes['zone_vertical'].extras['z0'] = (1, 0, 0)
-g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)
-```
-
-| | |
-|---|---|
-| **Computed** | eta, chi, phi, delta |
-| **Constant during** `forward()` | mu = 0, nu = 0 |
-| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
-| **Extras (output)** | in_plane_residual |
-
-### `zone_horizontal`
-
-Horizontal-plane analogue of `zone_vertical`.  Locks `eta = 0`,
-`delta = 0`; the bisecting condition `mu = nu/2` together with chi,
-phi solves any in-plane (h, k, l).
-
-Note that horizontal-plane reachability depends on the orientation of
-the zone plane relative to the lab frame.  The `(h, k, 0)` reciprocal
-plane (z0=(1,0,0), z1=(0,1,0)) is generally not reachable in the
-horizontal scattering geometry under the You (1999) basis convention;
-choose a plane that contains a vertical reciprocal direction
-(e.g. z0=(1,0,0), z1=(0,0,1)) for reachable horizontal-plane work.
-
-| | |
-|---|---|
-| **Computed** | mu, chi, phi, nu |
-| **Constant during** `forward()` | eta = 0, delta = 0 |
-| **Extras (input)** | z0, z1 (Miller-index 3-tuples) |
-| **Extras (output)** | in_plane_residual |
-
 ## Mode cross-reference
 
 Each `psic` mode mapped to its closest analogue in SPEC's `psic` macros,
@@ -356,8 +356,8 @@ the Hkl/Soleil `E6C` `hkl` engine, and You (1999).
 | `double_diffraction_vertical` | — | `double_diffraction_vertical` | §6.5 |
 | `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) | §6 |
 | `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` | §5.1 |
-| `fixed_phi_horizontal` | `(1,0,4,1,0)` | — | §5.2 |
-| `fixed_chi_horizontal` | `(1,0,3,1,0)` | — | §5.2 |
+| `fixed_phi_horizontal` | `(1,0,4,1,0)` † | — | §5.2 |
+| `fixed_chi_horizontal` | `(1,0,3,1,0)` † | — | §5.2 |
 | `fixed_alpha_i_horizontal` | `(1,2,6,0,0)` | — | §6.1 |
 | `fixed_beta_out_horizontal` | `(1,3,6,0,0)` | — | §6.2 |
 | `alpha_eq_beta_horizontal` | `(1,1,6,0,0)` | — | §6.3 |
@@ -373,7 +373,11 @@ where `g_mode1` selects the scattering plane (1 = horizontal,
 reference-angle constraint (0 = none, 1 = α=β, 2 = α-fixed,
 3 = β-fixed, 4 = ψ-fixed), and `g_mode3`–`g_mode5` fix specific motor
 angles. A dash (—) means no documented analogue exists in that
-package. References:
+package. The dagger (†) marks SPEC mode tuples that the SPEC
+documentation lists as currently not working (the eta-fixed + chi-fixed
+and eta-fixed + phi-fixed combinations under `setmode d1 0 s1 s2`); the
+`ad_hoc_diffractometer` implementation of these modes is independent of
+SPEC and works as documented above. References:
 [SPEC `psic` macros](https://certif.com/spec_help/psic.html);
 [Hkl/Soleil E6C](https://people.debian.org/~picca/hkl/hkl.html);
 [Hkl source](https://repo.or.cz/hkl.git).

--- a/src/ad_hoc_diffractometer/benchmark.py
+++ b/src/ad_hoc_diffractometer/benchmark.py
@@ -99,6 +99,7 @@ def _prepare_mode(geometry, mode_name: str) -> None:
 
     - fixed_psi modes: sets ``azimuthal_reference``
     - double_diffraction modes: sets h2/k2/l2 extras
+    - zone modes: sets z0/z1 extras to a generic (h,k,0) plane
     - surface/reference modes (alpha_i, beta_out, a_eq_b):
       sets ``surface_normal``
     """
@@ -110,6 +111,11 @@ def _prepare_mode(geometry, mode_name: str) -> None:
         if key in cs.extras and cs.extras[key] is REQUIRED:
             defaults = {"h2": 0.0, "k2": 1.0, "l2": 0.0}
             cs.extras[key] = defaults[key]
+
+    # Zone modes: replace REQUIRED z0/z1 sentinels with a generic plane
+    for key, default in (("z0", (1, 0, 0)), ("z1", (0, 1, 0))):
+        if key in cs.extras and cs.extras[key] is REQUIRED:
+            cs.extras[key] = default
 
     # Reference-vector modes: set azimuthal_reference if needed
     for c in cs._constraints:

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -499,6 +499,13 @@ def _solve_constraint_set(
     if _is_double_diffraction_mode(geometry, mode):
         return _solve_double_diffraction(geometry, Q_phi, ttheta_deg, mode)
 
+    # Zone mode (You 1999 §6, SPEC `setmode 5`):  Q is confined to the
+    # plane spanned by two reciprocal-lattice vectors z0, z1.  Like
+    # double_diffraction, this is dispatched by extras keys, not by a
+    # dedicated constraint type.
+    if _is_zone_mode(geometry, mode):
+        return _solve_zone(geometry, Q_phi, ttheta_deg, mode)
+
     if mode.has_bisect:
         return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
 
@@ -2616,6 +2623,187 @@ def _collect_dd_solution(
     _apply_cut_points(sol, mode, geometry)
     if _check_limits(geometry, sol):  # pragma: no branch
         found_solutions.append(sol)
+
+
+# ---------------------------------------------------------------------------
+# Zone-mode solver (You 1999 §6, SPEC `setmode 5`)
+# ---------------------------------------------------------------------------
+
+
+def _is_zone_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """Return True when ``mode.extras`` contains both ``z0`` and ``z1`` keys.
+
+    Zone modes confine the scattering vector Q to the plane spanned by two
+    reciprocal-lattice vectors z0 and z1.  Like double-diffraction modes,
+    zone modes are dispatched by their ``extras`` schema rather than by a
+    dedicated constraint class.
+    """
+    extras = mode.extras
+    return extras is not None and ("z0" in extras and "z1" in extras)
+
+
+def _solve_zone(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """Forward solver for zone modes.
+
+    The zone plane is fixed by two reciprocal-lattice vectors ``z0`` and
+    ``z1`` supplied via ``mode.extras``.  For a single ``forward(h, k, l)``
+    call the in-plane condition is a property of the requested (h, k, l)
+    and the orientation matrix only — it does not constrain the motor
+    angles directly.  The solver therefore:
+
+    1. Validates ``z0``, ``z1`` are concrete and non-degenerate.
+    2. Computes the zone-plane normal in the φ frame:
+       ``n_zone_phi = (UB @ z0) × (UB @ z1)``.
+    3. Verifies that the requested ``Q_phi`` lies in the plane.  If not,
+       returns ``[]`` and emits a warning (matching the soft-failure
+       pattern adopted for ``fixed_psi`` in #176).
+    4. Records the in-plane residual in ``mode.extras['in_plane_residual']``.
+    5. Builds a synthetic :class:`~mode.ConstraintSet` that adds a
+       :class:`~mode.BisectConstraint` (or
+       :class:`~mode.VirtualBisectConstraint` for kappa6c) so the system
+       is fully constrained, then delegates to the existing bisecting
+       solver.  Bisecting is the canonical SPEC-zone "br" position; the
+       remaining azimuthal DOF can be exercised by a separate scan
+       function (``cz``/``mz`` macros in SPEC), which is out of scope for
+       a single ``forward()`` call.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+        Target scattering vector in the φ frame: ``UB @ (h, k, l)``.
+    ttheta_deg : float
+        Two-theta angle from Bragg's law.
+    mode : ConstraintSet
+        Active mode with ``extras['z0']``, ``extras['z1']`` set.
+
+    Returns
+    -------
+    list of dict[str, float]
+        Bisecting solutions filtered for plane membership.  Empty list when
+        the requested (h, k, l) does not lie in the zone plane.
+
+    Raises
+    ------
+    ValueError
+        If ``z0`` or ``z1`` are still :data:`~mode.REQUIRED` placeholders,
+        or if they are zero vectors, or if they are parallel (so the plane
+        normal is undefined).
+    """
+    from .mode import REQUIRED
+    from .mode import BisectConstraint
+    from .mode import ConstraintSet
+    from .mode import VirtualBisectConstraint
+
+    extras = mode.extras
+    z0_raw = extras.get("z0")
+    z1_raw = extras.get("z1")
+
+    # --- Validate z0/z1 -------------------------------------------------
+    if z0_raw is REQUIRED or z1_raw is REQUIRED:
+        raise ValueError(
+            "zone mode requires z0 and z1 to be set in mode.extras "
+            "before calling forward(). "
+            "Set them with e.g. "
+            "g.modes['zone_vertical'].extras['z0'] = (1, 0, 0); "
+            "g.modes['zone_vertical'].extras['z1'] = (0, 1, 0)"
+        )
+    try:
+        z0 = np.asarray(z0_raw, dtype=float).reshape(3)
+        z1 = np.asarray(z1_raw, dtype=float).reshape(3)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"zone mode: z0 and z1 must each be a 3-element sequence of "
+            f"Miller indices; got z0={z0_raw!r}, z1={z1_raw!r}."
+        ) from exc
+
+    if float(np.linalg.norm(z0)) < 1e-12 or float(np.linalg.norm(z1)) < 1e-12:
+        raise ValueError(
+            "zone mode: z0 and z1 must be non-zero reciprocal-lattice vectors; "
+            f"got z0={z0_raw!r}, z1={z1_raw!r}."
+        )
+
+    # --- Compute the zone-plane normal in the φ frame -------------------
+    UB = geometry.sample.UB
+    z0_phi = UB @ z0
+    z1_phi = UB @ z1
+    n_zone_phi = np.cross(z0_phi, z1_phi)
+    n_zone_norm = float(np.linalg.norm(n_zone_phi))
+    if n_zone_norm < 1e-12:
+        raise ValueError(
+            "zone mode: z0 and z1 are parallel (or one is zero) so the "
+            "zone-plane normal is undefined; "
+            f"got z0={z0_raw!r}, z1={z1_raw!r}."
+        )
+    n_zone_hat = n_zone_phi / n_zone_norm
+
+    # --- Plane-membership prefilter -------------------------------------
+    in_plane_residual = float(abs(np.dot(Q_phi, n_zone_hat)))
+    extras["in_plane_residual"] = in_plane_residual
+
+    q_norm = float(np.linalg.norm(Q_phi))
+    # Tolerance scaled by |Q| so the test is meaningful for both
+    # short and long reciprocal vectors.
+    tol = max(1e-8, 1e-6 * q_norm)
+    if in_plane_residual > tol:
+        logger.warning(
+            "zone mode: requested Q (|Q|=%.6g) is not in the zone plane "
+            "defined by z0=%s, z1=%s "
+            "(|Q · n_zone| = %.3e > tolerance %.3e); returning no solutions.",
+            q_norm,
+            tuple(z0_raw) if hasattr(z0_raw, "__iter__") else z0_raw,
+            tuple(z1_raw) if hasattr(z1_raw, "__iter__") else z1_raw,
+            in_plane_residual,
+            tol,
+        )
+        return []
+
+    # --- Build the synthetic bisecting ConstraintSet --------------------
+    # Vertical zone modes: bisect = (sample-stage rotating about transverse,
+    #   detector-stage rotating about transverse) i.e. (eta or komega, delta).
+    # Horizontal zone modes: bisect = (mu, nu).  ``mu`` is a real motor on
+    #   both psic and kappa6c, so a literal BisectConstraint suffices.
+    sample_names = {s.name for s in geometry.sample_stages}
+    is_vertical = "nu" in {c.name for c in mode.constraints if hasattr(c, "name")}
+    # ``mode.constraints`` for zone_vertical contains DetectorConstraint("nu",0)
+    # and SampleConstraint("mu",0); for zone_horizontal it has
+    # DetectorConstraint("delta",0) and SampleConstraint("eta"/"komega",0).
+    # Distinguish on the detector-side fixed name:
+    det_c = mode.detector_constraint
+    is_vertical = det_c is not None and det_c.name == "nu"
+
+    if is_vertical:
+        # Vertical: bisect detector "delta" with the sample stage that
+        # rotates about the same axis (transverse).  On psic that is
+        # "eta"; on kappa6c true bisecting is on the *virtual* omega.
+        if "komega" in sample_names and geometry.kappa_alpha_deg is not None:
+            bisect_cs = VirtualBisectConstraint("omega", "delta")
+        else:
+            bisect_cs = BisectConstraint("eta", "delta")
+        synth_constraints = [bisect_cs] + list(mode.constraints)
+    else:
+        # Horizontal: bisect detector "nu" with sample "mu" (a real motor
+        # on both psic and kappa6c, rotating about the vertical axis).
+        bisect_cs = BisectConstraint("mu", "nu")
+        synth_constraints = [bisect_cs] + list(mode.constraints)
+
+    synth_mode = ConstraintSet(
+        synth_constraints,
+        computed=mode.computed,
+        cut_points=mode.cut_points,
+    )
+
+    # --- Delegate to the existing bisecting solver ----------------------
+    # ``_solve_bisecting`` itself dispatches to the kappa-virtual solver
+    # when the BisectConstraint is a VirtualBisectConstraint, so the
+    # single call covers both psic (literal bisect) and kappa6c (virtual
+    # bisect) zone modes uniformly.
+    return _solve_bisecting(geometry, Q_phi, ttheta_deg, synth_mode)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -72,6 +72,22 @@ Cut-points control which branch of a multi-valued angle solution is
 returned (SPEC #G4 convention).  They are stored on :class:`ConstraintSet`
 and applied by the forward solver.
 
+A few specialised modes are dispatched not by their constraint composition
+but by the keys present in :attr:`ConstraintSet.extras`:
+
+- **double_diffraction** modes carry ``h2``, ``k2``, ``l2`` extras and are
+  routed to a 4-DOF simultaneous Bragg solver.
+- **zone** modes (You 1999 §6, SPEC ``setmode 5``) carry ``z0`` and ``z1``
+  extras (each a Miller-index 3-tuple) and confine the scattering vector
+  Q to the plane spanned by ``UB @ z0`` and ``UB @ z1``.  The solver
+  validates that the requested (h, k, l) lies in the plane and then
+  returns the bisecting solutions; off-plane requests yield an empty
+  list with a warning.
+
+This extras-driven dispatch keeps the constraint taxonomy small while
+allowing modes whose distinguishing input is a parameter (a secondary
+reflection or a zone plane) rather than a fixed motor angle.
+
 The DOF rule is geometry-dependent:
 
 - 4-circle (N=4): 1 constraint needed

--- a/src/ad_hoc_diffractometer/presets.py
+++ b/src/ad_hoc_diffractometer/presets.py
@@ -521,6 +521,36 @@ def psic(basis: dict = BASIS_YOU) -> AdHocDiffractometer:
             computed=["mu", "chi", "phi", "nu"],
             extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
         ),
+        # ── Zone modes (You 1999 §6, SPEC `setmode 5`) ──────────────────────
+        # Q is confined to the plane defined by two reciprocal-lattice
+        # vectors z0 and z1.  The caller still requests forward(h, k, l);
+        # if the requested Q does not lie in the zone plane (within
+        # tolerance) the solver returns an empty list with a warning.
+        # See SPEC `sz`, `cz`, `mz` macros.
+        "zone_vertical": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+            ],
+            computed=["eta", "chi", "phi", "delta"],
+            extras={
+                "z0": REQUIRED,
+                "z1": REQUIRED,
+                "in_plane_residual": None,
+            },
+        ),
+        "zone_horizontal": ConstraintSet(
+            [
+                SampleConstraint("eta", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "chi", "phi", "nu"],
+            extras={
+                "z0": REQUIRED,
+                "z1": REQUIRED,
+                "in_plane_residual": None,
+            },
+        ),
         # ── Lifting detector (out-of-plane) ─────────────────────────────────
         "lifting_detector_phi": ConstraintSet(
             [
@@ -1105,6 +1135,34 @@ def kappa6c(
             ],
             computed=["mu", "kappa", "kphi", "nu"],
             extras={"h2": REQUIRED, "k2": REQUIRED, "l2": REQUIRED},
+        ),
+        # ── Zone modes (You 1999 §6, SPEC `setmode 5`) ──────────────────────
+        # Q is confined to the plane defined by two reciprocal-lattice
+        # vectors z0 and z1.  Same dispatch pattern as psic — see psic
+        # ``zone_vertical`` / ``zone_horizontal`` for details.
+        "zone_vertical": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+            ],
+            computed=["komega", "kappa", "kphi", "delta"],
+            extras={
+                "z0": REQUIRED,
+                "z1": REQUIRED,
+                "in_plane_residual": None,
+            },
+        ),
+        "zone_horizontal": ConstraintSet(
+            [
+                SampleConstraint("komega", 0.0),
+                DetectorConstraint("delta", 0.0),
+            ],
+            computed=["mu", "kappa", "kphi", "nu"],
+            extras={
+                "z0": REQUIRED,
+                "z1": REQUIRED,
+                "in_plane_residual": None,
+            },
         ),
     }
     return AdHocDiffractometer(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -120,6 +120,24 @@ class TestPrepareMode:
     @pytest.mark.parametrize(
         "geometry_name, mode_name",
         [
+            pytest.param("psic", "zone_vertical", id="psic-zone-vert"),
+            pytest.param("psic", "zone_horizontal", id="psic-zone-horiz"),
+            pytest.param("kappa6c", "zone_vertical", id="kappa6c-zone-vert"),
+            pytest.param("kappa6c", "zone_horizontal", id="kappa6c-zone-horiz"),
+        ],
+    )
+    def test_zone_extras_replaced(self, geometry_name, mode_name):
+        """Zone modes get z0/z1 REQUIRED sentinels replaced with the
+        default (1,0,0)/(0,1,0) plane."""
+        g = _setup_geometry(geometry_name)
+        _prepare_mode(g, mode_name)
+        cs = g.modes[mode_name]
+        assert cs.extras["z0"] == (1, 0, 0)
+        assert cs.extras["z1"] == (0, 1, 0)
+
+    @pytest.mark.parametrize(
+        "geometry_name, mode_name",
+        [
             pytest.param("sixc", "fixed_alpha_zaxis", id="sixc-alpha-zaxis"),
             pytest.param("sixc", "fixed_beta_zaxis", id="sixc-beta-zaxis"),
             pytest.param("sixc", "alpha_eq_beta_zaxis", id="sixc-a-eq-b"),

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1383,6 +1383,8 @@ _PSIC_MODES_ALL = {
     "fixed_alpha_i_horizontal",
     "fixed_beta_out_horizontal",
     "alpha_eq_beta_horizontal",
+    "zone_vertical",
+    "zone_horizontal",
 }
 
 _PSIC_MODES_IMPLEMENTED = {
@@ -1396,6 +1398,8 @@ _PSIC_MODES_IMPLEMENTED = {
     "double_diffraction_horizontal",
     "lifting_detector_mu",
     "lifting_detector_phi",
+    "zone_vertical",
+    "zone_horizontal",
 }
 
 _PSIC_MODES_STUBS = _PSIC_MODES_ALL - _PSIC_MODES_IMPLEMENTED

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -2219,6 +2219,8 @@ _KAPPA6C_MODES = {
     "fixed_psi_horizontal",
     "double_diffraction_vertical",
     "double_diffraction_horizontal",
+    "zone_vertical",
+    "zone_horizontal",
 }
 
 _KAPPA6C_IMPLEMENTED = {
@@ -2232,6 +2234,8 @@ _KAPPA6C_IMPLEMENTED = {
     "lifting_detector_kphi",
     "double_diffraction_vertical",
     "double_diffraction_horizontal",
+    "zone_vertical",
+    "zone_horizontal",
 }
 _KAPPA6C_STUBS = _KAPPA6C_MODES - _KAPPA6C_IMPLEMENTED  # fixed_psi_*
 

--- a/tests/test_regression_issue_262.py
+++ b/tests/test_regression_issue_262.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Cross-module regression tests for issue #262 — psic and kappa6c zone modes.
+
+Zone mode (You 1999 §6, SPEC ``setmode 5``) confines the scattering vector
+Q to the plane spanned by two reciprocal-lattice vectors ``z0`` and
+``z1``.  The implementation is "extras-driven", parallel to the existing
+``double_diffraction`` modes:
+
+- The mode definition lives in :mod:`presets` (zone_vertical and
+  zone_horizontal on both psic and kappa6c).
+- The dispatcher :func:`forward._is_zone_mode` recognises modes whose
+  ``extras`` carry both ``z0`` and ``z1`` keys.
+- :func:`forward._solve_zone` validates inputs, computes the zone-plane
+  normal in the φ frame, applies the in-plane prefilter, and delegates
+  to the existing bisecting solver (which itself dispatches to the
+  kappa-virtual variant for kappa6c).
+
+This file lives at the cross-module level because the change spans
+``presets.py`` (mode registration), ``forward.py`` (dispatcher and
+solver), ``mode.py`` (extras-driven dispatch documentation), and
+``benchmark.py`` (default ``z0``/``z1`` for the slow-benchmark sweep).
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer.forward import _is_zone_mode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_cubic(factory, a=4.0, wavelength=1.5406):
+    """Return a fresh diffractometer with a cubic lattice and UB = identity."""
+    g = factory()
+    g.wavelength = wavelength
+    g.sample.lattice = ahd.Lattice(a=a)
+    ahd.ub_identity(g.sample)
+    return g
+
+
+def _activate_zone(geom, mode_name, z0, z1):
+    """Activate ``mode_name`` and set the zone-plane vectors."""
+    geom.mode_name = mode_name
+    cs = geom.modes[mode_name]
+    cs.extras["z0"] = z0
+    cs.extras["z1"] = z1
+    return cs
+
+
+# Zone-plane combinations that work for each (geometry, mode_name) pair.
+# psic horizontal cannot reach the (h, k, 0) plane in the You basis
+# (vertical = +x), so its tests use the (h, 0, l) plane instead.
+_GEOM_MODES = [
+    pytest.param(
+        ahd.presets.psic,
+        "zone_vertical",
+        (1, 0, 0),
+        (0, 1, 0),
+        id="psic-vertical-hk0",
+    ),
+    pytest.param(
+        ahd.presets.psic,
+        "zone_horizontal",
+        (1, 0, 0),
+        (0, 0, 1),
+        id="psic-horizontal-h0l",
+    ),
+    pytest.param(
+        ahd.presets.kappa6c,
+        "zone_vertical",
+        (1, 0, 0),
+        (0, 1, 0),
+        id="kappa6c-vertical-hk0",
+    ),
+    pytest.param(
+        ahd.presets.kappa6c,
+        "zone_horizontal",
+        (1, 0, 0),
+        (0, 1, 0),
+        id="kappa6c-horizontal-hk0",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Mode registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, context",
+    [
+        pytest.param(
+            ahd.presets.psic,
+            "zone_vertical",
+            does_not_raise(),
+            id="psic-zone_vertical-registered",
+        ),
+        pytest.param(
+            ahd.presets.psic,
+            "zone_horizontal",
+            does_not_raise(),
+            id="psic-zone_horizontal-registered",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_vertical",
+            does_not_raise(),
+            id="kappa6c-zone_vertical-registered",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_horizontal",
+            does_not_raise(),
+            id="kappa6c-zone_horizontal-registered",
+        ),
+    ],
+)
+def test_zone_mode_registered(factory, mode_name, context):
+    """Both zone modes are registered on psic and kappa6c, with the
+    expected extras schema (``z0`` and ``z1`` REQUIRED, ``in_plane_residual``
+    None) and dispatcher recognition.
+    """
+    with context:
+        from ad_hoc_diffractometer.mode import REQUIRED
+
+        g = factory()
+        cs = g.modes[mode_name]
+        assert cs.extras["z0"] is REQUIRED
+        assert cs.extras["z1"] is REQUIRED
+        assert cs.extras["in_plane_residual"] is None
+        assert _is_zone_mode(g, cs)
+        assert cs.is_implemented(g)
+
+
+# ---------------------------------------------------------------------------
+# Extras validation: missing, malformed, zero, parallel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "z0, z1, context",
+    [
+        # z0/z1 both still REQUIRED → ValueError mentioning the extras keys
+        pytest.param(
+            None,
+            None,
+            pytest.raises(
+                ValueError,
+                match=re.escape("zone mode requires z0 and z1"),
+            ),
+            id="both-required",
+        ),
+        # z0 zero vector
+        pytest.param(
+            (0, 0, 0),
+            (0, 1, 0),
+            pytest.raises(
+                ValueError,
+                match=re.escape("non-zero reciprocal-lattice vectors"),
+            ),
+            id="z0-zero",
+        ),
+        # z1 zero vector
+        pytest.param(
+            (1, 0, 0),
+            (0, 0, 0),
+            pytest.raises(
+                ValueError,
+                match=re.escape("non-zero reciprocal-lattice vectors"),
+            ),
+            id="z1-zero",
+        ),
+        # parallel z0 and z1 (collinear) → undefined plane normal
+        pytest.param(
+            (1, 0, 0),
+            (2, 0, 0),
+            pytest.raises(
+                ValueError,
+                match=re.escape("parallel"),
+            ),
+            id="parallel",
+        ),
+        # malformed: not a 3-vector
+        pytest.param(
+            (1, 0),
+            (0, 1, 0),
+            pytest.raises(
+                ValueError,
+                match=re.escape("3-element sequence"),
+            ),
+            id="z0-too-short",
+        ),
+    ],
+)
+def test_zone_extras_validation(z0, z1, context):
+    """The zone solver rejects malformed, zero, or parallel z0/z1
+    inputs with a descriptive ``ValueError``.
+    """
+    g = _setup_cubic(ahd.presets.psic)
+    g.mode_name = "zone_vertical"
+    if z0 is not None:
+        g.modes["zone_vertical"].extras["z0"] = z0
+    if z1 is not None:
+        g.modes["zone_vertical"].extras["z1"] = z1
+    with context:
+        g.forward(1, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# In-plane reflections: forward returns ≥ 1 solution; round-trip closes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory, mode_name, z0, z1", _GEOM_MODES)
+@pytest.mark.parametrize(
+    "hkl",
+    [
+        pytest.param((1, 0, 0), id="100"),
+        pytest.param((0, 1, 0), id="010"),
+        pytest.param((1, 1, 0), id="110"),
+        pytest.param((2, 0, 0), id="200"),
+    ],
+)
+def test_zone_in_plane_round_trip(factory, mode_name, z0, z1, hkl):
+    """Reflections that lie in the zone plane:
+
+    1. Return at least one solution (when geometrically reachable).
+    2. Round-trip ``forward`` → ``inverse`` to within machine precision.
+    3. Have ``in_plane_residual`` recorded near zero in mode.extras.
+
+    A reflection that is in-plane mathematically but unreachable in the
+    chosen scattering geometry (e.g. ``(0,1,0)`` in psic's horizontal
+    family using the ``(h,0,l)`` zone plane) is skipped, not failed —
+    that is a property of the geometry, not the zone solver.
+    """
+    g = _setup_cubic(factory)
+
+    # Skip hkl values not in the active zone plane (some test cases
+    # cross-combine).  Compute Q-component along z-normal in the
+    # cubic-orthonormal reciprocal frame.
+    z0_arr = np.asarray(z0, dtype=float)
+    z1_arr = np.asarray(z1, dtype=float)
+    n_zone = np.cross(z0_arr, z1_arr)
+    if abs(float(np.dot(np.asarray(hkl, dtype=float), n_zone))) > 1e-9:
+        pytest.skip(f"{hkl} is not in the zone plane spanned by {z0} and {z1}")
+
+    cs = _activate_zone(g, mode_name, z0, z1)
+    sols = g.forward(*hkl)
+    if not sols:
+        pytest.skip(
+            f"{factory.__name__}/{mode_name}: {hkl} is in the zone plane "
+            f"but unreachable in this scattering geometry."
+        )
+    assert cs.extras["in_plane_residual"] == pytest.approx(0.0, abs=1e-10)
+    for sol in sols:
+        np.testing.assert_allclose(g.inverse(sol), hkl, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Off-plane reflections: empty list + warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, z0, z1, off_plane_hkl",
+    [
+        pytest.param(
+            ahd.presets.psic,
+            "zone_vertical",
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            id="psic-vertical-off-001",
+        ),
+        pytest.param(
+            ahd.presets.psic,
+            "zone_horizontal",
+            (1, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            id="psic-horizontal-off-010",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_vertical",
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            id="kappa6c-vertical-off-001",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_horizontal",
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            id="kappa6c-horizontal-off-001",
+        ),
+    ],
+)
+def test_zone_off_plane_returns_empty_with_warning(
+    factory, mode_name, z0, z1, off_plane_hkl, caplog
+):
+    """An (h, k, l) that does not lie in the zone plane returns an empty
+    solution list and logs a warning identifying the in-plane residual
+    (matching the soft-failure pattern used for ``fixed_psi`` in #176).
+    """
+    import logging
+
+    g = _setup_cubic(factory)
+    cs = _activate_zone(g, mode_name, z0, z1)
+
+    with caplog.at_level(logging.WARNING, logger="ad_hoc_diffractometer.forward"):
+        sols = g.forward(*off_plane_hkl)
+
+    assert sols == []
+    assert cs.extras["in_plane_residual"] > 1e-6
+    assert any(
+        "zone mode" in record.message and "not in the zone plane" in record.message
+        for record in caplog.records
+    ), f"expected zone-mode warning; got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Plane-lock invariants: the constant_stages of each mode are honored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory, mode_name, z0, z1, in_plane_hkl, constant_stage_values",
+    [
+        pytest.param(
+            ahd.presets.psic,
+            "zone_vertical",
+            (1, 0, 0),
+            (0, 1, 0),
+            (1, 1, 0),
+            {"mu": 0.0, "nu": 0.0},
+            id="psic-vertical-mu0-nu0",
+        ),
+        pytest.param(
+            ahd.presets.psic,
+            "zone_horizontal",
+            (1, 0, 0),
+            (0, 0, 1),
+            (1, 0, 1),
+            {"eta": 0.0, "delta": 0.0},
+            id="psic-horizontal-eta0-delta0",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_vertical",
+            (1, 0, 0),
+            (0, 1, 0),
+            (1, 1, 0),
+            {"mu": 0.0, "nu": 0.0},
+            id="kappa6c-vertical-mu0-nu0",
+        ),
+        pytest.param(
+            ahd.presets.kappa6c,
+            "zone_horizontal",
+            (1, 0, 0),
+            (0, 1, 0),
+            (1, 1, 0),
+            {"komega": 0.0, "delta": 0.0},
+            id="kappa6c-horizontal-komega0-delta0",
+        ),
+    ],
+)
+def test_zone_constant_stages(
+    factory, mode_name, z0, z1, in_plane_hkl, constant_stage_values
+):
+    """Every solution has the constant stages frozen at their declared
+    values (mu/nu for vertical, eta/delta for psic horizontal,
+    komega/delta for kappa6c horizontal).  This is the structural
+    counterpart of the in-plane prefilter — the bisecting solver may
+    not violate the SampleConstraint/DetectorConstraint values that
+    accompany the zone constraint.
+    """
+    g = _setup_cubic(factory)
+    _activate_zone(g, mode_name, z0, z1)
+    sols = g.forward(*in_plane_hkl)
+    if not sols:  # pragma: no cover — covered by round-trip test above
+        pytest.skip(f"{factory.__name__}/{mode_name}: {in_plane_hkl} unreachable.")
+    for sol in sols:
+        for stage, expected in constant_stage_values.items():
+            assert sol[stage] == pytest.approx(expected, abs=1e-10), (
+                f"{factory.__name__}/{mode_name}: stage {stage!r} should "
+                f"be {expected}, got {sol[stage]} for hkl={in_plane_hkl}."
+            )


### PR DESCRIPTION
- closes #262

Adds `zone_vertical` and `zone_horizontal` modes to both `psic` and
`kappa6c`.  The scattering vector Q is confined to the plane spanned
by two reciprocal-lattice vectors `z0` and `z1` supplied via
`mode.extras` (parallel to the existing extras-driven
`double_diffraction` modes).

## Highlights

- **Extras-driven dispatch**: `_is_zone_mode()` recognises modes whose
  `extras` carry both `z0` and `z1` keys, then `_solve_zone()`
  validates inputs, computes the zone-plane normal in the φ frame,
  and delegates to the existing bisecting solver (which itself
  dispatches to the kappa-virtual variant for `kappa6c`).
- **Soft failure**: off-plane (h, k, l) requests return `[]` and emit
  a warning, matching the pattern adopted for `fixed_psi` in #176.
- **Cross-reference tables**: the geometry docs for `psic` and
  `kappa6c` now include a table mapping each mode to its SPEC and
  Hkl/Soleil counterparts, with the new `zone_*` modes referenced to
  SPEC `setmode 5` and the open `HklEngine "zone"` TODO.

## Test coverage

- 30 new tests in `tests/test_regression_issue_262.py` covering
  mode registration, extras validation (5 error cases), in-plane
  round-trip closure (4 geometries × 4 hkl), off-plane warning
  behaviour, and constant-stage invariants.
- 4 new tests in `tests/test_benchmark.py` exercising the
  `_prepare_mode` extras replacement for zone modes.
- Mode-registration tests in `test_forward.py` and `test_mode.py`
  updated to expect the new modes.
- Coverage remains at 100%.
- Slow benchmarks pass.

Contributed by: OpenCode (argo/claudeopus47)