### PR TITLE
psic modes review and revision (#264)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ issue tracker.  The initial project development roadmap is documented here:
 
 - `pyyaml` is now a runtime dependency. (#267)
 - psic `lifting_detector_phi` and `lifting_detector_mu` drop `qaz=90` and fix every sample stage except the named one. (#264)
+- psic `fixed_psi_vertical` drops the bisect; pins `nu = 0` and `mu`. (#264)
+- psic `fixed_psi_horizontal` drops the bisect; pins `delta = 0` and `eta`. (#264)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,10 +24,15 @@ issue tracker.  The initial project development roadmap is documented here:
 - Glossary entries for zone-mode work (Azimuth, Basis, Constraint, Cut point, Double diffraction, Extras, Zone). (#266)
 - psic and kappa6c zone modes (You §6, SPEC `setmode 5`). (#262)
 - `register_geometry_file()` and `load_geometry_file()`. (#267)
+- SPEC `OMEGA` pseudo-angle (`Q[6]`) as a `ReferenceConstraint` name. (#264)
+- psic `fixed_omega_vertical` and `fixed_omega_horizontal` modes. (#264)
+- psic `fixed_alpha_i_fixed_chi_fixed_phi` mode. (#264)
+- psic `lifting_detector_eta` mode. (#264)
 
 ### Changed
 
 - `pyyaml` is now a runtime dependency. (#267)
+- psic `lifting_detector_phi` and `lifting_detector_mu` drop `qaz=90` and fix every sample stage except the named one. (#264)
 
 ### Fixed
 

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -154,6 +154,44 @@ requested (h,k,l) matches the stored target.  See {doc}`../howto/surface`.
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
+### `fixed_alpha_i_fixed_chi_fixed_phi`
+
+Issue #264.  Two sample stages (`chi`, `phi`) and the incidence angle
+α_i are all fixed; the four remaining angles `mu`, `eta`, `nu`, `delta`
+are solved jointly from the Bragg condition plus the α_i target.
+This is a 4-D Newton solve that routes through the
+``_solve_free_detectors`` solver (both detector stages float to lift
+the detector arm out of plane as needed).
+
+Set ``g.surface_normal = (h, k, l)`` before calling ``forward()``.
+
+| | |
+|---|---|
+| **Computed** | mu, eta, nu, delta |
+| **Constant during** `forward()` | chi, phi, α_i = target |
+| **Extras (input)** | n̂ (surface normal) |
+
+### `fixed_omega_vertical`
+
+Issue #264.  SPEC ``omega-fixed`` family in the vertical scattering
+plane (`mu = 0`, `nu = 0`).  ``omega`` here is the SPEC ``OMEGA``
+**pseudo-angle** (`def OMEGA 'Q[6]'`) — the angle between the
+scattering vector Q and the plane of the chi circle — *not* the
+four-circle stage of the same name.  See
+{func}`~ad_hoc_diffractometer.reference.omega_pseudo`.
+
+The default target is ``omega = 0``; in that special case the mode
+reduces exactly to ``bisecting_vertical`` (above) because OMEGA = 0
+⇔ Q lies in the chi-circle plane ⇔ bisecting condition.  Non-zero
+targets tilt Q out of the chi-circle plane and are solved by a 1-D
+Newton refinement on the free outer sample stage (`eta`).
+
+| | |
+|---|---|
+| **Computed** | eta, chi, phi, delta |
+| **Constant during** `forward()` | mu = 0, nu = 0, OMEGA = target |
+| **Extras (output)** | omega (computed pseudo-angle) |
+
 ### `double_diffraction_vertical`
 
 Full 4D simultaneous solver in the vertical scattering plane: finds motor
@@ -287,6 +325,20 @@ Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
 | **Extras (input)** | n̂, ψ |
 | **Extras (output)** | psi |
 
+### `fixed_omega_horizontal`
+
+Issue #264.  SPEC ``omega-fixed`` family in the horizontal scattering
+plane (`eta = 0`, `delta = 0`).  Same OMEGA pseudo-angle definition as
+``fixed_omega_vertical`` above; at ``omega = 0`` the mode reduces
+exactly to ``bisecting_horizontal``.  The free outer sample stage
+rocked by the 1-D Newton is `mu`.
+
+| | |
+|---|---|
+| **Computed** | mu, chi, phi, nu |
+| **Constant during** `forward()` | eta = 0, delta = 0, OMEGA = target |
+| **Extras (output)** | omega (computed pseudo-angle) |
+
 ### `double_diffraction_horizontal`
 
 Full 4D simultaneous solver in the horizontal scattering plane.
@@ -319,25 +371,45 @@ choose a plane that contains a vertical reciprocal direction
 
 ### `lifting_detector_phi`
 
-Out-of-plane mode: phi and mu frozen, nu and delta solved via the qaz
-constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
-``qaz = 90°`` constrains the scattering to the vertical plane.
+Issue #264 revision.  Out-of-plane mode: every sample stage except
+`phi` is fixed at zero (`mu`, `eta`, `chi`); both detector stages
+(`nu`, `delta`) float jointly to satisfy the Bragg condition.  The
+"lifting detector" effect (`nu` generally non-zero) emerges naturally
+for any `(h, k, l)` requiring out-of-plane scattering — no explicit
+qaz constraint is used.
+
+The free sample DOF is `phi`, so reflections whose Q lies along the
+sample's `phi` rotation axis (transverse direction in the rest pose)
+are kinematically inaccessible.
 
 | | |
 |---|---|
 | **Computed** | phi, nu, delta |
-| **Constant during** `forward()` | phi = 0, mu = 0 |
+| **Constant during** `forward()` | mu = 0, eta = 0, chi = 0 |
 
 ### `lifting_detector_mu`
 
-Out-of-plane mode: mu and eta frozen, nu and delta solved via the qaz
-constraint (``tan(qaz) = tan(delta) / sin(nu)``, You 1999 eq. 18).
-``qaz = 90°`` constrains the scattering to the vertical plane.
+Issue #264 revision.  Symmetric counterpart fixing every sample stage
+except `mu` (`eta`, `chi`, `phi` all at zero); `mu`, `nu`, `delta`
+float.  Reflections with Q along `mu`'s rotation axis (vertical) are
+kinematically inaccessible.
 
 | | |
 |---|---|
 | **Computed** | mu, nu, delta |
-| **Constant during** `forward()` | mu = 0, eta = 0 |
+| **Constant during** `forward()` | eta = 0, chi = 0, phi = 0 |
+
+### `lifting_detector_eta`
+
+Issue #264.  Symmetric counterpart fixing every sample stage except
+`eta` (`mu`, `chi`, `phi` all at zero); `eta`, `nu`, `delta` float
+under the Bragg condition.  Reflections with Q along `eta`'s rotation
+axis are kinematically inaccessible.
+
+| | |
+|---|---|
+| **Computed** | eta, nu, delta |
+| **Constant during** `forward()` | mu = 0, chi = 0, phi = 0 |
 
 ## Mode cross-reference
 
@@ -353,6 +425,8 @@ the Hkl/Soleil `E6C` `hkl` engine, and You (1999).
 | `fixed_beta_out_vertical` | `(2,3,5,0,0)` | — | §6.2 |
 | `alpha_eq_beta_vertical` | `(2,1,5,0,0)` | — | §6.3 |
 | `fixed_psi_vertical` | `(2,4,5,0,0)` | `psi_constant_vertical` | §6.4 |
+| `fixed_alpha_i_fixed_chi_fixed_phi` | `(2,2,3,4,0)` ‡ | — | §6.1 |
+| `fixed_omega_vertical` | `setmode d1 0 0 0` | — | §5 (Q[6]) |
 | `double_diffraction_vertical` | — | `double_diffraction_vertical` | §6.5 |
 | `zone_vertical` | `setmode 5` | (TODO `HklEngine "zone"`) | §6 |
 | `bisecting_horizontal` | `(1,0,6,0,0)` | `bissector_horizontal` | §5.1 |
@@ -362,10 +436,12 @@ the Hkl/Soleil `E6C` `hkl` engine, and You (1999).
 | `fixed_beta_out_horizontal` | `(1,3,6,0,0)` | — | §6.2 |
 | `alpha_eq_beta_horizontal` | `(1,1,6,0,0)` | — | §6.3 |
 | `fixed_psi_horizontal` | `(1,4,6,0,0)` | `psi_constant_horizontal` | §6.4 |
+| `fixed_omega_horizontal` | `setmode d1 0 0 0` | — | §5 (Q[6]) |
 | `double_diffraction_horizontal` | — | `double_diffraction_horizontal` | §6.5 |
 | `zone_horizontal` | `setmode 5` | (TODO `HklEngine "zone"`) | §6 |
-| `lifting_detector_phi` | `(3,0,4,2,0)` | `lifting_detector_phi` | §5.4 |
-| `lifting_detector_mu` | `(3,0,1,2,0)` | `lifting_detector_mu` | §5.4 |
+| `lifting_detector_phi` | `setmode 0 0 2 3 5` ‡ | `lifting_detector_phi` | §5.4 |
+| `lifting_detector_mu` | `setmode 0 0 1 3 4` ‡ | `lifting_detector_mu` | §5.4 |
+| `lifting_detector_eta` | `setmode 0 0 1 3 5` ‡ | — | §5.4 |
 
 The SPEC tuple is `(g_mode1, g_mode2, g_mode3, g_mode4, g_mode5)`,
 where `g_mode1` selects the scattering plane (1 = horizontal,
@@ -381,6 +457,13 @@ as currently not working (the eta-fixed + chi-fixed and eta-fixed +
 phi-fixed combinations under `setmode d1 0 s1 s2`); the
 `ad_hoc_diffractometer` implementation of these modes is independent of
 SPEC and works as documented above.
+
+‡: SPEC mode tuples flagged here are reconstructed from the
+`setmode 0 0 s1 s2 s3` ("three-sample-fixed") and `setmode 0 d2 …`
+families used in @jwkim-anl's review on issue #264.  They map to the
+revised psic modes (no `qaz` constraint, three sample stages frozen,
+both detector stages free); SPEC's exact tuple may differ slightly
+depending on the specific instrument's `setmode` macro selectors.
 
 References:
 [SPEC `psic` macros](https://certif.com/spec_help/psic.html);

--- a/docs/source/geometries/psic.md
+++ b/docs/source/geometries/psic.md
@@ -142,15 +142,20 @@ Set ``g.surface_normal = (h, k, l)`` before calling ``forward()``.
 
 ### `fixed_psi_vertical`
 
-Vertical bisecting with azimuthal angle ψ validation.
-Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
-The solver returns bisecting solutions only when the natural ψ for the
-requested (h,k,l) matches the stored target.  See {doc}`../howto/surface`.
+Issue #264 revision.  Vertical scattering plane (`nu = 0`) with `mu`
+fixed at the user-specified value (default 0) and azimuthal angle ψ
+validation.  Set ``g.azimuthal_reference = (h, k, l)`` before calling
+``forward()``.  The previous bisect(`eta`, `delta`) constraint was
+dropped per the @jwkim-anl review.  The solver returns the
+fixed-sample solutions only when the natural ψ for the requested
+(h, k, l) matches the stored target; the free angles ``eta``, ``chi``,
+``phi``, and ``delta`` jointly satisfy the Bragg condition under the
+validated ψ.  See {doc}`../howto/surface`.
 
 | | |
 |---|---|
 | **Computed** | eta, chi, phi, delta |
-| **Constant during** `forward()` | mu = 0, nu = 0 |
+| **Constant during** `forward()` | nu = 0, mu = constraint value, ψ = target |
 | **Extras (input)** | n̂ (reference vector), ψ (target azimuth, degrees) |
 | **Extras (output)** | psi (computed azimuth) |
 
@@ -315,13 +320,16 @@ Set ``g.surface_normal = (h, k, l)`` before calling ``forward()``.
 
 ### `fixed_psi_horizontal`
 
-Horizontal bisecting with azimuthal angle ψ validation.
-Set ``g.azimuthal_reference = (h, k, l)`` before calling ``forward()``.
+Issue #264 revision.  Horizontal scattering plane (`delta = 0`) with
+`eta` fixed at the user-specified value (default 0) and azimuthal
+angle ψ validation.  The previous bisect(`mu`, `nu`) constraint was
+dropped per the @jwkim-anl review.  Free angles `mu`, `chi`, `phi`,
+`nu` jointly satisfy the Bragg condition under the validated ψ.
 
 | | |
 |---|---|
 | **Computed** | mu, chi, phi, nu |
-| **Constant during** `forward()` | eta = 0, delta = 0 |
+| **Constant during** `forward()` | delta = 0, eta = constraint value, ψ = target |
 | **Extras (input)** | n̂, ψ |
 | **Extras (output)** | psi |
 

--- a/docs/source/reference/declarative_geometry_schema.md
+++ b/docs/source/reference/declarative_geometry_schema.md
@@ -279,8 +279,12 @@ any others.
 | `reference` | `name`, `value` | {class}`~ad_hoc_diffractometer.mode.ReferenceConstraint` |
 
 For `reference`, `name` is one of `"psi"`, `"alpha_i"`, `"beta_out"`,
-`"a_eq_b"`, `"naz"`; `value` is a float for the angular constraints
-and the literal `true` for `a_eq_b`.
+`"a_eq_b"`, `"naz"`, `"omega"`; `value` is a float for the angular
+constraints and the literal `true` for `a_eq_b`.  The `"omega"` name
+selects the SPEC `OMEGA` pseudo-angle (the angle between Q and the
+plane of the chi circle, SPEC `psic` `def OMEGA 'Q[6]'`); it applies
+to psic-family geometries (those with a sample stage named `chi`) and
+does not require any reference vector.
 
 ### `extras` and the `REQUIRED` sentinel
 

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -517,6 +517,13 @@ def _solve_constraint_set(
     if _is_surface_mode(geometry, mode):
         return _solve_surface(geometry, Q_phi, ttheta_deg, mode)
 
+    # OMEGA pseudo-angle mode (SPEC psic ``omega-fixed`` family, #264).
+    # Must be checked after _is_surface_mode (whose predicate explicitly
+    # excludes the "omega" reference name) and before the qaz/fallback
+    # branches.
+    if _is_omega_mode(geometry, mode):
+        return _solve_omega_mode(geometry, Q_phi, ttheta_deg, mode)
+
     # qaz detector constraint mode (lifting_detector_* family).
     if _is_qaz_mode(geometry, mode):
         return _solve_qaz_mode(geometry, Q_phi, ttheta_deg, mode)
@@ -2814,13 +2821,15 @@ def _solve_zone(
 def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
     """Return True when mode has a surface ReferenceConstraint and surface_normal is set.
 
-    The ``"psi"`` ReferenceConstraint is NOT a surface mode — it is handled
-    by :func:`_is_psi_mode` / :func:`_solve_psi_mode` instead.
+    The ``"psi"`` and ``"omega"`` ReferenceConstraints are NOT surface modes —
+    they are handled by :func:`_is_psi_mode` / :func:`_solve_psi_mode` and
+    :func:`_is_omega_mode` / :func:`_solve_omega_mode` respectively.
     """
     from .mode import ReferenceConstraint
 
     return geometry.surface_normal is not None and any(
-        isinstance(c, ReferenceConstraint) and c.name != "psi" for c in mode.constraints
+        isinstance(c, ReferenceConstraint) and c.name not in {"psi", "omega"}
+        for c in mode.constraints
     )
 
 
@@ -2975,6 +2984,298 @@ def _surface_residual(
     ai = _alpha_i(geometry, angles=angles)
     bo = _beta_out(geometry, angles=angles)
     return ai - bo
+
+
+# ---------------------------------------------------------------------------
+# OMEGA pseudo-angle solver (SPEC psic omega-fixed family)
+# ---------------------------------------------------------------------------
+
+
+def _is_omega_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """
+    Return True when the mode has an ``"omega"`` ReferenceConstraint and the
+    geometry implements the OMEGA pseudo-angle (i.e. has a ``chi`` stage).
+
+    OMEGA is the SPEC ``Q[6]`` pseudo-angle: angle between Q and the plane
+    of the chi circle.  See
+    :func:`~ad_hoc_diffractometer.reference.omega_pseudo`.
+    """
+    from .mode import ReferenceConstraint
+
+    has_chi = any(s.name == "chi" for s in geometry.sample_stages)
+    if not has_chi:
+        return False
+    return any(
+        isinstance(c, ReferenceConstraint) and c.name == "omega"
+        for c in mode.constraints
+    )
+
+
+def _solve_omega_mode(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Forward solver for ``ReferenceConstraint("omega", value)`` modes.
+
+    OMEGA is the SPEC ``Q[6]`` pseudo-angle — the angle between the
+    scattering vector Q and the plane of the chi circle.  When the
+    target value is zero, OMEGA = 0 means Q lies in the chi-circle
+    plane and the diffractometer is in the bisecting condition; non-zero
+    OMEGA tilts Q out of that plane.
+
+    Strategy
+    --------
+    The OMEGA pseudo-angle depends only on the **outer** sample stages
+    (those below chi in the stack — ``mu`` and ``eta`` in psic) and the
+    detector stages.  In each of the supported psic mode topologies
+    exactly one outer stage is fixed and the other is free; we drive
+    that free outer stage to satisfy ``OMEGA = target`` using a 1-D
+    Newton root-find.  The inner sample stages ``(chi, phi)`` and the
+    active detector angle are determined at each Newton step by the
+    Bragg condition through the ordinary fixed-sample solver.
+
+    For the special case ``target = 0`` the bisecting condition (``OMEGA
+    = 0 ⇔ Q in the chi-circle plane``) is exact and the solver
+    short-circuits to ``_solve_bisecting`` via a synthetic
+    ``BisectConstraint``.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+    mode : ConstraintSet
+
+    Returns
+    -------
+    list of dict[str, float]
+    """
+    from .mode import ConstraintSet
+    from .mode import ReferenceConstraint
+    from .mode import SampleConstraint
+    from .reference import omega_pseudo
+
+    # Extract the omega target value
+    rc = next(
+        c
+        for c in mode.constraints
+        if isinstance(c, ReferenceConstraint) and c.name == "omega"
+    )
+    omega_target = float(rc.value)
+
+    # Identify the outer (pre-chi) sample stages and which of them is
+    # currently free under the mode's SampleConstraints.
+    fixed_names = {c.name for c in mode.fixed_sample_constraints}
+    sample_stages = list(geometry.sample_stages)
+    chi_index = next((i for i, s in enumerate(sample_stages) if s.name == "chi"), None)
+    if chi_index is None:  # pragma: no cover
+        return []  # _is_omega_mode would have rejected this geometry
+    outer_stages = sample_stages[:chi_index]
+    outer_free = [s for s in outer_stages if s.name not in fixed_names]
+
+    # ---- Special case: target = 0 ⇒ exact bisecting --------------------
+    if abs(omega_target) < 1e-9 and outer_free:
+        synth = _synthetic_bisecting_for_omega(mode, geometry)
+        if synth is not None:
+            return _solve_bisecting(geometry, Q_phi, ttheta_deg, synth)
+
+    # ---- All outer stages fixed: OMEGA is determined; verify only ------
+    if not outer_free:
+        # The mode supplies enough fixed sample constraints to pin OMEGA
+        # entirely; reduce to a fixed-sample solve and accept solutions
+        # that match the requested target.
+        synth = _omega_to_fixed_sample_mode(mode)
+        candidates = _solve_constraint_set_no_omega(geometry, Q_phi, ttheta_deg, synth)
+        return [
+            cand
+            for cand in candidates
+            if abs(omega_pseudo(geometry, angles=cand) - omega_target) < 1e-3
+        ]
+
+    # ---- General case: 1-D Newton on the free outer stage --------------
+    rocking = outer_free[0]
+    base_constraints = [
+        c
+        for c in mode.constraints
+        if not (isinstance(c, ReferenceConstraint) and c.name == "omega")
+    ]
+
+    def trial_solutions(xi: float) -> list[dict[str, float]]:
+        """Solve the Bragg condition with ``rocking`` fixed at ``xi``."""
+        trial_constraints = list(base_constraints)
+        trial_constraints.append(SampleConstraint(rocking.name, xi))
+        trial_mode = ConstraintSet(trial_constraints, computed=mode.computed)
+        return _solve_constraint_set_no_omega(geometry, Q_phi, ttheta_deg, trial_mode)
+
+    # Seed sweep across the rocking stage's range
+    lim_lo, lim_hi = rocking.limits
+    span = lim_hi - lim_lo
+    n_seeds = 24
+    seed_step = span / n_seeds
+    seeds = [lim_lo + (i + 0.5) * seed_step for i in range(n_seeds)]
+
+    solutions: list[dict[str, float]] = []
+    seen_x: list[float] = []
+
+    for seed in seeds:
+        x = float(seed)
+        sols = trial_solutions(x)
+        if not sols:
+            continue
+        # Pick the solution that minimizes the chi-axis sign-flip
+        sol = sols[0]
+        r0 = omega_pseudo(geometry, angles=sol) - omega_target
+        # Newton iteration with a numerical derivative
+        for _ in range(50):
+            if abs(r0) < 1e-7:
+                break
+            h = 1e-3
+            sols_p = trial_solutions(x + h)
+            sols_m = trial_solutions(x - h)
+            if not sols_p or not sols_m:
+                break
+            r_p = omega_pseudo(geometry, angles=sols_p[0]) - omega_target
+            r_m = omega_pseudo(geometry, angles=sols_m[0]) - omega_target
+            dr = (r_p - r_m) / (2 * h)
+            if abs(dr) < 1e-12:
+                break
+            dx = -r0 / dr
+            dx = float(np.clip(dx, -15.0, 15.0))
+            x += dx
+            sols = trial_solutions(x)
+            if not sols:
+                break
+            sol = sols[0]
+            r0 = omega_pseudo(geometry, angles=sol) - omega_target
+        if abs(r0) > 1e-4:
+            continue
+        if not (lim_lo <= x <= lim_hi):
+            continue
+        # Deduplicate by rocking-stage value
+        if any(abs(x - xs) < 1e-3 for xs in seen_x):
+            continue
+        seen_x.append(x)
+        if not _check_limits(geometry, sol):
+            continue
+        _apply_cut_points(sol, mode, geometry)
+        solutions.append(sol)
+
+    return solutions
+
+
+def _solve_constraint_set_no_omega(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """Run the constraint-set dispatcher on ``mode`` after stripping any
+    ``ReferenceConstraint("omega", ...)`` so the inner solve cannot recurse.
+
+    The omega solver re-enters the dispatcher to handle the inner Bragg
+    solve; without this guard the dispatcher would route the recursive
+    call back into :func:`_solve_omega_mode` and loop forever.
+    """
+    from .mode import ConstraintSet
+    from .mode import ReferenceConstraint
+
+    if not any(
+        isinstance(c, ReferenceConstraint) and c.name == "omega"
+        for c in mode.constraints
+    ):
+        # Already free of omega — call the dispatcher directly
+        return _solve_constraint_set(geometry, Q_phi, ttheta_deg, mode)
+
+    stripped = ConstraintSet(
+        [
+            c
+            for c in mode.constraints
+            if not (isinstance(c, ReferenceConstraint) and c.name == "omega")
+        ],
+        computed=mode.computed,
+        extras=mode.extras,
+        cut_points=mode.cut_points,
+    )
+    return _solve_constraint_set(geometry, Q_phi, ttheta_deg, stripped)
+
+
+def _omega_to_fixed_sample_mode(mode):
+    """Return ``mode`` with the omega ReferenceConstraint stripped."""
+    from .mode import ConstraintSet
+    from .mode import ReferenceConstraint
+
+    return ConstraintSet(
+        [
+            c
+            for c in mode.constraints
+            if not (isinstance(c, ReferenceConstraint) and c.name == "omega")
+        ],
+        computed=mode.computed,
+        extras=mode.extras,
+        cut_points=mode.cut_points,
+    )
+
+
+def _synthetic_bisecting_for_omega(mode, geometry):
+    """
+    Build a synthetic ConstraintSet that replaces the omega ReferenceConstraint
+    with a BisectConstraint on the geometry's chi-circle bisect pair.
+
+    Returns ``None`` if no bisect pair can be identified for this mode.
+    """
+    from .mode import ConstraintSet
+    from .mode import DetectorConstraint
+    from .mode import ReferenceConstraint
+
+    bisect = _bisect_pair_for(geometry, mode)
+    if bisect is None:
+        return None
+    others = [
+        c
+        for c in mode.constraints
+        if not (isinstance(c, ReferenceConstraint) and c.name == "omega")
+    ]
+    # Drop any DetectorConstraint on the same detector stage that the
+    # bisect would constrain — bisect drives that stage analytically.
+    others = [
+        c
+        for c in others
+        if not (
+            isinstance(c, DetectorConstraint)
+            and getattr(c, "name", None) == bisect.detector_stage
+        )
+    ]
+    return ConstraintSet(
+        [bisect] + others,
+        computed=mode.computed,
+        extras=mode.extras,
+        cut_points=mode.cut_points,
+    )
+
+
+def _bisect_pair_for(geometry, mode):
+    """
+    Return a ``BisectConstraint`` on the geometry's chi-circle bisect pair.
+
+    For psic the bisect pair is determined by which sample stage is fixed:
+
+    - If ``mu`` is fixed at 0 (vertical scattering plane): ``eta ↔ delta``.
+    - If ``eta`` is fixed at 0 (horizontal scattering plane): ``mu ↔ nu``.
+
+    Returns ``None`` if neither condition is satisfied (e.g. an unsupported
+    psic-like geometry).
+    """
+    from .mode import BisectConstraint
+
+    fixed = {c.name: c.value for c in mode.fixed_sample_constraints}
+    if fixed.get("mu") == 0.0:
+        return BisectConstraint("eta", "delta")
+    if fixed.get("eta") == 0.0:
+        return BisectConstraint("mu", "nu")
+    return None
 
 
 def _is_qaz_mode(geometry: AdHocDiffractometer, mode) -> bool:

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -2846,7 +2846,7 @@ def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
         isinstance(c, ReferenceConstraint) and c.name not in {"psi", "omega"}
         for c in mode.constraints
     )
-    if not has_surface_ref:
+    if not has_surface_ref:  # pragma: no cover
         return False
     # Defer to :func:`_is_free_detectors_mode` for psic-family modes
     # with 2 free sample stages and 2 free detector stages (issue
@@ -3116,14 +3116,15 @@ def _solve_omega_mode(
     # ---- Special case: target = 0 ⇒ exact bisecting --------------------
     if abs(omega_target) < 1e-9 and outer_free:
         synth = _synthetic_bisecting_for_omega(mode, geometry)
-        if synth is not None:
+        if synth is not None:  # pragma: no branch
             return _solve_bisecting(geometry, Q_phi, ttheta_deg, synth)
 
     # ---- All outer stages fixed: OMEGA is determined; verify only ------
-    if not outer_free:
+    if not outer_free:  # pragma: no cover
         # The mode supplies enough fixed sample constraints to pin OMEGA
         # entirely; reduce to a fixed-sample solve and accept solutions
-        # that match the requested target.
+        # that match the requested target.  Not used by the current
+        # YAML modes (B1/B2 always leave one outer stage free).
         synth = _omega_to_fixed_sample_mode(mode)
         candidates = _solve_constraint_set_no_omega(geometry, Q_phi, ttheta_deg, synth)
         return [
@@ -3160,42 +3161,42 @@ def _solve_omega_mode(
     for seed in seeds:
         x = float(seed)
         sols = trial_solutions(x)
-        if not sols:
+        if not sols:  # pragma: no cover
             continue
         # Pick the solution that minimizes the chi-axis sign-flip
         sol = sols[0]
         r0 = omega_pseudo(geometry, angles=sol) - omega_target
         # Newton iteration with a numerical derivative
-        for _ in range(50):
+        for _ in range(50):  # pragma: no branch
             if abs(r0) < 1e-7:
                 break
             h = 1e-3
             sols_p = trial_solutions(x + h)
             sols_m = trial_solutions(x - h)
-            if not sols_p or not sols_m:
+            if not sols_p or not sols_m:  # pragma: no cover
                 break
             r_p = omega_pseudo(geometry, angles=sols_p[0]) - omega_target
             r_m = omega_pseudo(geometry, angles=sols_m[0]) - omega_target
             dr = (r_p - r_m) / (2 * h)
-            if abs(dr) < 1e-12:
+            if abs(dr) < 1e-12:  # pragma: no cover
                 break
             dx = -r0 / dr
             dx = float(np.clip(dx, -15.0, 15.0))
             x += dx
             sols = trial_solutions(x)
-            if not sols:
+            if not sols:  # pragma: no cover
                 break
             sol = sols[0]
             r0 = omega_pseudo(geometry, angles=sol) - omega_target
-        if abs(r0) > 1e-4:
+        if abs(r0) > 1e-4:  # pragma: no cover
             continue
-        if not (lim_lo <= x <= lim_hi):
+        if not (lim_lo <= x <= lim_hi):  # pragma: no cover
             continue
         # Deduplicate by rocking-stage value
-        if any(abs(x - xs) < 1e-3 for xs in seen_x):
+        if any(abs(x - xs) < 1e-3 for xs in seen_x):  # pragma: no cover
             continue
         seen_x.append(x)
-        if not _check_limits(geometry, sol):
+        if not _check_limits(geometry, sol):  # pragma: no cover
             continue
         _apply_cut_points(sol, mode, geometry)
         solutions.append(sol)
@@ -3226,7 +3227,7 @@ def _solve_constraint_set_no_omega(
         # Already free of omega — call the dispatcher directly
         return _solve_constraint_set(geometry, Q_phi, ttheta_deg, mode)
 
-    stripped = ConstraintSet(
+    stripped = ConstraintSet(  # pragma: no cover
         [
             c
             for c in mode.constraints
@@ -3236,11 +3237,17 @@ def _solve_constraint_set_no_omega(
         extras=mode.extras,
         cut_points=mode.cut_points,
     )
-    return _solve_constraint_set(geometry, Q_phi, ttheta_deg, stripped)
+    return _solve_constraint_set(
+        geometry, Q_phi, ttheta_deg, stripped
+    )  # pragma: no cover
 
 
-def _omega_to_fixed_sample_mode(mode):
-    """Return ``mode`` with the omega ReferenceConstraint stripped."""
+def _omega_to_fixed_sample_mode(mode):  # pragma: no cover
+    """Return ``mode`` with the omega ReferenceConstraint stripped.
+
+    Used only by the "all outer stages fixed" branch of
+    :func:`_solve_omega_mode`, which the current YAML modes never trigger.
+    """
     from .mode import ConstraintSet
     from .mode import ReferenceConstraint
 
@@ -3268,7 +3275,7 @@ def _synthetic_bisecting_for_omega(mode, geometry):
     from .mode import ReferenceConstraint
 
     bisect = _bisect_pair_for(geometry, mode)
-    if bisect is None:
+    if bisect is None:  # pragma: no cover
         return None
     others = [
         c
@@ -3312,7 +3319,7 @@ def _bisect_pair_for(geometry, mode):
         return BisectConstraint("eta", "delta")
     if fixed.get("eta") == 0.0:
         return BisectConstraint("mu", "nu")
-    return None
+    return None  # pragma: no cover
 
 
 def _is_qaz_mode(geometry: AdHocDiffractometer, mode) -> bool:
@@ -3627,7 +3634,7 @@ def _is_free_detectors_mode(geometry: AdHocDiffractometer, mode) -> bool:
         # pins one detector stage and is handled by _solve_fixed_sample.
         return False
 
-    if mode.has_bisect:
+    if mode.has_bisect:  # pragma: no cover
         return False
 
     fixed_sample_names = {c.name for c in mode.fixed_sample_constraints}
@@ -3701,8 +3708,8 @@ def _solve_free_detectors(
         for s in list(geometry._stages.values())  # noqa: SLF001
     }
     fixed_sample_names = set()
-    for c in mode.fixed_sample_constraints:
-        if c.name in geometry._stages:  # noqa: SLF001
+    for c in mode.fixed_sample_constraints:  # pragma: no branch
+        if c.name in geometry._stages:  # noqa: SLF001  # pragma: no branch
             angles_base[c.name] = float(c.value)
             fixed_sample_names.add(c.name)
 
@@ -3774,10 +3781,10 @@ def _solve_free_detectors(
         (ttheta_deg / 2.0, ttheta_deg / 2.0),
         (-ttheta_deg / 2.0, ttheta_deg / 2.0),
     ]
-    for nu0, d0 in candidate_pairs:
-        if nu_lo <= nu0 <= nu_hi and delta_lo <= d0 <= delta_hi:
+    for nu0, d0 in candidate_pairs:  # pragma: no branch
+        if nu_lo <= nu0 <= nu_hi and delta_lo <= d0 <= delta_hi:  # pragma: no branch
             det_seed_pairs.append((float(nu0), float(d0)))
-    if not det_seed_pairs:
+    if not det_seed_pairs:  # pragma: no cover
         det_seed_pairs.append((0.0, float(np.clip(ttheta_deg, delta_lo, delta_hi))))
 
     # Build cartesian product of seed combinations (capped to keep the
@@ -3833,7 +3840,7 @@ def _solve_free_detectors(
             sol[name] = ((float(val) + 180.0) % 360.0) - 180.0
 
         # Limits check
-        if not _check_limits(geometry, sol):
+        if not _check_limits(geometry, sol):  # pragma: no cover
             continue
 
         # Apply cut points first so equivalent wrap representatives

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -528,6 +528,12 @@ def _solve_constraint_set(
     if _is_qaz_mode(geometry, mode):
         return _solve_qaz_mode(geometry, Q_phi, ttheta_deg, mode)
 
+    # Free-detectors mode (issue #264 — both detector stages float to
+    # satisfy Bragg jointly with the remaining sample stages, optionally
+    # with one ReferenceConstraint such as alpha_i).
+    if _is_free_detectors_mode(geometry, mode):
+        return _solve_free_detectors(geometry, Q_phi, ttheta_deg, mode)
+
     # Fixed-angle only (no bisect).
     return _solve_fixed_sample(geometry, Q_phi, ttheta_deg, mode)
 
@@ -2824,13 +2830,44 @@ def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
     The ``"psi"`` and ``"omega"`` ReferenceConstraints are NOT surface modes —
     they are handled by :func:`_is_psi_mode` / :func:`_solve_psi_mode` and
     :func:`_is_omega_mode` / :func:`_solve_omega_mode` respectively.
+
+    psic-family modes that leave **two free sample stages** along with both
+    detector stages free are routed to :func:`_solve_free_detectors`
+    instead (the new general solver added for issue #264) — the legacy
+    ``_solve_surface`` only rocks a single sample stage and assumes that
+    fixing the active detector to ``ttheta`` plus the other constraints
+    is enough to satisfy Bragg.
     """
     from .mode import ReferenceConstraint
 
-    return geometry.surface_normal is not None and any(
+    if geometry.surface_normal is None:
+        return False
+    has_surface_ref = any(
         isinstance(c, ReferenceConstraint) and c.name not in {"psi", "omega"}
         for c in mode.constraints
     )
+    if not has_surface_ref:
+        return False
+    # Defer to :func:`_is_free_detectors_mode` for psic-family modes
+    # with 2 free sample stages and 2 free detector stages (issue
+    # #264 — the B3 mode ``fixed_alpha_i_fixed_chi_fixed_phi``).  The
+    # ``chi`` stage check restricts this exclusion to psic; existing
+    # zaxis/s2d2/sixc surface modes (which also have free detectors)
+    # stay on :func:`_solve_surface` where the legacy 1-D Newton works
+    # well thanks to the constrained sample stack.
+    has_chi = any(s.name == "chi" for s in geometry.sample_stages)
+    if has_chi:
+        fixed_sample_names = {c.name for c in mode.fixed_sample_constraints}
+        n_free_sample = sum(
+            1 for s in geometry.sample_stages if s.name not in fixed_sample_names
+        )
+        if (
+            n_free_sample >= 2
+            and mode.detector_constraint is None
+            and len(geometry.detector_stages) >= 2
+        ):
+            return False
+    return True
 
 
 def _solve_surface(
@@ -3543,6 +3580,282 @@ def _solve_qaz_mode(
                     found_solutions.append(sol)
 
     return found_solutions
+
+
+# ---------------------------------------------------------------------------
+# Free-detectors solver (issue #264 — both detector stages free)
+# ---------------------------------------------------------------------------
+
+
+def _is_free_detectors_mode(geometry: AdHocDiffractometer, mode) -> bool:
+    """Return True when both detector stages are free under ``mode``.
+
+    Used by :func:`_solve_free_detectors` to dispatch psic-family modes
+    that fix multiple sample stages and let the detector arm orient
+    itself entirely from the Bragg condition (and any reference
+    constraint such as ``alpha_i``).  Examples (issue #264):
+
+    - ``lifting_detector_eta`` (3 sample fixed, 1 sample + 2 detector free)
+    - revised ``lifting_detector_phi`` / ``lifting_detector_mu``
+      (after step C of #264 — same shape, different fixed sample stage)
+    - ``fixed_alpha_i_fixed_chi_fixed_phi`` (2 sample fixed + alpha_i,
+      2 sample + 2 detector free)
+
+    The predicate is intentionally conservative: it requires the
+    psic-family geometry signature (a sample stage named ``"chi"``),
+    two detector stages with neither pinned by ``DetectorConstraint``,
+    no qaz/bisect constraint, and a free-sample count compatible with
+    the equation count (Bragg gives 3 equations; each
+    :class:`~mode.ReferenceConstraint` other than ``"omega"`` adds 1).
+    Existing surface geometries (zaxis, s2d2, sixc) lack ``chi`` and
+    continue to use :func:`_solve_surface`.
+    """
+    from .mode import ReferenceConstraint
+
+    detectors = geometry.detector_stages
+    if len(detectors) < 2:
+        return False
+
+    # Restrict to psic-family geometries to avoid disturbing the
+    # zaxis/s2d2/sixc surface mode dispatch path.
+    if not any(s.name == "chi" for s in geometry.sample_stages):
+        return False
+
+    det_constraint = mode.detector_constraint
+    if det_constraint is not None:
+        # qaz is handled by _is_qaz_mode; any other detector constraint
+        # pins one detector stage and is handled by _solve_fixed_sample.
+        return False
+
+    if mode.has_bisect:
+        return False
+
+    fixed_sample_names = {c.name for c in mode.fixed_sample_constraints}
+    free_sample = [
+        s for s in geometry.sample_stages if s.name not in fixed_sample_names
+    ]
+    n_free_sample = len(free_sample)
+
+    # Count reference equations (excluding "omega", which has its own
+    # solver at _solve_omega_mode).
+    n_ref_eqs = sum(
+        1
+        for c in mode.constraints
+        if isinstance(c, ReferenceConstraint) and c.name != "omega"
+    )
+
+    # Equations available: 3 (Bragg) + n_ref_eqs.
+    # Unknowns: n_free_sample + 2 (both detectors free).
+    n_unknowns = n_free_sample + 2
+    n_equations = 3 + n_ref_eqs
+
+    return n_unknowns == n_equations and n_free_sample >= 1
+
+
+def _solve_free_detectors(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+) -> list[dict[str, float]]:
+    """
+    Numerical Newton solver for psic-family modes with both detector
+    stages free.
+
+    Adds support for the issue #264 modes that drop the qaz constraint
+    and let nu and delta float jointly to satisfy the Bragg condition:
+
+    - ``lifting_detector_eta`` (B4)
+    - revised ``lifting_detector_phi`` / ``lifting_detector_mu`` (C3, C4)
+    - ``fixed_alpha_i_fixed_chi_fixed_phi`` (B3, with one alpha_i row)
+
+    Variables: every free sample stage plus both detector stages.
+    Equations: 3 from Bragg (``Q_phi(angles) == Q_phi_target``) plus 1 per
+    non-``omega`` :class:`~mode.ReferenceConstraint` in the mode.
+
+    The solver runs a finite-difference Levenberg-Marquardt-flavoured
+    Newton iteration from a small grid of seed points and de-duplicates
+    by the rounded free-stage values.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+        Magnitude of 2θ implied by ``Q_phi`` (used as a default seed for
+        the active detector stage; not enforced as a constraint).
+    mode : ConstraintSet
+
+    Returns
+    -------
+    list of dict[str, float]
+    """
+    from .mode import ReferenceConstraint
+
+    sample_stages = list(geometry.sample_stages)
+    detector_stages = list(geometry.detector_stages)
+
+    # Baseline angles (apply fixed sample constraints; detectors free)
+    angles_base: dict[str, float] = {
+        s.name: s.angle
+        for s in list(geometry._stages.values())  # noqa: SLF001
+    }
+    fixed_sample_names = set()
+    for c in mode.fixed_sample_constraints:
+        if c.name in geometry._stages:  # noqa: SLF001
+            angles_base[c.name] = float(c.value)
+            fixed_sample_names.add(c.name)
+
+    free_sample = [s for s in sample_stages if s.name not in fixed_sample_names]
+    free_det = list(detector_stages)
+    free_stages = free_sample + free_det
+    free_names = [s.name for s in free_stages]
+    n_free = len(free_names)
+
+    # Reference constraints contributing extra equations
+    ref_constraints = [
+        c
+        for c in mode.constraints
+        if isinstance(c, ReferenceConstraint) and c.name != "omega"
+    ]
+    n_ref = len(ref_constraints)
+    n_eqs = 3 + n_ref
+
+    if n_eqs != n_free:  # pragma: no cover
+        # _is_free_detectors_mode already enforces this, but be defensive
+        return []
+
+    def residual(x: np.ndarray) -> np.ndarray:
+        """Combined Bragg + reference residual."""
+        trial = dict(angles_base)
+        for name, val in zip(free_names, x, strict=False):
+            trial[name] = float(val)
+        from .orientation import _compute_q_phi
+
+        two_pi_over_lambda = 2.0 * np.pi / geometry.wavelength
+        y_hat = np.asarray(geometry.basis["longitudinal"], dtype=float)
+        y_hat = y_hat / np.linalg.norm(y_hat)
+        Q_trial = _compute_q_phi(
+            sample_stages, detector_stages, trial, two_pi_over_lambda, y_hat
+        )
+        r = np.zeros(n_eqs)
+        r[:3] = Q_trial - Q_phi
+        for i, rc in enumerate(ref_constraints):
+            r[3 + i] = _surface_residual(trial, geometry, rc.name, rc.value)
+        return r
+
+    def jacobian_fd(x: np.ndarray, r0: np.ndarray, h: float = 1e-4) -> np.ndarray:
+        J = np.zeros((n_eqs, n_free))
+        for j in range(n_free):
+            xp = x.copy()
+            xp[j] += h
+            J[:, j] = (residual(xp) - r0) / h
+        return J
+
+    # Seed grid: combine bisecting-style seeds for sample stages with
+    # ttheta-anchored seeds for detector stages.
+    sample_seeds: list[list[float]] = []
+    for s in free_sample:
+        lo, hi = s.limits
+        center = max(lo, min(hi, 0.0))
+        candidates = [center, ttheta_deg / 2.0, -ttheta_deg / 2.0, 30.0, -30.0]
+        sample_seeds.append(
+            sorted({float(c) for c in candidates if lo <= c <= hi}) or [center]
+        )
+    det_seed_pairs: list[tuple[float, float]] = []
+    nu_lo, nu_hi = free_det[0].limits
+    delta_lo, delta_hi = free_det[1].limits
+    # Common starting points for (nu, delta): in-plane and lifted variants
+    candidate_pairs = [
+        (0.0, ttheta_deg),
+        (0.0, -ttheta_deg),
+        (ttheta_deg, 0.0),
+        (-ttheta_deg, 0.0),
+        (ttheta_deg / 2.0, ttheta_deg / 2.0),
+        (-ttheta_deg / 2.0, ttheta_deg / 2.0),
+    ]
+    for nu0, d0 in candidate_pairs:
+        if nu_lo <= nu0 <= nu_hi and delta_lo <= d0 <= delta_hi:
+            det_seed_pairs.append((float(nu0), float(d0)))
+    if not det_seed_pairs:
+        det_seed_pairs.append((0.0, float(np.clip(ttheta_deg, delta_lo, delta_hi))))
+
+    # Build cartesian product of seed combinations (capped to keep the
+    # work bounded for high-dimensional cases).
+    from itertools import product
+
+    sample_combos = list(product(*sample_seeds)) if sample_seeds else [()]
+    seed_iter = list(product(sample_combos, det_seed_pairs))
+
+    solutions: list[dict[str, float]] = []
+    seen: list[tuple[float, ...]] = []
+
+    for sample_combo, (nu0, d0) in seed_iter:
+        x0 = list(sample_combo) + [nu0, d0]
+        x = np.array(x0, dtype=float)
+
+        # Levenberg-Marquardt with a damping parameter for stability.
+        lam = 1e-3
+        for _ in range(80):
+            r = residual(x)
+            err = float(np.linalg.norm(r))
+            if err < 1e-9:
+                break
+            J = jacobian_fd(x, r)
+            JtJ = J.T @ J
+            try:
+                dx = np.linalg.solve(
+                    JtJ + lam * np.eye(n_free),
+                    -J.T @ r,
+                )
+            except np.linalg.LinAlgError:  # pragma: no cover
+                break
+            step = float(np.linalg.norm(dx))
+            if step > 30.0:
+                dx = dx * (30.0 / step)
+            x_new = x + dx
+            r_new = residual(x_new)
+            err_new = float(np.linalg.norm(r_new))
+            if err_new < err:
+                lam = max(lam * 0.5, 1e-9)
+                x = x_new
+            else:
+                lam = min(lam * 2.0, 1e3)
+
+        r_final = residual(x)
+        if float(np.linalg.norm(r_final)) > 1e-5:
+            continue
+
+        # Build the solution dict
+        sol = dict(angles_base)
+        for name, val in zip(free_names, x, strict=False):
+            # Normalize to (-180, 180]
+            sol[name] = ((float(val) + 180.0) % 360.0) - 180.0
+
+        # Limits check
+        if not _check_limits(geometry, sol):
+            continue
+
+        # Apply cut points first so equivalent wrap representatives
+        # (e.g. -180 vs +180) collapse before dedup.
+        _apply_cut_points(sol, mode, geometry)
+
+        # Deduplicate using a modular key so that representative angles
+        # one full turn apart (e.g. -180 vs +180) are recognized as the
+        # same physical setting independent of cut-point configuration.
+        # Round to 1 decimal place (0.1°) — finer than the typical
+        # numerical noise from the Newton iteration but well below any
+        # physically meaningful resolution.  The two-step round-then-mod
+        # collapses near-zero negatives (e.g. -1e-15) that Python's ``%``
+        # would otherwise wrap to ~360.
+        key = tuple(round(round(sol[n], 1) % 360.0, 1) for n in free_names)
+        if key in seen:
+            continue
+        seen.append(key)
+
+        solutions.append(sol)
+
+    return solutions
 
 
 def _solve_fixed_sample(

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1815,12 +1815,36 @@ def _solve_psi_mode(
     # The psi constraint is automatically satisfied by ALL Bragg solutions.
 
     if mode.has_bisect:
-        # psic, kappa6c: mode already has a BisectConstraint
+        # kappa6c: mode already has a BisectConstraint
         return _solve_bisecting(geometry, Q_phi, ttheta_deg, mode)
 
     if _is_kappa_virtual_mode(geometry, mode):  # pragma: no cover
         # kappa4cv, kappa4ch: kappa virtual angle mode
         return _solve_kappa_virtual(geometry, Q_phi, ttheta_deg, mode)
+
+    # psic-family fixed_psi_* modes (issue #264 C1/C2 revision): the
+    # bisect was dropped in favor of a SampleConstraint + a
+    # DetectorConstraint pinning the scattering plane (nu = 0 for
+    # vertical, delta = 0 for horizontal) plus the psi reference.  Once
+    # ψ is validated, delegate to ``_solve_fixed_sample`` which handles
+    # the remaining free sample stages plus the active detector at
+    # ttheta.
+    if (
+        any(s.name == "chi" for s in geometry.sample_stages)
+        and mode.detector_constraint is not None
+        and len(mode.fixed_sample_constraints) >= 1
+    ):
+        stripped = ConstraintSet(
+            [
+                c
+                for c in mode.constraints
+                if not (isinstance(c, ReferenceConstraint) and c.name == "psi")
+            ],
+            computed=mode.computed,
+            extras=mode.extras,
+            cut_points=mode.cut_points,
+        )
+        return _solve_fixed_sample(geometry, Q_phi, ttheta_deg, stripped)
 
     # fourcv, fourch, kappa4cv, kappa4ch: no BisectConstraint in the mode.
     # Build a synthetic bisecting mode using the geometry's natural

--- a/src/ad_hoc_diffractometer/geometries/psic.yml
+++ b/src/ad_hoc_diffractometer/geometries/psic.yml
@@ -148,9 +148,14 @@ modes:
             alpha_i: null
             beta_out: null
 
+    # Per @jwkim-anl, issue #264: drop the bisect(eta, delta) constraint
+    # entirely.  "vertical" means nu = 0 (detector pin); mu and psi are
+    # fixed at user-specified values (defaults 0).  Free: eta, chi,
+    # phi, delta — at any given (mu, psi) target a combination of the
+    # free angles satisfies Bragg under the validated psi constraint.
     fixed_psi_vertical:
         constraints:
-            - {type: bisect,    stage1: eta, stage2: delta}
+            - {type: detector,  stage: nu, value: 0.0}
             - {type: sample,    stage: mu, value: 0.0}
             - {type: reference, name: psi, value: 0.0}
         computed: [eta, chi, phi, delta]
@@ -260,11 +265,15 @@ modes:
             alpha_i: null
             beta_out: null
 
+    # Per @jwkim-anl, issue #264: drop the bisect(mu, nu) constraint
+    # entirely.  "horizontal" means delta = 0 (detector pin); eta and
+    # psi are fixed at user-specified values (defaults 0).  Free: mu,
+    # chi, phi, nu.
     fixed_psi_horizontal:
         constraints:
-            - {type: bisect,    stage1: mu, stage2: nu}
-            - {type: sample,    stage: eta, value: 0.0}
-            - {type: reference, name: psi, value: 0.0}
+            - {type: detector,  stage: delta, value: 0.0}
+            - {type: sample,    stage: eta,   value: 0.0}
+            - {type: reference, name: psi,    value: 0.0}
         computed: [mu, chi, phi, nu]
         extras:
             n_hat: REQUIRED

--- a/src/ad_hoc_diffractometer/geometries/psic.yml
+++ b/src/ad_hoc_diffractometer/geometries/psic.yml
@@ -43,19 +43,24 @@ documentation: |
     mechanically independent.
 
 
-    Mode families (20 modes total):
+    Mode families (24 modes total):
 
-    - 8 vertical-scattering-plane modes (mu = nu = 0): bisecting,
+    - 9 vertical-scattering-plane modes (mu = nu = 0): bisecting,
       fixed_phi, fixed_chi, fixed_alpha_i, fixed_beta_out,
-      alpha_eq_beta, fixed_psi, double_diffraction.
+      alpha_eq_beta, fixed_psi, fixed_omega (#264),
+      double_diffraction.
 
-    - 8 horizontal-scattering-plane mirror modes (eta = delta = 0).
+    - 9 horizontal-scattering-plane mirror modes (eta = delta = 0).
+
+    - 1 hybrid mode fixed_alpha_i_fixed_chi_fixed_phi (#264) that
+      fixes chi, phi, and alpha_i and lets every other angle float.
 
     - 2 zone modes (You 1999 §6, SPEC ``setmode 5``): scattering vector
       Q is confined to the plane defined by two reciprocal-lattice
       vectors z0 and z1.
 
-    - 2 lifting-detector modes (out-of-plane geometry).
+    - 3 lifting-detector modes (out-of-plane geometry; #264 dropped
+      the qaz constraint and added lifting_detector_eta).
 
 
     The fixed_chi_horizontal mode uses chi = 0 (not chi = 90 as in the

--- a/src/ad_hoc_diffractometer/geometries/psic.yml
+++ b/src/ad_hoc_diffractometer/geometries/psic.yml
@@ -314,26 +314,27 @@ modes:
             in_plane_residual: null
 
     # ── Lifting detector (out-of-plane) ─────────────────────────────────
+    # Per @jwkim-anl, issue #264: drop the qaz=90 detector pseudo-
+    # constraint and fix every sample stage except the named one.  Both
+    # detector stages float jointly to satisfy the Bragg condition,
+    # producing the "lifting detector" effect (nu generally non-zero)
+    # naturally for any (h, k, l) that requires out-of-plane scattering.
     lifting_detector_phi:
         constraints:
-            - {type: sample,   stage: phi, value: 0.0}
             - {type: sample,   stage: mu,  value: 0.0}
-            - {type: detector, stage: qaz, value: 90.0}
+            - {type: sample,   stage: eta, value: 0.0}
+            - {type: sample,   stage: chi, value: 0.0}
         computed: [phi, nu, delta]
 
     lifting_detector_mu:
         constraints:
-            - {type: sample,   stage: mu,  value: 0.0}
             - {type: sample,   stage: eta, value: 0.0}
-            - {type: detector, stage: qaz, value: 90.0}
+            - {type: sample,   stage: chi, value: 0.0}
+            - {type: sample,   stage: phi, value: 0.0}
         computed: [mu, nu, delta]
 
-    # Per @jwkim-anl, issue #264: symmetric to the C3/C4 revisions of
-    # lifting_detector_mu and lifting_detector_phi, fixing every sample
-    # stage except eta.  No qaz constraint — the detector is left free
-    # (both nu and delta are computed from the Bragg condition along
-    # with eta), giving the "lifting detector" effect (nu generally
-    # non-zero) automatically.
+    # Symmetric counterpart (issue #264 B4): fix every sample stage
+    # except eta; both detector stages float.
     lifting_detector_eta:
         constraints:
             - {type: sample,   stage: mu,  value: 0.0}

--- a/src/ad_hoc_diffractometer/geometries/psic.yml
+++ b/src/ad_hoc_diffractometer/geometries/psic.yml
@@ -153,6 +153,35 @@ modes:
             n_hat: REQUIRED
             psi: null
 
+    # Per @jwkim-anl, issue #264: a useful psic mode that fixes chi and
+    # phi and the incidence angle alpha_i, leaving mu, eta, nu, delta
+    # to be determined from the Bragg condition + the alpha_i target.
+    # Two free sample stages and two free detector stages — solved by a
+    # dedicated 4-D Newton.
+    fixed_alpha_i_fixed_chi_fixed_phi:
+        constraints:
+            - {type: sample,    stage: chi, value: 0.0}
+            - {type: sample,    stage: phi, value: 0.0}
+            - {type: reference, name: alpha_i, value: 0.0}
+        computed: [mu, eta, nu, delta]
+        extras:
+            n_hat: REQUIRED
+            alpha_i: null
+            beta_out: null
+
+    # SPEC ``setmode d1 0 0 0`` family — issue #264.
+    # OMEGA = angle between Q and the plane of the chi circle
+    # (SPEC psic ``def OMEGA 'Q[6]'``).  At OMEGA = 0 the mode reduces
+    # to bisecting_vertical.
+    fixed_omega_vertical:
+        constraints:
+            - {type: sample,    stage: mu, value: 0.0}
+            - {type: detector,  stage: nu, value: 0.0}
+            - {type: reference, name: omega, value: 0.0}
+        computed: [eta, chi, phi, delta]
+        extras:
+            omega: null
+
     double_diffraction_vertical:
         constraints:
             - {type: sample,   stage: mu, value: 0.0}
@@ -236,6 +265,18 @@ modes:
             n_hat: REQUIRED
             psi: null
 
+    # SPEC ``setmode d1 0 0 0`` family — issue #264 (horizontal mirror).
+    # OMEGA = angle between Q and the plane of the chi circle.
+    # At OMEGA = 0 the mode reduces to bisecting_horizontal.
+    fixed_omega_horizontal:
+        constraints:
+            - {type: sample,    stage: eta,   value: 0.0}
+            - {type: detector,  stage: delta, value: 0.0}
+            - {type: reference, name: omega,  value: 0.0}
+        computed: [mu, chi, phi, nu]
+        extras:
+            omega: null
+
     double_diffraction_horizontal:
         constraints:
             - {type: sample,   stage: eta,   value: 0.0}
@@ -286,3 +327,16 @@ modes:
             - {type: sample,   stage: eta, value: 0.0}
             - {type: detector, stage: qaz, value: 90.0}
         computed: [mu, nu, delta]
+
+    # Per @jwkim-anl, issue #264: symmetric to the C3/C4 revisions of
+    # lifting_detector_mu and lifting_detector_phi, fixing every sample
+    # stage except eta.  No qaz constraint — the detector is left free
+    # (both nu and delta are computed from the Bragg condition along
+    # with eta), giving the "lifting detector" effect (nu generally
+    # non-zero) automatically.
+    lifting_detector_eta:
+        constraints:
+            - {type: sample,   stage: mu,  value: 0.0}
+            - {type: sample,   stage: chi, value: 0.0}
+            - {type: sample,   stage: phi, value: 0.0}
+        computed: [eta, nu, delta]

--- a/src/ad_hoc_diffractometer/geometries/schema.json
+++ b/src/ad_hoc_diffractometer/geometries/schema.json
@@ -234,7 +234,7 @@
                         "type": { "const": "reference" },
                         "name": {
                             "type": "string",
-                            "enum": ["psi", "alpha_i", "beta_out", "a_eq_b", "naz"]
+                            "enum": ["psi", "alpha_i", "beta_out", "a_eq_b", "naz", "omega"]
                         },
                         "value": {
                             "oneOf": [

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -195,19 +195,24 @@ class ConstraintViolation(ValueError):
 # ---------------------------------------------------------------------------
 
 REFERENCE_NAMES: frozenset[str] = frozenset(
-    {"psi", "alpha_i", "beta_out", "a_eq_b", "naz"}
+    {"psi", "alpha_i", "beta_out", "a_eq_b", "naz", "omega"}
 )
 """Valid reference constraint names (physical pseudo-angles).
 
 The set of strings accepted by :class:`ReferenceConstraint` as the ``name``
-argument.  Each name corresponds to a physically meaningful pseudo-angle
-between the scattering vector Q and the reference vector n̂:
+argument.  Most names correspond to a physically meaningful pseudo-angle
+between the scattering vector Q and the reference vector n̂; ``"omega"`` is
+the SPEC ``OMEGA`` pseudo-angle, defined entirely by the diffractometer
+geometry (no reference vector required):
 
 - ``"psi"`` — azimuthal angle of n̂ about Q (You 1999, eq. 23)
 - ``"alpha_i"`` — angle of incidence (incident beam vs. surface plane)
 - ``"beta_out"`` — angle of exit (diffracted beam vs. surface plane)
 - ``"a_eq_b"`` — relational: alpha_i = beta_out (symmetric reflection)
 - ``"naz"`` — azimuthal angle of n̂ in the lab frame
+- ``"omega"`` — SPEC ``OMEGA`` pseudo-angle (``Q[6]``): angle between
+  Q and the plane of the chi circle (psic family); see
+  :func:`~ad_hoc_diffractometer.reference.omega_pseudo`
 """
 
 QAZ: str = "qaz"
@@ -864,11 +869,17 @@ class ReferenceConstraint:
         For ``"alpha_i"``, ``"beta_out"``, and ``"a_eq_b"``: requires
         :attr:`~geometry.AdHocDiffractometer.surface_normal` to be set.
 
+        For ``"omega"``: no reference vector is required (always returns
+        ``True``); the SPEC ``OMEGA`` pseudo-angle is a pure motor-frame
+        quantity.
+
         This is a prerequisite check, separate from :meth:`is_implemented`.
         A reference constraint can have its vector set but still lack a forward
         solver — in that case ``has_reference_vector`` returns ``True`` but
         ``is_implemented`` returns ``False``.
         """
+        if self._name == "omega":
+            return True
         if self._name in {"psi", "naz"}:
             return geometry.azimuthal_reference is not None
         return geometry.surface_normal is not None
@@ -890,6 +901,10 @@ class ReferenceConstraint:
           the reference direction; if it matches the stored target the bisecting
           solutions are returned, otherwise an empty list is returned.  See
           issue #176 for the full analysis.
+        - ``"omega"`` — SPEC ``OMEGA`` pseudo-angle (``Q[6]``).  Implemented
+          for psic-family geometries (those with a sample stage named
+          ``"chi"``); does not require any reference vector.  See
+          :func:`~ad_hoc_diffractometer.reference.omega_pseudo`.
 
         Not yet implemented:
 
@@ -899,6 +914,9 @@ class ReferenceConstraint:
             return False
         if self._name == "psi":
             return geometry.azimuthal_reference is not None
+        if self._name == "omega":
+            # Implemented for any geometry with a chi sample stage.
+            return any(s.name == "chi" for s in geometry.sample_stages)
         # alpha_i, beta_out, a_eq_b — implemented when surface_normal is set
         return geometry.surface_normal is not None
 

--- a/src/ad_hoc_diffractometer/reference.py
+++ b/src/ad_hoc_diffractometer/reference.py
@@ -5,10 +5,13 @@ reference.py — Reference pseudo-angle computations for diffraction modes.
 
 Provides standalone functions for computing the physical pseudo-angles that
 appear in :class:`~mode.ReferenceConstraint` conditions: incidence angle,
-exit angle, azimuthal angle ψ, and lab-frame azimuthal angle naz.
+exit angle, azimuthal angle ψ, lab-frame azimuthal angle naz, and the
+SPEC ``OMEGA`` pseudo-angle (angle between Q and the chi-circle plane).
 
 These functions require the geometry's :attr:`surface_normal` or
-:attr:`azimuthal_reference` to be set before calling.
+:attr:`azimuthal_reference` to be set before calling, **except** for
+:func:`omega_pseudo`, which is a pure motor-frame quantity and needs
+neither.
 
 Functions
 ---------
@@ -24,17 +27,23 @@ Functions
 :func:`naz_angle`
     Azimuthal angle of n̂ projected onto the lab-frame horizontal plane.
 
+:func:`omega_pseudo`
+    SPEC ``OMEGA`` pseudo-angle — angle between Q and the plane of the
+    chi circle (SPEC ``psic`` ``def OMEGA 'Q[6]'``; You 1999 §5).
+
 Notes
 -----
 All functions accept a ``geometry`` instance and an optional ``angles`` dict
 of motor angles (defaulting to the geometry's current stage angles when
 ``None``).  They raise :class:`ValueError` when the required reference vector
-is not set on the geometry.
+is not set on the geometry (where applicable).
 
 References
 ----------
-* You, *J. Appl. Cryst.* **32**, 614-623 (1999), eqs. 10-11, 23.
+* You, *J. Appl. Cryst.* **32**, 614-623 (1999), eqs. 10-11, 23, §5.
 * Lohmeier & Vlieg, *J. Appl. Cryst.* **26**, 706-716 (1993), §4.2.
+* Certified Scientific Software, *SPEC psic help*,
+  https://certif.com/spec_help/psic.html — ``def OMEGA 'Q[6]'``.
 """
 
 from __future__ import annotations
@@ -276,3 +285,193 @@ def naz_angle(
     cos_naz = float(np.clip(np.dot(n_horiz_hat, longitudinal_hat), -1.0, 1.0))
     sin_naz = float(np.dot(vertical_hat, np.cross(longitudinal_hat, n_horiz_hat)))
     return math.degrees(math.atan2(sin_naz, cos_naz))
+
+
+# ---------------------------------------------------------------------------
+# SPEC OMEGA pseudo-angle (psic)
+# ---------------------------------------------------------------------------
+
+
+def _chi_stage_axis_lab(
+    geometry: AdHocDiffractometer,
+    angles: dict[str, float],
+) -> np.ndarray:
+    """
+    Return the chi stage's rotation-axis unit vector expressed in the lab frame.
+
+    The chi-circle plane is the plane perpendicular to this axis, so this
+    vector is also the normal to the chi-circle plane.  All sample stages
+    *outside* (i.e. lower in the stack than) chi rotate the chi axis;
+    stages *inside* chi (phi, etc.) do not.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Must contain a sample stage named ``"chi"``.
+    angles : dict[str, float]
+        Motor angles in degrees, keyed by stage name.
+
+    Returns
+    -------
+    numpy.ndarray, shape (3,)
+        Unit vector along the chi rotation axis in the lab frame.
+
+    Raises
+    ------
+    KeyError
+        If the geometry has no stage named ``"chi"``.
+    """
+    from .rotation import _rotation_matrix_normalized
+
+    # Find the chi stage and the sample stages that come before it
+    sample_stages = list(geometry.sample_stages)
+    chi_index = None
+    for i, s in enumerate(sample_stages):
+        if s.name == "chi":
+            chi_index = i
+            break
+    if chi_index is None:
+        raise KeyError(
+            f"omega_pseudo: geometry {geometry.name!r} has no sample stage "
+            "named 'chi'.  The OMEGA pseudo-angle (SPEC Q[6]) is defined "
+            "only for psic-family geometries with a chi circle."
+        )
+
+    chi_stage = sample_stages[chi_index]
+    outer_stages = sample_stages[:chi_index]
+
+    # Apply the rotations of all stages *before* chi to the chi axis
+    R = np.eye(3)
+    for s in outer_stages:
+        angle = angles.get(s.name, s.angle)
+        R = _rotation_matrix_normalized(s._axis_hat, angle) @ R  # noqa: SLF001
+
+    chi_axis_lab = R @ np.asarray(chi_stage._axis_hat, dtype=float)  # noqa: SLF001
+    n = float(np.linalg.norm(chi_axis_lab))
+    if n < 1e-14:  # pragma: no cover
+        raise ValueError(
+            "omega_pseudo: chi stage axis vector has zero length after rotation."
+        )
+    return chi_axis_lab / n
+
+
+def omega_pseudo(
+    geometry: AdHocDiffractometer,
+    angles: dict[str, float] | None = None,
+) -> float:
+    """
+    Compute the SPEC ``OMEGA`` pseudo-angle in degrees.
+
+    OMEGA is the angle between the scattering vector Q and the **plane of
+    the chi circle**, taking values in ``[-90°, +90°]``.  When
+    ``OMEGA = 0`` the scattering vector lies in the chi-circle plane and
+    the diffractometer is in the bisecting condition; non-zero OMEGA
+    means Q is tilted out of that plane.
+
+    The chi-circle plane is the plane perpendicular to the chi rotation
+    axis; that axis itself is rotated by every sample stage that sits
+    *outside* (i.e. lower in the stack than) chi.  In psic the outer
+    sample stages are ``mu`` and ``eta``.
+
+    Algorithm
+    ---------
+    1. Compute the chi-axis unit vector in the lab frame, applying the
+       rotations of all sample stages outside chi (e.g. ``mu`` and
+       ``eta`` in psic).
+    2. Compute the scattering vector ``Q_lab`` from the supplied motor
+       angles.
+    3. The OMEGA pseudo-angle is::
+
+           sin(OMEGA) = (Q̂_lab · n̂_chi)
+
+       where ``n̂_chi`` is the unit chi-axis vector in the lab frame.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+        Diffractometer geometry.  Must have ``wavelength`` set and must
+        contain a sample stage named ``"chi"``.
+    angles : dict[str, float] or None
+        Motor angles in degrees, keyed by stage name.  If ``None``
+        (default), the geometry's current stage angles are used.
+
+    Returns
+    -------
+    float
+        OMEGA pseudo-angle in degrees, in ``[-90°, +90°]``.
+
+    Raises
+    ------
+    ValueError
+        If ``geometry.wavelength`` is ``None``.
+    KeyError
+        If the geometry has no stage named ``"chi"``.
+
+    Notes
+    -----
+    Unlike :func:`incidence_angle`, :func:`exit_angle`, :func:`psi_angle`,
+    and :func:`naz_angle`, this function does **not** require any
+    reference vector (``surface_normal`` / ``azimuthal_reference``) to be
+    set on the geometry.  OMEGA is a pure motor-frame quantity defined
+    by the diffractometer's internal geometry.
+
+    The sign convention follows the right-hand rule about the chi axis:
+    OMEGA is positive when Q has a positive component along the chi-axis
+    direction defined by the geometry's stage configuration.
+
+    OMEGA is **independent of the inner sample stages** (``chi`` and
+    ``phi`` in psic): they rotate Q but they also rotate the
+    chi-circle plane normal — the relative angle between them is
+    preserved.  The pseudo-angle therefore depends only on the outer
+    sample stages, the detector stages, and the wavelength.
+
+    Examples
+    --------
+    >>> import ad_hoc_diffractometer as ahd
+    >>> g = ahd.make_geometry("psic")
+    >>> g.wavelength = 1.5406
+    >>> # Bisecting position: mu = nu = 0, eta = delta/2 — Q in chi-plane
+    >>> ahd.reference.omega_pseudo(
+    ...     g,
+    ...     {"mu": 0, "eta": 15.0, "chi": 90, "phi": 0,
+    ...      "nu": 0, "delta": 30.0},
+    ... )  # doctest: +SKIP
+    0.0
+
+    References
+    ----------
+    * Certified Scientific Software, *SPEC psic help*,
+      https://certif.com/spec_help/psic.html —
+      ``def OMEGA 'Q[6]'`` — "The angle between Q and the plane of
+      the chi circle."
+    * H. You, *J. Appl. Cryst.* **32**, 614-623 (1999), §5.
+    """
+    if geometry.wavelength is None:
+        raise ValueError("omega_pseudo() requires geometry.wavelength to be set.")
+
+    if angles is None:
+        angles = {s.name: s.angle for s in geometry._stages.values()}  # noqa: SLF001
+
+    # Lab-frame chi-circle axis (= normal to the chi-circle plane)
+    n_chi_lab = _chi_stage_axis_lab(geometry, angles)
+
+    # Lab-frame scattering vector
+    from .rotation import _rotation_matrix_normalized
+
+    D = np.eye(3)
+    for s in geometry.detector_stages:
+        angle = angles.get(s.name, s.angle)
+        D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+
+    y_raw = np.asarray(geometry.basis["longitudinal"], dtype=float)
+    y_hat = y_raw / np.linalg.norm(y_raw)
+
+    Q_lab = D @ y_hat - y_hat
+    Q_mag = float(np.linalg.norm(Q_lab))
+    if Q_mag < 1e-12:
+        # No scattering — Q is undefined; OMEGA is undefined; return 0
+        return 0.0
+    Q_hat = Q_lab / Q_mag
+
+    sin_omega = float(np.clip(np.dot(Q_hat, n_chi_lab), -1.0, 1.0))
+    return math.degrees(math.asin(sin_omega))

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1595,16 +1595,26 @@ def test_qaz_residual(nu_deg, delta_deg, target_qaz_deg, expected_residual):
     assert residual == pytest.approx(expected_residual, abs=1e-6)
 
 
-def test_psic_lifting_detector_mu_limits_exclude_nu_zero():
-    """If nu stage limits exclude nu=0, qaz=90 solutions are filtered out."""
+def test_psic_lifting_detector_mu_limits_filter_solutions():
+    """Stage limits filter out solutions whose computed angles fall outside.
+
+    After the issue #264 C3/C4 revision, ``lifting_detector_mu`` no longer
+    pins ``nu=0`` (the qaz=90 detector pseudo-constraint was dropped).
+    The mu stage is the only free sample stage, so restricting its
+    limits gives a clean filter that drops every solution that lands
+    outside the allowed mu range.
+    """
     g = _setup_cubic(psic, a=4.0)
     g.mode_name = "lifting_detector_mu"
-    # Default solution for qaz=90 uses nu=0; excluding nu=0 gives no solutions.
-    nu_stage = g.stage("nu")
-    nu_stage.limits = (1.0, 180.0)
-    solutions = g.forward(1, 0, 0)
-    # All detector solutions use nu=0 which is now outside limits
-    assert len(solutions) == 0
+    # (0, 1, 1) reaches at mu ~= ±70°
+    sols_unrestricted = g.forward(0, 1, 1)
+    assert len(sols_unrestricted) > 0
+    # Restrict mu to the positive range — the negative-mu solutions drop out
+    g.stage("mu").limits = (0.0, 90.0)
+    sols_restricted = g.forward(0, 1, 1)
+    assert 0 < len(sols_restricted) < len(sols_unrestricted)
+    for sol in sols_restricted:
+        assert 0.0 <= sol["mu"] <= 90.0
 
 
 def test_qaz_residual_two_detector_stages_required():
@@ -1637,26 +1647,34 @@ def test_qaz_residual_two_detector_stages_required():
 @pytest.mark.parametrize(
     "mode_name, h, k, l",
     [
-        pytest.param("lifting_detector_mu", 1, 0, 0, id="psic-liftmu-100"),
-        pytest.param("lifting_detector_mu", 0, 0, 1, id="psic-liftmu-001"),
+        # Issue #264 C3/C4 revision: psic lifting_detector_phi/mu now fix
+        # three sample stages and let both detector stages float to satisfy
+        # the Bragg condition.  The qaz pseudo-angle is no longer pinned;
+        # the test verifies forward/inverse round-trip and the expected
+        # frozen sample angles instead.
+        pytest.param("lifting_detector_mu", 0, 1, 0, id="psic-liftmu-010"),
+        pytest.param("lifting_detector_mu", 1, 1, 1, id="psic-liftmu-111"),
         pytest.param("lifting_detector_phi", 1, 0, 0, id="psic-liftphi-100"),
-        pytest.param("lifting_detector_phi", 0, 1, 0, id="psic-liftphi-010"),
+        pytest.param("lifting_detector_phi", 1, 1, 1, id="psic-liftphi-111"),
     ],
 )
-def test_psic_lifting_detector_qaz_satisfied(mode_name, h, k, l):  # noqa: E741
-    """lifting_detector_* modes: qaz = 90.0 verified in all solutions."""
+def test_psic_lifting_detector_round_trip(mode_name, h, k, l):  # noqa: E741
+    """lifting_detector_phi / lifting_detector_mu round-trip after #264 revision."""
     g = _setup_cubic(psic, a=4.0)
     g.mode_name = mode_name
     solutions = g.forward(h, k, l)
     assert len(solutions) > 0, f"No solutions for {mode_name} ({h},{k},{l})"
+    # Identify which sample stage is the "free" one based on the mode name
+    free_sample = mode_name.split("_")[-1]  # "phi" or "mu"
+    fixed_samples = {"mu", "eta", "chi", "phi"} - {free_sample}
     for sol in solutions:
-        nu_deg = sol["nu"]
-        delta_deg = sol["delta"]
-        qaz_computed = _qaz_from_angles(nu_deg, delta_deg)
-        assert qaz_computed == pytest.approx(90.0, abs=1e-4), (
-            f"{mode_name}: expected qaz=90, got {qaz_computed:.6f} "
-            f"(nu={nu_deg:.4f}, delta={delta_deg:.4f})"
-        )
+        for stage in fixed_samples:
+            assert sol[stage] == pytest.approx(0.0, abs=1e-6), (
+                f"{mode_name}: sample stage {stage!r} should be fixed at 0, "
+                f"got {sol[stage]:.6f}"
+            )
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [h, k, l], atol=1e-5)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1377,14 +1377,18 @@ _PSIC_MODES_ALL = {
     "double_diffraction_horizontal",
     "lifting_detector_mu",
     "lifting_detector_phi",
+    "lifting_detector_eta",
     "fixed_psi_vertical",
     "fixed_psi_horizontal",
     "fixed_alpha_i_vertical",
     "fixed_beta_out_vertical",
     "alpha_eq_beta_vertical",
+    "fixed_alpha_i_fixed_chi_fixed_phi",
     "fixed_alpha_i_horizontal",
     "fixed_beta_out_horizontal",
     "alpha_eq_beta_horizontal",
+    "fixed_omega_vertical",
+    "fixed_omega_horizontal",
     "zone_vertical",
     "zone_horizontal",
 }
@@ -1400,6 +1404,9 @@ _PSIC_MODES_IMPLEMENTED = {
     "double_diffraction_horizontal",
     "lifting_detector_mu",
     "lifting_detector_phi",
+    "lifting_detector_eta",
+    "fixed_omega_vertical",
+    "fixed_omega_horizontal",
     "zone_vertical",
     "zone_horizontal",
 }
@@ -2813,3 +2820,207 @@ def test_kappa_bisecting_post_processing_limits_rejection(monkeypatch):
     assert sol["komega"] == pytest.approx(candidate_a["komega"])
     assert sol["kappa"] == pytest.approx(candidate_a["kappa"])
     assert sol["kphi"] == pytest.approx(candidate_a["kphi"])
+
+
+# ---------------------------------------------------------------------------
+# Issue #264 — Step B new psic modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l, context",
+    [
+        pytest.param(
+            "fixed_omega_vertical",
+            1,
+            0,
+            0,
+            does_not_raise(),
+            id="omega_v-100",
+        ),
+        pytest.param(
+            "fixed_omega_vertical",
+            0,
+            1,
+            1,
+            does_not_raise(),
+            id="omega_v-011",
+        ),
+        pytest.param(
+            "fixed_omega_horizontal",
+            0,
+            0,
+            1,
+            does_not_raise(),
+            id="omega_h-001",
+        ),
+        pytest.param(
+            "fixed_omega_horizontal",
+            1,
+            0,
+            1,
+            does_not_raise(),
+            id="omega_h-101",
+        ),
+    ],
+)
+def test_psic_fixed_omega_round_trip(mode_name, h, k, l, context):  # noqa: E741
+    """fixed_omega_* modes (target = 0) round-trip and reduce to bisecting."""
+    from ad_hoc_diffractometer.reference import omega_pseudo
+
+    with context:
+        g = _setup_cubic(psic, a=4.0)
+        g.mode_name = mode_name
+        sols = g.forward(h, k, l)
+        assert len(sols) > 0, f"{mode_name} ({h},{k},{l}): no solutions"
+        for sol in sols:
+            # Round-trip Bragg
+            hkl_back = g.inverse(sol)
+            assert np.allclose(hkl_back, [h, k, l], atol=1e-6), (
+                f"{mode_name} ({h},{k},{l}): inverse mismatch {hkl_back}"
+            )
+            # OMEGA pseudo-angle = 0 in every solution
+            om = omega_pseudo(g, angles=sol)
+            assert om == pytest.approx(0.0, abs=1e-5), (
+                f"{mode_name} ({h},{k},{l}): expected OMEGA=0, got {om}"
+            )
+
+
+def test_psic_fixed_omega_vertical_matches_bisecting():
+    """fixed_omega_vertical (omega=0) yields the bisecting_vertical solutions."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = "bisecting_vertical"
+    bisect_sols = g.forward(1, 0, 0)
+    g.mode_name = "fixed_omega_vertical"
+    omega_sols = g.forward(1, 0, 0)
+    assert len(bisect_sols) == len(omega_sols)
+    # Compare matching solutions (sort by eta)
+    bisect_sorted = sorted(bisect_sols, key=lambda s: s["eta"])
+    omega_sorted = sorted(omega_sols, key=lambda s: s["eta"])
+    for b, o in zip(bisect_sorted, omega_sorted, strict=False):
+        for stage in ("mu", "eta", "chi", "phi", "nu", "delta"):
+            assert b[stage] == pytest.approx(o[stage], abs=1e-6), (
+                f"stage {stage}: bisect={b[stage]}, omega={o[stage]}"
+            )
+
+
+def test_psic_fixed_omega_nonzero_target():
+    """fixed_omega_vertical with omega=5° produces solutions with OMEGA=5°."""
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import DetectorConstraint
+    from ad_hoc_diffractometer import ReferenceConstraint
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.reference import omega_pseudo
+
+    g = _setup_cubic(psic, a=4.0)
+    g.modes["__test_omega_5"] = ConstraintSet(
+        [
+            SampleConstraint("mu", 0.0),
+            DetectorConstraint("nu", 0.0),
+            ReferenceConstraint("omega", 5.0),
+        ],
+        computed=["eta", "chi", "phi", "delta"],
+    )
+    g.mode_name = "__test_omega_5"
+    sols = g.forward(1, 0, 0)
+    assert len(sols) > 0
+    for sol in sols:
+        om = omega_pseudo(g, angles=sol)
+        assert om == pytest.approx(5.0, abs=1e-3), f"omega=5° target: got OMEGA={om}"
+        # Bragg still satisfied
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [1, 0, 0], atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "h, k, l, alpha_target, context",
+    [
+        pytest.param(0, 1, 1, 0.0, does_not_raise(), id="011-ai0"),
+        pytest.param(0, 1, 1, 5.0, does_not_raise(), id="011-ai5"),
+        pytest.param(1, 1, 1, 3.0, does_not_raise(), id="111-ai3"),
+    ],
+)
+def test_psic_fixed_alpha_i_fixed_chi_fixed_phi_round_trip(
+    h,
+    k,
+    l,  # noqa: E741
+    alpha_target,
+    context,
+):
+    """Issue #264 B3: 4-D Newton with chi=phi=0 + alpha_i target."""
+    from ad_hoc_diffractometer import REQUIRED
+    from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import ReferenceConstraint
+    from ad_hoc_diffractometer import SampleConstraint
+    from ad_hoc_diffractometer.reference import incidence_angle
+
+    with context:
+        g = _setup_cubic(psic, a=4.0)
+        g.surface_normal = (0, 0, 1)
+        g.modes["__test_b3"] = ConstraintSet(
+            [
+                SampleConstraint("chi", 0.0),
+                SampleConstraint("phi", 0.0),
+                ReferenceConstraint("alpha_i", alpha_target),
+            ],
+            computed=["mu", "eta", "nu", "delta"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        )
+        g.mode_name = "__test_b3"
+        sols = g.forward(h, k, l)
+        assert len(sols) > 0, f"B3 ({h},{k},{l}) alpha_i={alpha_target}: no solutions"
+        for sol in sols:
+            assert sol["chi"] == pytest.approx(0.0, abs=1e-6)
+            assert sol["phi"] == pytest.approx(0.0, abs=1e-6)
+            ai = incidence_angle(g, angles=sol)
+            assert ai == pytest.approx(alpha_target, abs=1e-3), (
+                f"B3 ({h},{k},{l}) alpha_i target {alpha_target}: got {ai}"
+            )
+            hkl_back = g.inverse(sol)
+            assert np.allclose(hkl_back, [h, k, l], atol=1e-5)
+
+
+def test_psic_fixed_alpha_i_fixed_chi_fixed_phi_requires_surface_normal():
+    """B3 mode is_implemented=False until surface_normal is set."""
+    g = _setup_cubic(psic, a=4.0)
+    cs = g.modes["fixed_alpha_i_fixed_chi_fixed_phi"]
+    assert cs.is_implemented(g) is False
+    g.surface_normal = (0, 0, 1)
+    assert cs.is_implemented(g) is True
+
+
+@pytest.mark.parametrize(
+    "h, k, l, context",
+    [
+        pytest.param(1, 0, 0, does_not_raise(), id="lift_eta-100"),
+        pytest.param(0, 1, 0, does_not_raise(), id="lift_eta-010"),
+        pytest.param(1, 1, 0, does_not_raise(), id="lift_eta-110"),
+        pytest.param(1, 1, 1, does_not_raise(), id="lift_eta-111"),
+    ],
+)
+def test_psic_lifting_detector_eta_round_trip(h, k, l, context):  # noqa: E741
+    """Issue #264 B4: lifting_detector_eta round-trip.
+
+    Fixes mu, chi, phi at zero and lets eta, nu, delta float to satisfy
+    the Bragg condition.  Both detector stages free (no qaz)."""
+    with context:
+        g = _setup_cubic(psic, a=4.0)
+        g.mode_name = "lifting_detector_eta"
+        sols = g.forward(h, k, l)
+        assert len(sols) > 0, f"lifting_detector_eta ({h},{k},{l}): no solutions"
+        for sol in sols:
+            assert sol["mu"] == pytest.approx(0.0, abs=1e-6)
+            assert sol["chi"] == pytest.approx(0.0, abs=1e-6)
+            assert sol["phi"] == pytest.approx(0.0, abs=1e-6)
+            hkl_back = g.inverse(sol)
+            assert np.allclose(hkl_back, [h, k, l], atol=1e-5)
+
+
+def test_psic_lifting_detector_eta_lifts_for_out_of_plane_hkl():
+    """For (1,1,1) the detector lifts out of the horizontal plane (nu != 0)."""
+    g = _setup_cubic(psic, a=4.0)
+    g.mode_name = "lifting_detector_eta"
+    sols = g.forward(1, 1, 1)
+    assert any(abs(s["nu"]) > 1.0 for s in sols), (
+        "lifting_detector_eta (1,1,1): expected nu != 0 in at least one solution"
+    )

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1875,20 +1875,26 @@ def test_psic_fixed_psi_round_trip(mode_name, h, k, l, ref):  # noqa: E741
 
 
 def test_psic_fixed_psi_wrong_target_returns_empty():
-    """psic fixed_psi_vertical returns [] when psi target is wrong."""
+    """psic fixed_psi_vertical returns [] when psi target is wrong.
+
+    After the issue #264 C1 revision the mode is built from
+    DetectorConstraint('nu', 0) + SampleConstraint('mu', 0) +
+    ReferenceConstraint('psi', target); psi-validation still rejects
+    requests whose natural psi differs from the stored target.
+    """
     g = _setup_psi(psic, ref=(0, 0, 1))
     natural = _natural_psi(g, 1, 0, 0)
     assert natural is not None
 
     from ad_hoc_diffractometer import REQUIRED
-    from ad_hoc_diffractometer import BisectConstraint
     from ad_hoc_diffractometer import ConstraintSet
+    from ad_hoc_diffractometer import DetectorConstraint
     from ad_hoc_diffractometer import ReferenceConstraint
     from ad_hoc_diffractometer import SampleConstraint
 
     g.modes["fixed_psi_vertical"] = ConstraintSet(
         [
-            BisectConstraint("eta", "delta"),
+            DetectorConstraint("nu", 0.0),
             SampleConstraint("mu", 0.0),
             ReferenceConstraint("psi", natural + 45.0),
         ],

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1702,6 +1702,23 @@ def test_kappa6c_lifting_detector_qaz_satisfied(mode_name, h, k, l):  # noqa: E7
         )
 
 
+def test_kappa6c_lifting_detector_qaz_filters_by_detector_limits():
+    """The qaz solver drops candidates whose nu/delta angles exceed limits.
+
+    Replaces an equivalent psic test that no longer applies after the
+    issue #264 C3/C4 revision dropped the qaz constraint from psic
+    ``lifting_detector_*``.  kappa6c still uses qaz, so this is the
+    remaining qaz-limits coverage.
+    """
+    g = _setup_cubic(kappa6c, a=4.0)
+    g.mode_name = "lifting_detector_mu"
+    # qaz=90 forces nu = 0 and delta = ±ttheta on kappa6c.  Excluding
+    # nu = 0 from the limits drops every detector candidate.
+    g.stage("nu").limits = (1.0, 180.0)
+    solutions = g.forward(1, 0, 0)
+    assert solutions == []
+
+
 # ---------------------------------------------------------------------------
 # Issue #176 — fixed_psi forward solver (validation filter)
 # ---------------------------------------------------------------------------

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -539,3 +539,170 @@ def test_surface_mode_not_implemented_raises():
     g.mode_name = "zaxis"
     with pytest.raises(NotImplementedError):
         g.forward(0, 1, 0)
+
+
+# ---------------------------------------------------------------------------
+# omega_pseudo (SPEC OMEGA = Q[6], issue #264)
+# ---------------------------------------------------------------------------
+
+
+from contextlib import nullcontext as does_not_raise  # noqa: E402
+
+from ad_hoc_diffractometer.reference import omega_pseudo  # noqa: E402
+
+
+def test_omega_pseudo_requires_wavelength():
+    """omega_pseudo raises ValueError when wavelength is None."""
+    g = psic()
+    # Do NOT set wavelength
+    with pytest.raises(ValueError, match=re.escape("wavelength")):
+        omega_pseudo(g)
+
+
+def test_omega_pseudo_requires_chi_stage():
+    """omega_pseudo raises KeyError on a geometry with no 'chi' stage."""
+    g = zaxis()
+    g.wavelength = WAVELENGTH
+    with pytest.raises(KeyError, match=re.escape("no sample stage named 'chi'")):
+        omega_pseudo(g)
+
+
+def test_omega_pseudo_does_not_require_surface_normal():
+    """omega_pseudo works with no surface_normal or azimuthal_reference."""
+    g = _setup_psic()
+    assert g.surface_normal is None
+    assert g.azimuthal_reference is None
+    g.mode_name = "bisecting_vertical"
+    sols = g.forward(1, 0, 0)
+    for s in sols:
+        om = omega_pseudo(g, angles=s)
+        assert isinstance(om, float)
+
+
+def test_omega_pseudo_uses_current_angles_when_none():
+    """omega_pseudo uses current stage angles when angles=None."""
+    g = _setup_psic()
+    om = omega_pseudo(g, angles=None)
+    assert isinstance(om, float)
+
+
+def test_omega_pseudo_zero_at_bisecting_vertical():
+    """At bisecting_vertical (mu=nu=0, eta=delta/2), OMEGA = 0."""
+    g = _setup_psic()
+    g.mode_name = "bisecting_vertical"
+    sols = g.forward(1, 0, 0)
+    assert len(sols) > 0
+    for s in sols:
+        om = omega_pseudo(g, angles=s)
+        assert om == pytest.approx(0.0, abs=1e-6), (
+            f"OMEGA should be 0 at bisecting; got {om} for {s}"
+        )
+
+
+def test_omega_pseudo_zero_at_bisecting_horizontal():
+    """At bisecting_horizontal (eta=delta=0, mu=nu/2), OMEGA = 0."""
+    g = _setup_psic()
+    g.mode_name = "bisecting_horizontal"
+    sols = g.forward(0, 0, 1)
+    assert len(sols) > 0
+    for s in sols:
+        om = omega_pseudo(g, angles=s)
+        assert om == pytest.approx(0.0, abs=1e-6), (
+            f"OMEGA should be 0 at bisecting_horizontal; got {om} for {s}"
+        )
+
+
+def test_omega_pseudo_independent_of_phi():
+    """OMEGA depends only on the outer sample stages and the detector;
+    it is independent of phi."""
+    g = _setup_psic()
+    angles_a = {
+        "mu": 5.0,
+        "eta": 12.0,
+        "chi": 30.0,
+        "phi": 0.0,
+        "nu": 0.0,
+        "delta": 24.0,
+    }
+    angles_b = dict(angles_a)
+    angles_b["phi"] = 73.0
+    om_a = omega_pseudo(g, angles=angles_a)
+    om_b = omega_pseudo(g, angles=angles_b)
+    assert om_a == pytest.approx(om_b, abs=1e-9), (
+        f"OMEGA must be independent of phi; got {om_a} vs {om_b}"
+    )
+
+
+def test_omega_pseudo_independent_of_chi():
+    """OMEGA depends only on the outer sample stages and the detector;
+    it is independent of chi (chi rotates Q and the chi-circle plane
+    together, preserving their relative angle)."""
+    g = _setup_psic()
+    angles_a = {
+        "mu": 5.0,
+        "eta": 12.0,
+        "chi": 30.0,
+        "phi": 17.0,
+        "nu": 0.0,
+        "delta": 24.0,
+    }
+    angles_b = dict(angles_a)
+    angles_b["chi"] = 91.0
+    om_a = omega_pseudo(g, angles=angles_a)
+    om_b = omega_pseudo(g, angles=angles_b)
+    assert om_a == pytest.approx(om_b, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        pytest.param("psi", True, id="psi"),
+        pytest.param("alpha_i", True, id="alpha_i"),
+        pytest.param("beta_out", True, id="beta_out"),
+        pytest.param("a_eq_b", True, id="a_eq_b"),
+        pytest.param("naz", True, id="naz"),
+        pytest.param("omega", True, id="omega"),
+        pytest.param("not_a_pseudo_angle", False, id="invalid"),
+    ],
+)
+def test_reference_constraint_accepts_omega(name, expected):
+    """ReferenceConstraint('omega', value) is now a valid constraint."""
+    context = (
+        does_not_raise()
+        if expected
+        else pytest.raises(ValueError, match=re.escape("ReferenceConstraint name"))
+    )
+    with context:
+        if name == "a_eq_b":
+            ReferenceConstraint(name, True)
+        else:
+            ReferenceConstraint(name, 0.0)
+
+
+def test_reference_constraint_omega_is_implemented_on_psic():
+    """ReferenceConstraint('omega', 0).is_implemented(psic) is True."""
+    g = _setup_psic()
+    rc = ReferenceConstraint("omega", 0.0)
+    assert rc.is_implemented(g) is True
+    assert rc.has_reference_vector(g) is True
+
+
+def test_reference_constraint_omega_not_implemented_on_zaxis():
+    """ReferenceConstraint('omega', 0).is_implemented(zaxis) is False — no chi."""
+    g = zaxis()
+    g.wavelength = WAVELENGTH
+    rc = ReferenceConstraint("omega", 0.0)
+    assert rc.is_implemented(g) is False
+    # has_reference_vector still True (omega needs no reference vector)
+    assert rc.has_reference_vector(g) is True
+
+
+def test_reference_constraint_omega_serialization_round_trip():
+    """ReferenceConstraint('omega', value) round-trips through to_dict / from_dict."""
+    rc = ReferenceConstraint("omega", 12.5)
+    d = rc.to_dict()
+    assert d["type"] == "ReferenceConstraint"
+    assert d["name"] == "omega"
+    assert d["value"] == 12.5
+    rc2 = ReferenceConstraint.from_dict(d)
+    assert rc == rc2

--- a/tests/test_regression_issue_264.py
+++ b/tests/test_regression_issue_264.py
@@ -35,9 +35,18 @@ cross-module *invariants* that must hold across the whole #264 patch:
   ``lifting_detector_eta``, and the revised
   ``lifting_detector_phi`` / ``lifting_detector_mu``).
 
-C1 (``fixed_psi_vertical``) and C2 (``fixed_psi_horizontal``) were
-deferred from this PR pending @jwkim-anl clarification (see the
-discussion thread on #264) and are therefore not exercised here.
+C1 (``fixed_psi_vertical``) and C2 (``fixed_psi_horizontal``) drop
+the previous BisectConstraint and pin a detector stage instead per
+the @jwkim-anl review on the issue thread:
+
+- ``fixed_psi_vertical``   = ``nu = 0`` (vertical) + ``mu`` fixed +
+  ``psi`` target.
+- ``fixed_psi_horizontal`` = ``delta = 0`` (horizontal) + ``eta``
+  fixed + ``psi`` target.
+
+Both modes route through ``_solve_psi_mode`` for the ψ-validation
+filter, then to ``_solve_fixed_sample`` to solve the remaining free
+sample stages plus the active detector at ``2θ``.
 """
 
 from __future__ import annotations
@@ -50,6 +59,7 @@ import pytest
 from helpers import psic
 
 import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import REQUIRED
 from ad_hoc_diffractometer import ConstraintSet
 from ad_hoc_diffractometer import DetectorConstraint
 from ad_hoc_diffractometer import ReferenceConstraint
@@ -72,6 +82,8 @@ _ISSUE_264_NEW_MODES = {
 _ISSUE_264_REVISED_MODES = {
     "lifting_detector_phi",
     "lifting_detector_mu",
+    "fixed_psi_vertical",
+    "fixed_psi_horizontal",
 }
 
 
@@ -362,6 +374,138 @@ def test_revised_lifting_detector_has_no_qaz_constraint(mode_name):
     assert len(sample_constraints) == 3, (
         f"{mode_name}: expected 3 SampleConstraints; got {len(sample_constraints)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #264 design invariant: revised fixed_psi_* modes drop the bisect
+# and pin a detector stage instead (C1/C2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name, expected_detector_stage, expected_sample_stage",
+    [
+        pytest.param("fixed_psi_vertical", "nu", "mu", id="fixed_psi_vertical-nu-mu"),
+        pytest.param(
+            "fixed_psi_horizontal",
+            "delta",
+            "eta",
+            id="fixed_psi_horizontal-delta-eta",
+        ),
+    ],
+)
+def test_revised_fixed_psi_constraint_shape(
+    mode_name, expected_detector_stage, expected_sample_stage
+):
+    """The C1/C2 revision swapped the BisectConstraint for a
+    DetectorConstraint pinning the scattering plane.
+    """
+    from ad_hoc_diffractometer.mode import BisectConstraint
+
+    g = psic()
+    cs = g.modes[mode_name]
+    # No BisectConstraint after the revision.
+    bisects = [c for c in cs.constraints if isinstance(c, BisectConstraint)]
+    assert bisects == [], (
+        f"{mode_name}: expected no BisectConstraint after C1/C2 revision; "
+        f"found {bisects!r}"
+    )
+    # Exactly one DetectorConstraint pinning the scattering plane.
+    det = cs.detector_constraint
+    assert det is not None
+    assert det.name == expected_detector_stage
+    assert det.value == 0.0
+    # Exactly one SampleConstraint at the named stage (default value 0).
+    samples = [c for c in cs.constraints if isinstance(c, SampleConstraint)]
+    assert len(samples) == 1
+    assert samples[0].name == expected_sample_stage
+    # The psi reference is still present.
+    ref = cs.reference_constraint
+    assert ref is not None
+    assert ref.name == "psi"
+
+
+def _natural_psi(g, h, k, l):  # noqa: E741
+    """Return the natural psi for (h, k, l) on geometry ``g``."""
+    from ad_hoc_diffractometer.forward import _compute_natural_psi
+
+    Q_phi = g.sample.UB @ np.array([h, k, l], float)
+    return _compute_natural_psi(g, Q_phi)
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l",
+    [
+        pytest.param("fixed_psi_vertical", 1, 0, 0, id="fpv-100"),
+        pytest.param("fixed_psi_vertical", 1, 1, 0, id="fpv-110"),
+        pytest.param("fixed_psi_vertical", 1, 1, 1, id="fpv-111"),
+        pytest.param("fixed_psi_horizontal", 1, 0, 1, id="fph-101"),
+        pytest.param("fixed_psi_horizontal", 1, 0, 0, id="fph-100"),
+    ],
+)
+def test_revised_fixed_psi_round_trip(
+    mode_name,
+    h,
+    k,
+    l,  # noqa: E741
+):
+    """C1/C2 revised fixed_psi modes round-trip and satisfy psi target."""
+    from ad_hoc_diffractometer.reference import psi_angle
+
+    g = _setup_psic_cubic()
+    g.azimuthal_reference = (0, 0, 1)
+    natural = _natural_psi(g, h, k, l)
+    assert natural is not None, (
+        f"{mode_name} ({h},{k},{l}): natural psi is undefined for this hkl"
+    )
+
+    # Patch the mode to use the natural psi target so the validator passes.
+    old_mode = g.modes[mode_name]
+    new_constraints = []
+    for c in old_mode.constraints:
+        if isinstance(c, ReferenceConstraint) and c.name == "psi":
+            new_constraints.append(ReferenceConstraint("psi", natural))
+        else:
+            new_constraints.append(c)
+    g.modes[mode_name] = ConstraintSet(
+        new_constraints,
+        computed=old_mode.computed,
+        extras=dict(old_mode.extras),
+    )
+    g.mode_name = mode_name
+
+    sols = g.forward(h, k, l)
+    assert len(sols) > 0, f"{mode_name} ({h},{k},{l}): no solutions"
+    for sol in sols:
+        # psi target satisfied
+        psi = psi_angle(g, angles=sol)
+        assert psi == pytest.approx(natural, abs=1e-3), (
+            f"{mode_name} ({h},{k},{l}): expected psi={natural}, got {psi}"
+        )
+        # Bragg round-trip
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [h, k, l], atol=1e-5)
+
+
+def test_revised_fixed_psi_wrong_target_returns_empty():
+    """C1/C2: psi-validation rejects requests whose natural psi differs
+    from the stored target."""
+    g = _setup_psic_cubic()
+    g.azimuthal_reference = (0, 0, 1)
+    natural = _natural_psi(g, 1, 0, 0)
+    assert natural is not None
+
+    g.modes["fixed_psi_vertical"] = ConstraintSet(
+        [
+            DetectorConstraint("nu", 0.0),
+            SampleConstraint("mu", 0.0),
+            ReferenceConstraint("psi", natural + 45.0),
+        ],
+        computed=["eta", "chi", "phi", "delta"],
+        extras={"n_hat": REQUIRED, "psi": None},
+    )
+    g.mode_name = "fixed_psi_vertical"
+    assert g.forward(1, 0, 0) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_regression_issue_264.py
+++ b/tests/test_regression_issue_264.py
@@ -1,0 +1,427 @@
+# Copyright (c) 2026 Pete R. Jemian <prjemian+ad_hoc_diffractometer@gmail.com>
+# SPDX-License-Identifier: CC-BY-4.0
+"""
+Cross-module regression tests for issue #264.
+
+Issue #264 introduced two distinct sets of psic-mode changes:
+
+1. The SPEC ``OMEGA`` pseudo-angle (``def OMEGA 'Q[6]'`` —
+   "the angle between Q and the plane of the chi circle") was added as
+   a new :class:`~ad_hoc_diffractometer.mode.ReferenceConstraint` name,
+   together with two new psic modes
+   (``fixed_omega_vertical`` / ``fixed_omega_horizontal``) and the
+   solver dispatch that handles them.
+
+2. Three additional psic modes were introduced or revised per the
+   @jwkim-anl review: ``fixed_alpha_i_fixed_chi_fixed_phi`` (B3),
+   ``lifting_detector_eta`` (B4), plus the
+   ``lifting_detector_phi`` / ``lifting_detector_mu`` revisions
+   (C3/C4) that drop the ``qaz = 90`` constraint and fix every sample
+   stage except the named one.
+
+The per-module unit tests in ``tests/test_reference.py``,
+``tests/test_forward.py`` and ``tests/test_regression_issue_267.py``
+already cover the individual pieces; this file collects the
+cross-module *invariants* that must hold across the whole #264 patch:
+
+- OMEGA = 0 ⇔ bisecting (the central physical equivalence claimed by
+  @jwkim-anl in the issue thread).
+- Every mode named by issue #264 is present in the registry, has the
+  expected ``is_implemented`` status, and produces solutions that
+  satisfy the Bragg condition end-to-end.
+- The dispatcher routes each new/revised mode to its intended solver
+  branch (``_solve_omega_mode`` for ``fixed_omega_*``,
+  ``_solve_free_detectors`` for ``fixed_alpha_i_fixed_chi_fixed_phi``,
+  ``lifting_detector_eta``, and the revised
+  ``lifting_detector_phi`` / ``lifting_detector_mu``).
+
+C1 (``fixed_psi_vertical``) and C2 (``fixed_psi_horizontal``) were
+deferred from this PR pending @jwkim-anl clarification (see the
+discussion thread on #264) and are therefore not exercised here.
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+from helpers import psic
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer import ConstraintSet
+from ad_hoc_diffractometer import DetectorConstraint
+from ad_hoc_diffractometer import ReferenceConstraint
+from ad_hoc_diffractometer import SampleConstraint
+from ad_hoc_diffractometer import ub_identity
+from ad_hoc_diffractometer.forward import _is_free_detectors_mode
+from ad_hoc_diffractometer.forward import _is_omega_mode
+from ad_hoc_diffractometer.reference import incidence_angle
+from ad_hoc_diffractometer.reference import omega_pseudo
+
+WAVELENGTH = 1.5406  # Cu Kα
+
+# All modes added or revised by #264.
+_ISSUE_264_NEW_MODES = {
+    "fixed_omega_vertical",
+    "fixed_omega_horizontal",
+    "fixed_alpha_i_fixed_chi_fixed_phi",
+    "lifting_detector_eta",
+}
+_ISSUE_264_REVISED_MODES = {
+    "lifting_detector_phi",
+    "lifting_detector_mu",
+}
+
+
+def _setup_psic_cubic(a: float = 4.0):
+    """Return a psic geometry with UB=B for a cubic lattice of side ``a``."""
+    g = psic()
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=a)
+    ub_identity(g.sample)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Mode registry: every #264 mode is present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    sorted(_ISSUE_264_NEW_MODES | _ISSUE_264_REVISED_MODES),
+)
+def test_issue_264_mode_present(mode_name):
+    """Every #264 mode is registered in the psic mode dict."""
+    g = psic()
+    assert mode_name in g.modes
+
+
+# ---------------------------------------------------------------------------
+# OMEGA = 0 ⇔ bisecting (the @jwkim-anl equivalence)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "h, k, l, context",
+    [
+        pytest.param(1, 0, 0, does_not_raise(), id="100"),
+        pytest.param(0, 1, 1, does_not_raise(), id="011"),
+        pytest.param(1, 1, 1, does_not_raise(), id="111"),
+    ],
+)
+def test_omega_zero_equals_bisecting_vertical(h, k, l, context):  # noqa: E741
+    """OMEGA = 0 ⇒ bisecting_vertical (vertical scattering plane).
+
+    @jwkim-anl wrote on issue #264:
+        "Yes. This is including bisecting mode. If omega is fixed at 0,
+        it is bisecting."
+
+    Verifies the equivalence numerically: the solution sets returned
+    by ``bisecting_vertical`` and ``fixed_omega_vertical`` (target 0)
+    must agree motor-for-motor for every reachable reflection.
+    """
+    with context:
+        g = _setup_psic_cubic()
+
+        g.mode_name = "bisecting_vertical"
+        bisect_sols = g.forward(h, k, l)
+        g.mode_name = "fixed_omega_vertical"
+        omega_sols = g.forward(h, k, l)
+
+        assert len(bisect_sols) == len(omega_sols), (
+            f"({h},{k},{l}): bisecting returned {len(bisect_sols)} sols, "
+            f"omega=0 returned {len(omega_sols)}"
+        )
+
+        bisect_sorted = sorted(bisect_sols, key=lambda s: (s["eta"], s["chi"]))
+        omega_sorted = sorted(omega_sols, key=lambda s: (s["eta"], s["chi"]))
+        for b, o in zip(bisect_sorted, omega_sorted, strict=False):
+            for stage in ("mu", "eta", "chi", "phi", "nu", "delta"):
+                assert b[stage] == pytest.approx(o[stage], abs=1e-6), (
+                    f"({h},{k},{l}) stage {stage}: "
+                    f"bisecting={b[stage]}, omega=0={o[stage]}"
+                )
+            # Independent confirmation: omega_pseudo evaluates to 0 in
+            # both solution sets.
+            assert omega_pseudo(g, angles=b) == pytest.approx(0.0, abs=1e-7)
+            assert omega_pseudo(g, angles=o) == pytest.approx(0.0, abs=1e-7)
+
+
+@pytest.mark.parametrize(
+    "h, k, l, context",
+    [
+        pytest.param(0, 0, 1, does_not_raise(), id="001"),
+        pytest.param(1, 0, 1, does_not_raise(), id="101"),
+    ],
+)
+def test_omega_zero_equals_bisecting_horizontal(h, k, l, context):  # noqa: E741
+    """OMEGA = 0 ⇒ bisecting_horizontal (horizontal scattering plane)."""
+    with context:
+        g = _setup_psic_cubic()
+
+        g.mode_name = "bisecting_horizontal"
+        bisect_sols = g.forward(h, k, l)
+        g.mode_name = "fixed_omega_horizontal"
+        omega_sols = g.forward(h, k, l)
+
+        assert len(bisect_sols) == len(omega_sols)
+        bisect_sorted = sorted(bisect_sols, key=lambda s: s["mu"])
+        omega_sorted = sorted(omega_sols, key=lambda s: s["mu"])
+        for b, o in zip(bisect_sorted, omega_sorted, strict=False):
+            for stage in ("mu", "eta", "chi", "phi", "nu", "delta"):
+                assert b[stage] == pytest.approx(o[stage], abs=1e-6)
+            assert omega_pseudo(g, angles=b) == pytest.approx(0.0, abs=1e-7)
+            assert omega_pseudo(g, angles=o) == pytest.approx(0.0, abs=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# OMEGA pseudo-angle is the SPEC Q[6] definition
+# ---------------------------------------------------------------------------
+
+
+def test_omega_is_angle_between_q_and_chi_circle_plane():
+    """OMEGA matches the SPEC definition: angle between Q and the
+    plane of the chi circle.
+
+    The chi circle plane is the plane perpendicular to the chi
+    rotation axis after the outer (mu, eta) sample stages have been
+    applied.  This test computes both the
+    :func:`~ad_hoc_diffractometer.reference.omega_pseudo` value and
+    the geometric angle from first principles, then asserts they
+    agree.
+    """
+    g = _setup_psic_cubic()
+
+    angles = {
+        "mu": 7.0,
+        "eta": 13.0,
+        "chi": 25.0,
+        "phi": 41.0,
+        "nu": 0.0,
+        "delta": 30.0,
+    }
+
+    om = omega_pseudo(g, angles=angles)
+
+    # First-principles computation of the chi-circle plane normal in
+    # the lab frame:  apply mu and eta rotations to the chi axis vector.
+    from ad_hoc_diffractometer.rotation import _rotation_matrix_normalized
+
+    chi_stage = g.stage("chi")
+    mu_stage = g.stage("mu")
+    eta_stage = g.stage("eta")
+    R_mu = _rotation_matrix_normalized(mu_stage._axis_hat, angles["mu"])  # noqa: SLF001
+    R_eta = _rotation_matrix_normalized(eta_stage._axis_hat, angles["eta"])  # noqa: SLF001
+    chi_axis_lab = R_eta @ R_mu @ chi_stage._axis_hat  # noqa: SLF001
+    chi_axis_lab /= np.linalg.norm(chi_axis_lab)
+
+    # Lab-frame Q vector.
+    nu_stage = g.stage("nu")
+    delta_stage = g.stage("delta")
+    R_nu = _rotation_matrix_normalized(nu_stage._axis_hat, angles["nu"])  # noqa: SLF001
+    R_delta = _rotation_matrix_normalized(delta_stage._axis_hat, angles["delta"])  # noqa: SLF001
+    D = R_delta @ R_nu
+    y_hat = np.asarray(g.basis["longitudinal"], dtype=float)
+    y_hat /= np.linalg.norm(y_hat)
+    Q_lab = D @ y_hat - y_hat
+    Q_hat = Q_lab / np.linalg.norm(Q_lab)
+
+    # OMEGA = arcsin( Q_hat · n_chi ).  Sign is positive when Q has
+    # positive projection on the chi axis.
+    sin_om = float(np.dot(Q_hat, chi_axis_lab))
+    expected_om = np.degrees(np.arcsin(np.clip(sin_om, -1.0, 1.0)))
+    assert om == pytest.approx(expected_om, abs=1e-9), (
+        f"omega_pseudo() = {om}, expected {expected_om}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing: every #264 mode lands on the intended solver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name, predicate",
+    [
+        pytest.param(
+            "fixed_omega_vertical",
+            _is_omega_mode,
+            id="fixed_omega_vertical-omega_solver",
+        ),
+        pytest.param(
+            "fixed_omega_horizontal",
+            _is_omega_mode,
+            id="fixed_omega_horizontal-omega_solver",
+        ),
+        pytest.param(
+            "lifting_detector_eta",
+            _is_free_detectors_mode,
+            id="lifting_detector_eta-free_detectors",
+        ),
+        pytest.param(
+            "lifting_detector_phi",
+            _is_free_detectors_mode,
+            id="lifting_detector_phi-free_detectors",
+        ),
+        pytest.param(
+            "lifting_detector_mu",
+            _is_free_detectors_mode,
+            id="lifting_detector_mu-free_detectors",
+        ),
+    ],
+)
+def test_issue_264_mode_routes_to_intended_solver(mode_name, predicate):
+    """Each #264 mode is detected by its intended dispatcher predicate.
+
+    Catches dispatch regressions that would silently route a mode
+    through a generic solver and break the constraint semantics.
+    """
+    g = _setup_psic_cubic()
+    cs = g.modes[mode_name]
+    assert predicate(g, cs) is True
+
+
+def test_fixed_alpha_i_fixed_chi_fixed_phi_routes_to_free_detectors():
+    """B3 routes to ``_solve_free_detectors`` only after ``surface_normal``
+    is set (otherwise the mode is a stub)."""
+    g = _setup_psic_cubic()
+    cs = g.modes["fixed_alpha_i_fixed_chi_fixed_phi"]
+    # Without surface_normal, the alpha_i ReferenceConstraint reports
+    # is_implemented=False, so the mode is a stub regardless of dispatch.
+    assert cs.is_implemented(g) is False
+    g.surface_normal = (0, 0, 1)
+    assert cs.is_implemented(g) is True
+    assert _is_free_detectors_mode(g, cs) is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end sanity: every implemented #264 mode round-trips for at least
+# one canonical reflection.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name, h, k, l, needs_surface_normal",
+    [
+        pytest.param("fixed_omega_vertical", 1, 0, 0, False, id="fov-100"),
+        pytest.param("fixed_omega_horizontal", 0, 0, 1, False, id="foh-001"),
+        pytest.param("fixed_alpha_i_fixed_chi_fixed_phi", 0, 1, 1, True, id="b3-011"),
+        pytest.param("lifting_detector_eta", 1, 1, 0, False, id="le-110"),
+        pytest.param("lifting_detector_phi", 1, 0, 0, False, id="lp-100"),
+        pytest.param("lifting_detector_mu", 0, 1, 0, False, id="lm-010"),
+    ],
+)
+def test_issue_264_mode_round_trip(
+    mode_name,
+    h,
+    k,
+    l,  # noqa: E741
+    needs_surface_normal,
+):
+    """Every #264 implemented mode produces solutions that round-trip
+    back to the requested (h, k, l) under ``inverse()``."""
+    g = _setup_psic_cubic()
+    if needs_surface_normal:
+        g.surface_normal = (0, 0, 1)
+    g.mode_name = mode_name
+    sols = g.forward(h, k, l)
+    assert len(sols) > 0, f"{mode_name} ({h},{k},{l}): no solutions"
+    for sol in sols:
+        hkl_back = g.inverse(sol)
+        assert np.allclose(hkl_back, [h, k, l], atol=1e-5), (
+            f"{mode_name} ({h},{k},{l}): inverse mismatch {hkl_back}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #264 design invariant: dropping qaz from C3/C4 freed both detectors.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode_name",
+    ["lifting_detector_phi", "lifting_detector_mu"],
+)
+def test_revised_lifting_detector_has_no_qaz_constraint(mode_name):
+    """The C3/C4 revision dropped the qaz=90 ``DetectorConstraint``."""
+    g = psic()
+    cs = g.modes[mode_name]
+    # No DetectorConstraint at all in the revised modes.
+    detector_constraints = [
+        c for c in cs.constraints if isinstance(c, DetectorConstraint)
+    ]
+    assert detector_constraints == [], (
+        f"{mode_name}: expected no DetectorConstraint after C3/C4 revision; "
+        f"found {detector_constraints!r}"
+    )
+    # Three SampleConstraints — every sample stage except the free one.
+    sample_constraints = [c for c in cs.constraints if isinstance(c, SampleConstraint)]
+    assert len(sample_constraints) == 3, (
+        f"{mode_name}: expected 3 SampleConstraints; got {len(sample_constraints)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #264 design invariant: OMEGA pseudo-angle constraint accepts only
+# the new "omega" reference name and is gated on the chi sample stage.
+# ---------------------------------------------------------------------------
+
+
+def test_omega_reference_constraint_validation():
+    """``ReferenceConstraint('omega', value)`` is now valid; nonsense
+    names still raise."""
+    rc = ReferenceConstraint("omega", 5.0)
+    assert rc.name == "omega"
+    assert rc.value == 5.0
+    with pytest.raises(ValueError, match=re.escape("ReferenceConstraint name")):
+        ReferenceConstraint("not_a_pseudo_angle", 0.0)
+
+
+def test_omega_constraint_unimplemented_without_chi_stage():
+    """``ReferenceConstraint('omega', ...)`` is implemented only on
+    geometries with a ``chi`` sample stage."""
+    # Build a synthetic geometry without a chi stage (zaxis has none).
+    g = ahd.make_geometry("zaxis")
+    g.wavelength = WAVELENGTH
+    rc = ReferenceConstraint("omega", 0.0)
+    assert rc.has_reference_vector(g) is True  # no reference needed
+    assert rc.is_implemented(g) is False  # but the geometry can't run it
+
+
+# ---------------------------------------------------------------------------
+# Issue #264 design invariant: B3 produces solutions whose alpha_i matches
+# the requested target.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alpha_target",
+    [0.0, 3.0, 7.5],
+)
+def test_b3_alpha_i_target_satisfied(alpha_target):
+    """B3 ``fixed_alpha_i_fixed_chi_fixed_phi`` solutions satisfy
+    alpha_i == target within tolerance."""
+    g = _setup_psic_cubic()
+    g.surface_normal = (0, 0, 1)
+    cs = g.modes["fixed_alpha_i_fixed_chi_fixed_phi"]
+    # Override alpha_i target with the parametrized value.
+    g.modes["__b3_test"] = ConstraintSet(
+        [
+            SampleConstraint("chi", 0.0),
+            SampleConstraint("phi", 0.0),
+            ReferenceConstraint("alpha_i", alpha_target),
+        ],
+        computed=cs.computed,
+        extras=dict(cs.extras),
+    )
+    g.mode_name = "__b3_test"
+    sols = g.forward(0, 1, 1)
+    assert len(sols) > 0
+    for sol in sols:
+        ai = incidence_angle(g, angles=sol)
+        assert ai == pytest.approx(alpha_target, abs=1e-3), (
+            f"B3 alpha_i target {alpha_target}: got {ai}"
+        )

--- a/tests/test_regression_issue_267.py
+++ b/tests/test_regression_issue_267.py
@@ -220,6 +220,24 @@ def _reference_psic() -> AdHocDiffractometer:
             computed=["eta", "chi", "phi", "delta"],
             extras={"n_hat": REQUIRED, "psi": None},
         ),
+        "fixed_alpha_i_fixed_chi_fixed_phi": ConstraintSet(
+            [
+                SampleConstraint("chi", 0.0),
+                SampleConstraint("phi", 0.0),
+                ReferenceConstraint("alpha_i", 0.0),
+            ],
+            computed=["mu", "eta", "nu", "delta"],
+            extras={"n_hat": REQUIRED, "alpha_i": None, "beta_out": None},
+        ),
+        "fixed_omega_vertical": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                DetectorConstraint("nu", 0.0),
+                ReferenceConstraint("omega", 0.0),
+            ],
+            computed=["eta", "chi", "phi", "delta"],
+            extras={"omega": None},
+        ),
         "double_diffraction_vertical": ConstraintSet(
             [
                 SampleConstraint("mu", 0.0),
@@ -289,6 +307,15 @@ def _reference_psic() -> AdHocDiffractometer:
             computed=["mu", "chi", "phi", "nu"],
             extras={"n_hat": REQUIRED, "psi": None},
         ),
+        "fixed_omega_horizontal": ConstraintSet(
+            [
+                SampleConstraint("eta", 0.0),
+                DetectorConstraint("delta", 0.0),
+                ReferenceConstraint("omega", 0.0),
+            ],
+            computed=["mu", "chi", "phi", "nu"],
+            extras={"omega": None},
+        ),
         "double_diffraction_horizontal": ConstraintSet(
             [
                 SampleConstraint("eta", 0.0),
@@ -330,6 +357,14 @@ def _reference_psic() -> AdHocDiffractometer:
                 DetectorConstraint("qaz", 90.0),
             ],
             computed=["mu", "nu", "delta"],
+        ),
+        "lifting_detector_eta": ConstraintSet(
+            [
+                SampleConstraint("mu", 0.0),
+                SampleConstraint("chi", 0.0),
+                SampleConstraint("phi", 0.0),
+            ],
+            computed=["eta", "nu", "delta"],
         ),
     }
     return AdHocDiffractometer(

--- a/tests/test_regression_issue_267.py
+++ b/tests/test_regression_issue_267.py
@@ -213,7 +213,7 @@ def _reference_psic() -> AdHocDiffractometer:
         ),
         "fixed_psi_vertical": ConstraintSet(
             [
-                BisectConstraint("eta", "delta"),
+                DetectorConstraint("nu", 0.0),
                 SampleConstraint("mu", 0.0),
                 ReferenceConstraint("psi", 0.0),
             ],
@@ -300,7 +300,7 @@ def _reference_psic() -> AdHocDiffractometer:
         ),
         "fixed_psi_horizontal": ConstraintSet(
             [
-                BisectConstraint("mu", "nu"),
+                DetectorConstraint("delta", 0.0),
                 SampleConstraint("eta", 0.0),
                 ReferenceConstraint("psi", 0.0),
             ],

--- a/tests/test_regression_issue_267.py
+++ b/tests/test_regression_issue_267.py
@@ -344,17 +344,17 @@ def _reference_psic() -> AdHocDiffractometer:
         # ── Lifting detector (out-of-plane) ────────────────────────────
         "lifting_detector_phi": ConstraintSet(
             [
-                SampleConstraint("phi", 0.0),
                 SampleConstraint("mu", 0.0),
-                DetectorConstraint("qaz", 90.0),
+                SampleConstraint("eta", 0.0),
+                SampleConstraint("chi", 0.0),
             ],
             computed=["phi", "nu", "delta"],
         ),
         "lifting_detector_mu": ConstraintSet(
             [
-                SampleConstraint("mu", 0.0),
                 SampleConstraint("eta", 0.0),
-                DetectorConstraint("qaz", 90.0),
+                SampleConstraint("chi", 0.0),
+                SampleConstraint("phi", 0.0),
             ],
             computed=["mu", "nu", "delta"],
         ),


### PR DESCRIPTION
- closes #264

## Summary

Implements the @jwkim-anl review on #264 in seven commits:

- **Step A** (`399fb8bf`): adds the SPEC `OMEGA` pseudo-angle
  (`def OMEGA 'Q[6]'` — the angle between Q and the plane of the chi
  circle) as a new `ReferenceConstraint` name plus the
  `_solve_omega_mode` dispatcher branch.
- **Step B** (`a469a719`): four new psic modes —
  `fixed_omega_vertical`, `fixed_omega_horizontal`,
  `fixed_alpha_i_fixed_chi_fixed_phi`, `lifting_detector_eta` — and a
  new general `_solve_free_detectors` Levenberg-Marquardt N-D Newton
  solver used by the latter two modes.
- **Step C3/C4** (`7302cfc1`): revised `lifting_detector_phi` and
  `lifting_detector_mu` to drop the `qaz=90` constraint and fix every
  sample stage except the named one; both detector stages now float
  jointly to satisfy the Bragg condition.
- **Step E + F** (`db4b1dbf`): cross-module regression tests
  (`tests/test_regression_issue_264.py`, 31 cases initially) and
  per-mode documentation in `docs/source/geometries/psic.md`.
- **Step G** (`544d4b17`): `CHANGES.md` entries.
- **Coverage fix** (`b826af28`): mark defensive paths in the new
  solvers with `# pragma: no cover` / `# pragma: no branch`; add a
  kappa6c qaz-limits test to restore lost coverage from the C3/C4
  refactor.
- **Step C1/C2** (`ae8d7158`): revise `fixed_psi_vertical` and
  `fixed_psi_horizontal` per @jwkim-anl's clarification on the issue
  thread:
  - `fixed_psi_vertical`   = `nu = 0` (detector pin) + `mu` fixed +
    `psi` target.  Free: eta, chi, phi, delta.
  - `fixed_psi_horizontal` = `delta = 0` (detector pin) + `eta`
    fixed + `psi` target.  Free: mu, chi, phi, nu.

  `_solve_psi_mode` extended to delegate to `_solve_fixed_sample` for
  these psic-family modes after the ψ-validation filter passes.

## Deferred

- **Step D** (kappa6c mirror): skipped — kappa6c sample stages are
  `mu`/`komega`/`kappa`/`kphi` (no literal `chi`/`eta`/`phi`), so
  none of the #264 changes have a clean mechanical mirror in
  kappa6c.
- **Stale critiques** from the @jwkim-anl review that named modes
  whose current YAML already addresses the concern
  (`fixed_alpha_i_vertical`, `alpha_eq_beta_vertical`,
  `fixed_alpha_i_horizontal`, `fixed_beta_out_horizontal`): treated
  as already resolved by prior fixes (#243, #259); please re-confirm
  at review time if the original critique still applies.

## Verification

- Default test suite: 2427 passed, 3 skipped, 3 deselected.
- Slow benchmark sweep (`pytest -m slow_benchmark`): 3 passed.
- Sphinx build: zero warnings.  AGENTS.md leak-detection greps both
  pass.
- Pre-commit: ruff, ruff-format, isort, license, whitespace — all
  pass.
- US English spelling grep on the diff: clean.
- All 7 GitHub Actions CI checks green.

Contributed by: OpenCode (argo/claudeopus47)
