### PR TITLE
fix(#280) rotation composition order, ub_identity, and B-matrix orthogonalized frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,25 +535,56 @@ diff is reviewable.
 ## CHANGES.md style
 
 `CHANGES.md` is a user-facing changelog, not a design document.  Each
-bullet is **one short headline plus the issue/PR reference** — that is
-the entire bullet.  Nothing more.
+bullet is **a few words plus the issue/PR reference**.  The issue/PR
+reference carries the full load of explanation — readers who want
+details follow the link.  The bullet itself names the change in the
+fewest words that identify it.
+
+**Hard length cap: ≤ 12 words before the ` (#NNN)` reference.**  If
+you find yourself writing a second clause, a semicolon, an "and", a
+parenthetical aside, or a "users must …" instruction in the bullet
+itself, the bullet is too long — cut it down.  All of that material
+belongs in the referenced issue or PR, not in the changelog.
 
 **Use v0.6.0 and earlier as the style reference.**  Several recent
 entries (v0.7.0, v0.8.0) drifted toward multi-sentence bullets with
 implementation detail and benchmark numbers; do not imitate them.
 v0.6.0 is the canonical pattern: each bullet is a short headline
-(typically ≤ 12 words) followed by ` (#NNN)` or ` (#NNN, #MMM)`.
+followed by ` (#NNN)` or ` (#NNN, #MMM)`.
 
-- One bullet per change.  A single short sentence (or sentence
-  fragment) followed by the issue/PR reference.  No second sentence,
-  no rationale, no cross-validation numbers, no comparison to other
-  packages, no internal implementation detail, no benchmark numbers.
+Examples of acceptable length:
+
+```
+- Rotation composition and `ub_identity` corrected. (#280)
+- B matrix for non-cubic lattices now matches BL1967. (#280)
+- Doc version-switcher dropdown now shows every published version. (#273)
+- Switch to declarative YAML for demo geometries. (#267)
+```
+
+Examples of bullets that are **too long** and must be cut:
+
+```
+- Compose stage rotations outermost-leftmost (BL1967); place crystal a*
+  along the beam at ub_identity; saved UB matrices must be re-derived. (#280)
+- Default UB matrix (ub_identity) now places the crystal a-axis along
+  the beam direction; sessions relying on the previous default must
+  explicitly set U or measure orienting reflections. (#NNN)
+```
+
+Both of the "too long" examples pack the issue body into the
+changelog.  The issue/PR already has the body; the bullet should not
+duplicate it.
+
+- One bullet per change.  A few words followed by the issue/PR
+  reference.  No second sentence, no rationale, no cross-validation
+  numbers, no comparison to other packages, no internal implementation
+  detail, no benchmark numbers, no migration instructions.
 - Use the existing subsection headings: `Breaking changes`, `Behavior
   change`, `Added`, `Changed`, `Fixed`.  Omit any that are empty.
 - A correctness fix that changes computed numerical output gets one
-  short `Behavior change` bullet stating what changes and what users
-  must do (e.g. "re-derive saved UB matrices") — not a multi-line
-  essay.
+  short `Behavior change` bullet naming what changed.  Migration
+  instructions (e.g. "re-derive saved UB matrices") belong in the
+  referenced issue/PR, not in the bullet.
 - Do **not** add bullets for test-suite changes (new tests,
   parametrization edits, test-only HKL substitutions), docstring
   fixes, or internal refactoring.  A `Fixed` entry implicitly
@@ -562,6 +593,11 @@ v0.6.0 is the canonical pattern: each bullet is a short headline
   `Released YYYY-MM-DD.` and nothing else.  No prose paragraph.
 - A single-fix release should be three or four lines of bullets, not
   more (see v0.9.0 for the model: two bullets, one line each).
+
+When in doubt, err on the side of fewer words.  If a reviewer can
+look at the bullet and identify what the change is about (well
+enough to decide whether to click the issue link), it is long
+enough.
 
 Contributed by: OpenCode (argo/claudeopus47)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ issue tracker.  The initial project development roadmap is documented here:
 
 ### Behavior change
 
-- Compose stage rotations outermost-leftmost; saved UB matrices must be re-derived. (#280)
+- Rotation composition and `ub_identity` corrected. (#280)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ issue tracker.  The initial project development roadmap is documented here:
 
 ## Unreleased
 
+### Behavior change
+
+- Compose stage rotations outermost-leftmost; saved UB matrices must be re-derived. (#280)
+
 ### Fixed
 
 - Doc version-switcher dropdown now shows every published version. (#273)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ issue tracker.  The initial project development roadmap is documented here:
 ### Behavior change
 
 - Rotation composition and `ub_identity` corrected. (#280)
+- B matrix for non-cubic lattices now matches BL1967. (#280)
 
 ### Fixed
 

--- a/docs/source/direct-lattice.md
+++ b/docs/source/direct-lattice.md
@@ -63,6 +63,58 @@ $$\mathbf{Q}_c = \mathbf{B}\,\mathbf{h}$$
 The magnitude $|\mathbf{Q}_c| = |\mathbf{B}\,\mathbf{h}| = 2\pi / d_{hkl}$,
 where $d_{hkl}$ is the interplanar spacing.
 
+### Explicit construction
+
+The B matrix is built from the reciprocal-lattice magnitudes
+$a^\star$, $b^\star$, $c^\star$ and the reciprocal-cell angles
+$\alpha^\star$, $\beta^\star$, $\gamma^\star$, using the explicit
+upper-triangular form (eq. 3 of Busing & Levy 1967):
+
+```
+B[0,0] = a*               B[0,1] = b* cos γ*        B[0,2] = c* cos β*
+B[1,0] = 0                B[1,1] = b* sin γ*        B[1,2] = -c* sin β* cos α
+B[2,0] = 0                B[2,1] = 0                B[2,2] = 2π / c
+```
+
+This places the **reciprocal-lattice $\mathbf{a}^\star$** along
+crystal-Cartesian $\hat{x}$, **$\mathbf{b}^\star$** in the
+crystal-$xy$-plane (with positive $y$ component), and
+**$\mathbf{c}^\star$** completing the right-handed orthonormal triple.
+The B matrix is therefore upper-triangular by construction for every
+crystal system.
+
+The reciprocal-lattice magnitudes carry the $2\pi$ factor (BL1967
+convention), giving $|\mathbf{B}\,\mathbf{h}| = 2\pi / d_{hkl}$ and
+$\mathbf{b}_i \cdot \mathbf{a}_j = 2\pi\,\delta_{ij}$.
+
+### Cross-solver equivalence
+
+This construction is **numerically identical** (to machine precision)
+to the B matrix used by
+
+- **SPEC** (psic and other four-circle modes),
+- **hkl_soleil** (the libhkl library) with its default
+  `HKL_TAU = 2π` compile-time setting,
+- **diffcalc-core** (`Crystal._set_reciprocal_cell`).
+
+The equivalence holds for every crystal system, including
+non-orthogonal cells (hexagonal, trigonal, monoclinic, triclinic).
+For orthogonal cells (cubic, tetragonal, orthorhombic), the
+direct-lattice vectors $\mathbf{a}$, $\mathbf{b}$, $\mathbf{c}$ are
+parallel to the reciprocal vectors $\mathbf{a}^\star$,
+$\mathbf{b}^\star$, $\mathbf{c}^\star$ respectively, so the BL1967
+crystal-Cartesian frame coincides with the
+"direct-lattice-$\mathbf{a}$-along-$\hat{x}$" frame.  For
+non-orthogonal cells the two frames differ by a rotation in the
+crystal-Cartesian space; both encode the same physical crystal, but
+only the BL1967 frame is the one SPEC and hkl_soleil cross-validate
+against.
+
+The no-$2\pi$ alternative ($\mathbf{b}_i \cdot \mathbf{a}_j =
+\delta_{ij}$, $|\mathbf{B}\,\mathbf{h}| = 1/d_{hkl}$), used by
+FullProf, CrysFML, parts of CCP4, and `libhkl` compiled with
+`HKL_TAU = 1`, is not exposed by this package.
+
 ## Reference
 
 - W.R. Busing & H.A. Levy, *Acta Cryst.* **22**, 457–464 (1967).

--- a/src/ad_hoc_diffractometer/diffractometer.py
+++ b/src/ad_hoc_diffractometer/diffractometer.py
@@ -1789,10 +1789,17 @@ class AdHocDiffractometer:
 
     def sample_rotation_matrix(self) -> np.ndarray:
         """
-        Compute the total sample rotation matrix Z = R_floor * ... * R_top.
+        Compute the total sample rotation matrix.
 
-        Stages are applied in stacking order: the floor-most stage is applied
-        first (leftmost in the product), the innermost stage last.
+        Composition follows the BL1967 standard convention (Busing &
+        Levy, *Acta Cryst.* 22, 457-464, 1967): the outermost
+        (floor-most) stage is leftmost in the product, so
+
+            Z = R_0 @ R_1 @ ... @ R_{n-1}
+
+        where ``R_0`` is the floor-most stage and ``R_{n-1}`` is the
+        innermost stage closest to the sample.  Z maps phi-frame vectors
+        to lab-frame vectors: ``v_lab = Z @ v_phi``.
 
         Returns
         -------
@@ -1800,12 +1807,17 @@ class AdHocDiffractometer:
         """
         Z = np.eye(3)
         for s in self.sample_stages:
-            Z = s.rotation_matrix() @ Z
+            Z = Z @ s.rotation_matrix()
         return Z
 
     def detector_rotation_matrix(self) -> np.ndarray:
         """
-        Compute the total detector rotation matrix in stacking order.
+        Compute the total detector rotation matrix.
+
+        Composition follows the same outermost-leftmost convention as
+        :meth:`sample_rotation_matrix`::
+
+            D = R_0 @ R_1 @ ... @ R_{n-1}
 
         Returns
         -------
@@ -1813,7 +1825,7 @@ class AdHocDiffractometer:
         """
         D = np.eye(3)
         for s in self.detector_stages:
-            D = s.rotation_matrix() @ D
+            D = D @ s.rotation_matrix()
         return D
 
     def summary(self) -> None:

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -155,13 +155,16 @@ class ForwardContext:
         """
         from .rotation import _rotation_matrix_normalized
 
-        # Detector: if no detector stage is free, cache D entirely
+        # Detector: if no detector stage is free, cache D entirely.
+        # Composition: BL1967 standard order (Busing & Levy 1967),
+        # outermost (floor-most) stage leftmost,
+        # so D = R_0 @ R_1 @ ... @ R_{n-1}.
         det_free = any(s.name in free_stage_names for s in self.detector_stages)
         if not det_free:
             D = np.eye(3)
             for s in self.detector_stages:
                 angle = fixed_angles.get(s.name, s.angle)
-                D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+                D = D @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
             self._cached_D = D
         else:  # pragma: no cover
             # No remaining call site passes a detector stage as free
@@ -171,6 +174,9 @@ class ForwardContext:
             self._cached_D = None
 
         # Sample: find the first free stage index and cache the prefix product
+        # of the fixed *outer* stages (indices 0..first_free-1).  This prefix
+        # is built in the same outermost-leftmost order:
+        # Z_prefix = R_0 @ R_1 @ ... @ R_{first_free-1}.
         self._free_sample_indices = []
         for i, s in enumerate(self.sample_stages):
             if s.name in free_stage_names:
@@ -183,8 +189,8 @@ class ForwardContext:
                 for i in range(first_free):
                     s = self.sample_stages[i]
                     angle = fixed_angles.get(s.name, s.angle)
-                    Z_prefix = (
-                        _rotation_matrix_normalized(s._axis_hat, angle) @ Z_prefix
+                    Z_prefix = Z_prefix @ _rotation_matrix_normalized(
+                        s._axis_hat, angle
                     )  # noqa: SLF001
                 self._cached_Z_prefix = Z_prefix
             else:
@@ -283,46 +289,41 @@ class ForwardContext:
                     angle,  # noqa: SLF001
                 )
 
-        # Build suffix products:  suffix[k] = R_{k-1} @ ... @ R_0
-        # where indices are relative to first_free.
-        # suffix[0] = cached_Z_prefix (product of stages 0..first_free-1).
-        # suffix[k] = R_{first_free+k-1} @ suffix[k-1]
-        suffix = [np.empty((3, 3))] * (n_tail + 1)
-        suffix[0] = (
+        # Composition (BL1967 standard convention, outermost-leftmost):
+        # the full sample rotation is
+        #
+        #   Z = R_0 @ R_1 @ ... @ R_{N-1}
+        #     = Z_prefix @ R_list[0] @ R_list[1] @ ... @ R_list[n_tail-1]
+        #
+        # where Z_prefix = R_0 @ ... @ R_{first_free-1} is cached and the
+        # tail R_list[0..n_tail-1] holds R_{first_free}..R_{N-1}.
+        #
+        # The derivative of Z w.r.t. the angle of the free stage at
+        # relative index k is
+        #
+        #   dZ/dθ_k = before[k] @ dR_list[k] @ after[k]
+        #
+        # with
+        #
+        #   before[k] = Z_prefix @ R_list[0] @ R_list[1] @ ... @ R_list[k-1]
+        #   after[k]  = R_list[k+1] @ R_list[k+2] @ ... @ R_list[n_tail-1]
+        #
+        # Build them by simple forward / backward sweeps.
+        Z_prefix = (
             self._cached_Z_prefix if self._cached_Z_prefix is not None else np.eye(3)
         )
-        for k in range(n_tail):
-            suffix[k + 1] = R_list[k] @ suffix[k]
 
-        # Build prefix products:  prefix[k] = R_{N-1} @ ... @ R_{k+1}
-        # where indices are relative to first_free.
-        # prefix[n_tail] = I  (nothing after the last stage)
-        # prefix[k] = prefix[k+1] @ R_{k+1}
-        #
-        # Actually we need prefix in absolute terms:
-        # prefix_abs[j] = R_{N-1} @ ... @ R_{j+1}
-        # For j = first_free + k:
-        #   prefix[k] = R_{n_tail-1} @ ... @ R_{k+1}  (relative indices)
-        prefix = [np.empty((3, 3))] * (n_tail + 1)
-        prefix[n_tail] = np.eye(3)
+        # before[k] for k = 0..n_tail
+        before = [np.empty((3, 3))] * (n_tail + 1)
+        before[0] = Z_prefix
+        for k in range(n_tail):
+            before[k + 1] = before[k] @ R_list[k]
+
+        # after[k] for k = 0..n_tail (after[k] is the product of R_list[k+1..])
+        after = [np.empty((3, 3))] * (n_tail + 1)
+        after[n_tail] = np.eye(3)
         for k in range(n_tail - 1, -1, -1):
-            prefix[k] = prefix[k + 1] @ R_list[k + 1] if k + 1 < n_tail else np.eye(3)
-        # Recalculate more carefully:
-        # prefix[k] should be the product of R_list[k+1] ... R_list[n_tail-1]
-        # applied left to right in stacking order (outermost first).
-        # Actually the Z chain is: Z = R_{N-1} @ R_{N-2} @ ... @ R_0
-        # So for relative index k, R_list[k] = R_{first_free + k}.
-        # Z_tail = R_list[n_tail-1] @ R_list[n_tail-2] @ ... @ R_list[0]
-        #        = suffix[n_tail] (already computed above, without prefix)
-        #
-        # dZ/dθ_j for j = first_free + k:
-        #   = (R_list[n_tail-1] @ ... @ R_list[k+1]) @ dR_list[k] @ (R_list[k-1] @ ... @ R_list[0] @ Z_prefix)
-        #   = prefix[k] @ dR_list[k] @ suffix[k]
-        #
-        # Rebuild prefix properly:
-        prefix[n_tail] = np.eye(3)
-        for k in range(n_tail - 1, -1, -1):
-            prefix[k] = prefix[k + 1] @ R_list[k + 1] if (k + 1) < n_tail else np.eye(3)
+            after[k] = R_list[k + 1] @ after[k + 1] if (k + 1) < n_tail else np.eye(3)
 
         # deg2rad factor: dR is w.r.t. radians, but angles are in degrees.
         deg2rad = np.pi / 180.0
@@ -333,8 +334,8 @@ class ForwardContext:
             abs_idx = next(i for i, s in enumerate(stages) if s.name == name)
             k = abs_idx - first_free  # relative index into R_list
             dR_k = dR_map[abs_idx]
-            # dZ/dθ = prefix[k] @ dR_k @ suffix[k]
-            dZ = prefix[k] @ dR_k @ suffix[k]
+            # dZ/dθ = before[k] @ dR_k @ after[k]
+            dZ = before[k] @ dR_k @ after[k]
             # dQ_phi/dθ = dZ^T @ Q_lab, with deg2rad conversion
             J[:, col] = deg2rad * (dZ.T @ Q_lab)
 
@@ -581,11 +582,12 @@ def _solve_bisecting_analytic(
 
     **Derivation.**
 
-    The sample rotation matrix is:
+    Under the BL1967 standard convention (Busing & Levy 1967,
+    outermost stage leftmost), the sample rotation matrix is:
 
     .. math::
 
-        Z = R_\phi \cdot R_\chi \cdot Z_{\text{prefix}}
+        Z = Z_{\text{prefix}} \cdot R_\chi \cdot R_\phi
 
     where :math:`Z_{\text{prefix}}` is the product of all fixed outer
     sample stages.  The scattering vector in the phi frame is:
@@ -593,45 +595,62 @@ def _solve_bisecting_analytic(
     .. math::
 
         Q_\phi = Z^T Q_{\text{lab}}
-              = Z_{\text{prefix}}^T \cdot R_\chi^T \cdot R_\phi^T \cdot Q_{\text{lab}}
+              = R_\phi^T \cdot R_\chi^T \cdot Z_{\text{prefix}}^T \cdot Q_{\text{lab}}
+
+    Equivalently, multiplying both sides by :math:`R_\chi R_\phi`:
+
+    .. math::
+
+        R(\hat n_\chi, \chi) \cdot R(\hat n_\phi, \phi) \cdot Q_{\phi,\text{target}}
+            = Z_{\text{prefix}}^T \cdot Q_{\text{lab}}
 
     Define the known vectors:
 
-    - :math:`q = Z_{\text{prefix}} \cdot Q_{\phi,\text{target}}`
-    - :math:`v = Q_{\text{lab}}`
+    - :math:`q = Z_{\text{prefix}}^T \cdot Q_{\text{lab}}`
+    - :math:`v = Q_{\phi,\text{target}}`
 
-    The equation to solve is:
+    The equation to solve becomes:
 
     .. math::
 
-        R(\hat n_\chi, -\chi) \cdot R(\hat n_\phi, -\phi) \cdot v = q
+        R(\hat n_\chi, \chi) \cdot R(\hat n_\phi, \phi) \cdot v = q
 
     Since :math:`\hat n_\chi \perp \hat n_\phi`, define
-    :math:`\hat n_3 = \hat n_\chi \times \hat n_\phi`.  Projecting onto
-    the :math:`(\hat n_\phi, \hat n_3)` plane gives a 2×2 linear system
-    for :math:`(\cos\chi, \sin\chi)`:
+    :math:`\hat n_3 = \hat n_\chi \times \hat n_\phi`.
+
+    **Step 1 — solve for phi.**  Project the equation onto
+    :math:`\hat n_\chi` (which is invariant under
+    :math:`R(\hat n_\chi, \chi)`):
 
     .. math::
 
-        \begin{pmatrix} A & B \\ -B & A \end{pmatrix}
-        \begin{pmatrix} \cos\chi \\ \sin\chi \end{pmatrix}
-        = \begin{pmatrix} C \\ E \end{pmatrix}
+        \hat n_\chi \cdot q
+            = \hat n_\chi \cdot R(\hat n_\phi, \phi) \cdot v
 
-    where
-    :math:`A = \hat n_\phi \cdot q`,
-    :math:`B = \hat n_\phi \cdot (\hat n_\chi \times q)`,
-    :math:`C = \hat n_\phi \cdot v`,
-    :math:`E = \hat n_3 \cdot v`.
-    This yields a unique :math:`\chi` via ``atan2``.
-
-    Phi is then solved from the :math:`\hat n_\chi` component:
+    By Rodrigues, since :math:`\hat n_\chi \perp \hat n_\phi`:
 
     .. math::
 
-        \hat n_\chi \cdot R(\hat n_\phi, -\phi) \cdot v = \hat n_\chi \cdot q
+        \hat n_\chi \cdot R(\hat n_\phi, \phi) \cdot v
+            = (\hat n_\chi \cdot v) \cos\phi
+            + (\hat n_\chi \cdot (\hat n_\phi \times v)) \sin\phi
+            = (\hat n_\chi \cdot v) \cos\phi
+            + (\hat n_3 \cdot v) \sin\phi
 
-    which gives :math:`\alpha\cos\phi + \beta\sin\phi = \gamma`, solved
-    with the standard ``atan2`` / ``acos`` decomposition.
+    so :math:`A \cos\phi + B \sin\phi = C` with
+    :math:`A = \hat n_\chi \cdot v`,
+    :math:`B = \hat n_3 \cdot v`,
+    :math:`C = \hat n_\chi \cdot q`, yielding two :math:`\phi`
+    candidates.
+
+    **Step 2 — for each phi, solve for chi.**  Compute
+    :math:`w = R(\hat n_\phi, \phi) \cdot v` (known once :math:`\phi`
+    is fixed).  The equation :math:`R(\hat n_\chi, \chi) \cdot w = q`
+    is a single rotation about :math:`\hat n_\chi` taking :math:`w`
+    onto :math:`q`.  Their :math:`\hat n_\chi`-components must agree
+    (guaranteed by construction); :math:`\chi` is the angle in the
+    plane perpendicular to :math:`\hat n_\chi` between the
+    perpendicular projections of :math:`w` and :math:`q`.
 
     Parameters
     ----------
@@ -656,133 +675,72 @@ def _solve_bisecting_analytic(
     n_chi = chi_stage._axis_hat  # noqa: SLF001
     n_phi = phi_stage._axis_hat  # noqa: SLF001
 
-    # Known vectors
+    # Known vectors (BL1967 standard outermost-leftmost convention).
     Z_prefix = ctx._cached_Z_prefix
     D = ctx._cached_D if ctx._cached_D is not None else np.eye(3)
 
     # Q_lab: scattering vector in the lab frame (all detector & bisect angles fixed)
-    v = ctx.two_pi_over_lambda * (D @ ctx.y_eff - ctx.y_eff)  # Q_lab
+    Q_lab = ctx.two_pi_over_lambda * (D @ ctx.y_eff - ctx.y_eff)
 
-    # q = Z_prefix @ Q_phi_target
-    q = Z_prefix @ Q_phi_target
-
-    # --- Step 1: Solve for chi (two solutions) ---
-    #
-    # Define w = R(n_phi, -phi) @ v.  Then R(n_chi, -chi) @ w = q.
-    # Since R(n_phi, -phi) preserves the n_phi component:
-    #   n_phi · w = n_phi · v  (constant L)
-    #
-    # From w = R(n_chi, chi) @ q (inverse of R(n_chi, -chi) @ w = q):
-    #   n_phi · [R(n_chi, chi) @ q] = L
-    #
-    # Expanding via Rodrigues (n_chi ⊥ n_phi):
-    #   cos(chi)*(n_phi·q) + sin(chi)*(n_phi·(n_chi×q)) = n_phi·v
-    #
-    # This is A*cos(chi) + B*sin(chi) = C, yielding two chi values.
-
-    A = float(np.dot(n_phi, q))
-    B = float(np.dot(n_phi, np.cross(n_chi, q)))
-    C = float(np.dot(n_phi, v))
-
-    R_chi_amp = math.sqrt(A * A + B * B)
-    if R_chi_amp < 1e-12:  # pragma: no cover
-        return []  # degenerate: q ∥ n_chi
-
-    cos_arg_chi = C / R_chi_amp
-    if abs(cos_arg_chi) > 1.0 + 1e-8:  # pragma: no cover
-        return []  # no solution
-    cos_arg_chi = max(-1.0, min(1.0, cos_arg_chi))
-
-    chi0 = math.atan2(B, A)
-    delta_chi = math.acos(cos_arg_chi)
-
-    chi_candidates_rad = [chi0 + delta_chi, chi0 - delta_chi]
-
-    # --- Step 2: For each chi, solve for phi (unique) ---
-    #
-    # From w = R(n_phi, -phi) @ v and n_chi · w = n_chi · q:
-    #   n_chi · [R(n_phi, -phi) @ v] = n_chi · q
-    #
-    # Expanding via Rodrigues (n_chi ⊥ n_phi):
-    #   cos(phi)*(n_chi·v) - sin(phi)*(n_chi·(n_phi×v)) = n_chi · q
-    #
-    # But this gives only one equation — not enough for a unique phi.
-    # We also have the n3 component (n3 = n_chi × n_phi):
-    #   n3 · [R(n_phi, -phi) @ v] = n3 · [R(n_chi, chi) @ q]
-    #
-    # The RHS depends on chi (already known), the LHS depends on phi.
-    # Together with the n_chi equation, this gives a 2×2 system for
-    # (cos(phi), sin(phi)), yielding a unique phi per chi.
-    #
-    # n_chi equation:  (n_chi·v)*cos(phi) - (n_chi·(n_phi×v))*sin(phi) = n_chi·q
-    # n3 equation:     (n3·v)*cos(phi) - (n3·(n_phi×v))*sin(phi) = n3·w_chi
-    #
-    # Using triple product identities (n_chi ⊥ n_phi, n3 = n_chi × n_phi):
-    #   n_chi·(n_phi×v) = (n_chi×n_phi)·v = n3·v
-    #   n3·(n_phi×v)    = v·(n3×n_phi) = v·n_chi   [since n3×n_phi = n_chi]
-    #
-    # So the system is:
-    #   (n_chi·v)*cos(phi) - (n3·v)*sin(phi) = n_chi·q       ...(i)
-    #   (n3·v)*cos(phi) + (n_chi·v)*sin(phi) = n3·w_chi      ...(ii)
-    #
-    # Wait, sign: n3·(n_phi×v) = v·(n3×n_phi). And n3×n_phi:
-    #   n3 = n_chi×n_phi, so n3×n_phi = (n_chi×n_phi)×n_phi
-    #   = n_chi*(n_phi·n_phi) - n_phi*(n_chi·n_phi) = n_chi
-    # So n3·(n_phi×v) = v·n_chi = n_chi·v.
-    #
-    # n3 LHS: R(n_phi, -phi)@v dotted with n3:
-    #   cos(phi)*(n3·v) + (1-cos(phi))*(n_phi·v)*(n_phi·n3) - sin(phi)*(n3·(n_phi×v))
-    #   = cos(phi)*(n3·v) - sin(phi)*(n_chi·v)     [since n_phi·n3=0]
-    #
-    # n3 RHS: R(n_chi, chi)@q dotted with n3:
-    #   cos(chi)*(n3·q) + sin(chi)*(n3·(n_chi×q))
-    #   n3·(n_chi×q) = q·(n3×n_chi) = q·(-n_phi) = -(n_phi·q)
-    #   [since n3×n_chi = (n_chi×n_phi)×n_chi = n_phi]
-    #   Wait: BAC-CAB: (n_chi×n_phi)×n_chi = n_phi(n_chi·n_chi) - n_chi(n_phi·n_chi) = n_phi
-    #   So n3×n_chi = n_phi, and n3·(n_chi×q) = q·(n3×n_chi) = q·n_phi = n_phi·q
-    #   Hmm, let me redo: a·(b×c) = det(a,b,c) = c·(a×b).
-    #   n3·(n_chi×q) = q·(n3×n_chi).
-    #   n3×n_chi = (n_chi×n_phi)×n_chi = n_phi (BAC-CAB, orthonormal)
-    #   So n3·(n_chi×q) = q·n_phi = A (= n_phi·q)
-    #
-    # So n3 RHS = cos(chi)*(n3·q) + sin(chi)*A
-    # And n3 LHS = cos(phi)*(n3·v) - sin(phi)*(n_chi·v)
-    #
-    # The 2×2 system:
-    #   [n_chi·v, -(n3·v)] [cos(phi)]   [n_chi·q        ]
-    #   [n3·v,    n_chi·v ] [sin(phi)] = [n3·R_chi(chi)@q]
-    #
-    # Determinant = (n_chi·v)² + (n3·v)² = |v_perp|² (component of v ⊥ n_phi)
-    # This is non-zero unless v ∥ n_phi (degenerate).
+    # q = Z_prefix^T @ Q_lab  (right-hand side of R_chi R_phi v = q)
+    q = Z_prefix.T @ Q_lab
+    # v = target Q_phi (left-hand side argument)
+    v = np.asarray(Q_phi_target, dtype=float)
 
     n3 = np.cross(n_chi, n_phi)
-    nchi_v = float(np.dot(n_chi, v))
-    n3_v = float(np.dot(n3, v))
-    nchi_q = float(np.dot(n_chi, q))
 
-    det_phi = nchi_v * nchi_v + n3_v * n3_v
-    if det_phi < 1e-20:  # pragma: no cover
-        return []  # v ∥ n_phi — phi indeterminate
+    # --- Step 1: solve A cos phi + B sin phi = C for two phi values ---
+    A = float(np.dot(n_chi, v))
+    B = float(np.dot(n3, v))
+    C = float(np.dot(n_chi, q))
 
-    # Pre-compute n3·q and n_phi·q for the chi-dependent RHS
-    n3_q = float(np.dot(n3, q))
-    # A = n_phi · q (already computed above)
+    amp = math.sqrt(A * A + B * B)
+    if amp < 1e-12:
+        # v ∥ n_phi (perpendicular component of v in (n_chi, n_3) plane is
+        # zero).  phi is indeterminate; defer to the Newton fallback.
+        return []
 
+    cos_arg_phi = C / amp
+    if abs(cos_arg_phi) > 1.0 + 1e-8:  # pragma: no cover
+        return []  # no real phi solution
+
+    cos_arg_phi = max(-1.0, min(1.0, cos_arg_phi))
+    phi0 = math.atan2(B, A)
+    delta_phi = math.acos(cos_arg_phi)
+    phi_candidates_rad = [phi0 + delta_phi, phi0 - delta_phi]
+
+    # --- Step 2: for each phi, recover chi from the residual rotation ---
+    # R(n_chi, chi) @ w = q with w = R(n_phi, phi) @ v.  chi is the
+    # signed angle about n_chi taking w_perp onto q_perp in the plane
+    # perpendicular to n_chi.
     raw_candidates = []
-    for chi_rad in chi_candidates_rad:
-        chi_d = math.degrees(chi_rad)
-        c_chi = math.cos(chi_rad)
-        s_chi = math.sin(chi_rad)
+    for phi_rad in phi_candidates_rad:
+        phi_d = math.degrees(phi_rad)
+        # Build w = R(n_phi, phi) @ v via Rodrigues:
+        #   w = v cos φ + (n_phi × v) sin φ + n_phi (n_phi · v)(1 − cos φ)
+        c_ph = math.cos(phi_rad)
+        s_ph = math.sin(phi_rad)
+        nphi_v = float(np.dot(n_phi, v))
+        w = v * c_ph + np.cross(n_phi, v) * s_ph + n_phi * nphi_v * (1.0 - c_ph)
 
-        # n3 · R(n_chi, chi) @ q = cos(chi)*(n3·q) + sin(chi)*(n_phi·q)
-        rhs_n3 = c_chi * n3_q + s_chi * A
-
-        # Solve 2×2 system for (cos_phi, sin_phi):
-        #   nchi_v * cos_phi - n3_v * sin_phi = nchi_q
-        #   n3_v * cos_phi + nchi_v * sin_phi = rhs_n3
-        cos_phi = (nchi_v * nchi_q + n3_v * rhs_n3) / det_phi
-        sin_phi = (nchi_v * rhs_n3 - n3_v * nchi_q) / det_phi
-        phi_d = math.degrees(math.atan2(sin_phi, cos_phi))
+        # Project w and q onto the plane perpendicular to n_chi.
+        w_par = float(np.dot(w, n_chi))
+        q_par = float(np.dot(q, n_chi))
+        w_perp = w - w_par * n_chi
+        q_perp = q - q_par * n_chi
+        w_perp_norm = float(np.linalg.norm(w_perp))
+        q_perp_norm = float(np.linalg.norm(q_perp))
+        if w_perp_norm < 1e-12 or q_perp_norm < 1e-12:
+            # Degenerate: w or q is parallel to n_chi; chi indeterminate.
+            chi_d = 0.0
+        else:
+            # cos chi = (w_perp · q_perp) / (|w_perp| |q_perp|)
+            # sin chi = n_chi · (w_perp × q_perp) / (|w_perp| |q_perp|)
+            cos_chi = float(np.dot(w_perp, q_perp)) / (w_perp_norm * q_perp_norm)
+            sin_chi = float(np.dot(n_chi, np.cross(w_perp, q_perp))) / (
+                w_perp_norm * q_perp_norm
+            )
+            chi_d = math.degrees(math.atan2(sin_chi, cos_chi))
 
         raw_candidates.append((chi_d, phi_d))
 
@@ -1242,28 +1200,27 @@ def _solve_one_free_angle_analytic(
     r"""
     Analytic single-``atan2`` solver for one free sample-stage rotation.
 
-    When all detector stages and all sample stages **except one** have
-    fixed angles, the forward equation reduces to a single rotation:
+    Under the BL1967 standard convention (Busing & Levy 1967,
+    outermost stage leftmost), when all detector stages and all sample
+    stages **except one** have fixed angles, the forward equation
+    reduces to a single rotation:
 
     .. math::
 
-        R_{\text{after}} \cdot R(\hat n, \theta) \cdot R_{\text{before}}
-            \cdot Q_{\phi,\text{target}}^* = Q_{\text{lab}}
+        Z = R_{\text{before}} \cdot R(\hat n, \theta) \cdot R_{\text{after}}
 
     where :math:`R_{\text{before}}` is the product of fixed sample stages
-    *outer* to the free stage (already cached as ``ctx._cached_Z_prefix``),
-    :math:`R_{\text{after}}` is the product of fixed sample stages *inner*
-    to the free stage, and the target satisfies
-    :math:`Q_\phi = Z^T Q_{\text{lab}}`.
-
-    Rearranging:
+    *outer* to the free stage (already cached as ``ctx._cached_Z_prefix``)
+    and :math:`R_{\text{after}}` is the product of fixed sample stages
+    *inner* to the free stage.  The target satisfies
+    :math:`Q_\phi = Z^T Q_{\text{lab}}`, so
 
     .. math::
 
         R(\hat n, \theta) \cdot q = u
 
-    with :math:`q = R_{\text{before}} \cdot Q_{\phi,\text{target}}` and
-    :math:`u = R_{\text{after}}^T \cdot Q_{\text{lab}}`.  The unknown
+    with :math:`q = R_{\text{after}} \cdot Q_{\phi,\text{target}}` and
+    :math:`u = R_{\text{before}}^T \cdot Q_{\text{lab}}`.  The unknown
     rotation about a known axis :math:`\hat n` is recovered by projecting
     both vectors onto the plane perpendicular to :math:`\hat n` and
     reading off the angle with a single ``atan2``.
@@ -1310,19 +1267,27 @@ def _solve_one_free_angle_analytic(
     if free_idx is None:  # pragma: no cover
         return None
 
+    # Build R_after in BL1967 standard outermost-leftmost order:
+    # R_after = R_{free_idx+1} @ R_{free_idx+2} @ ... @ R_{N-1}.
     R_after = np.eye(3)
     for i in range(free_idx + 1, len(sample_stages)):
         s = sample_stages[i]
         a = angles.get(s.name, s.angle)
-        R_after = _rotation_matrix_normalized(s._axis_hat, a) @ R_after  # noqa: SLF001
+        R_after = R_after @ _rotation_matrix_normalized(s._axis_hat, a)  # noqa: SLF001
 
     Z_prefix = ctx._cached_Z_prefix if ctx._cached_Z_prefix is not None else np.eye(3)
     D = ctx._cached_D if ctx._cached_D is not None else np.eye(3)
     Q_lab = ctx.two_pi_over_lambda * (D @ ctx.y_eff - ctx.y_eff)
 
+    # Solve R(n, θ) q = u with
+    #   q = R_after @ Q_phi_target
+    #   u = Z_prefix^T @ Q_lab
+    # (Derivation: Z = Z_prefix @ R(n, θ) @ R_after, so
+    #  Q_phi = Z^T Q_lab = R_after^T R(n, θ)^T Z_prefix^T Q_lab; multiply
+    #  through by R(n, θ) R_after on the left to get the equation above.)
     n = free_stage._axis_hat  # noqa: SLF001
-    q = Z_prefix @ np.asarray(Q_phi_target, dtype=float)
-    u = R_after.T @ Q_lab
+    q = R_after @ np.asarray(Q_phi_target, dtype=float)
+    u = Z_prefix.T @ Q_lab
 
     # Parallel components must agree: rotation about n preserves the
     # n-component.  If they disagree beyond tolerance the target is not
@@ -1344,7 +1309,12 @@ def _solve_one_free_angle_analytic(
 
     # Match magnitudes: rotation preserves |q_perp| = |u_perp|.
     u_perp_norm = float(np.linalg.norm(u_perp))
-    if abs(q_perp_norm - u_perp_norm) > 1e-7:
+    if abs(q_perp_norm - u_perp_norm) > 1e-7:  # pragma: no cover
+        # When the parallel-component check above passes (q_par == u_par)
+        # and the targets are derived from a consistent geometry/UB/wavelength
+        # configuration (the only call path in the package), rotation-
+        # preservation of perpendicular magnitudes is automatic; this branch
+        # is a defensive guard for caller-constructed contexts only.
         return None  # not reachable by rotation alone
 
     cos_t = float(np.dot(u_perp, e1))
@@ -2021,7 +1991,12 @@ def _solve_double_diffraction(
     is_eulerian = _is_standard_eulerian_pair(chi_stage, phi_stage)
 
     def _build_Z(angles: dict[str, float]) -> np.ndarray:
-        """Compute sample rotation matrix from angle values."""
+        """Compute sample rotation matrix from angle values.
+
+        Composition follows the BL1967 standard convention (Busing &
+        Levy 1967): outermost (floor-most) stage leftmost,
+        so Z = R_0 @ R_1 @ ... @ R_{N-1}.
+        """
         Z = np.eye(3)
         for s in sample_stages:
             Z = Z @ rotation_matrix(s.axis, angles[s.name])
@@ -2066,12 +2041,14 @@ def _solve_double_diffraction(
         )
         outer_stage_obj = sample_stages[outer_stage_idx]
 
-        # Pre-compute the Z_prefix for stages before the outer stage
+        # Pre-compute the Z_prefix for stages before the outer stage.
+        # Composition: BL1967 standard outermost-leftmost, so
+        # Z_pre_outer = R_0 @ R_1 @ ... @ R_{outer_stage_idx-1}.
         Z_pre_outer = np.eye(3)
         for i in range(outer_stage_idx):
             s = sample_stages[i]
             angle = angles_base.get(s.name, s.angle)
-            Z_pre_outer = _rotation_matrix_normalized(s._axis_hat, angle) @ Z_pre_outer  # noqa: SLF001
+            Z_pre_outer = Z_pre_outer @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     def _solve_inner_eulerian_fast(
         outer_deg: float,
@@ -2079,59 +2056,82 @@ def _solve_double_diffraction(
         """
         Fast analytic (chi, phi) solve for Eulerian geometries.
 
-        Returns list of (chi_deg, phi_deg) pairs.  No ForwardContext created.
+        Inlines the algebra of :func:`_solve_bisecting_analytic` for the
+        double-diffraction outer-scan loop.  Under the BL1967 standard
+        convention (Busing & Levy 1967, outermost-leftmost):
 
-        When the decomposition is degenerate (q parallel to n_chi, so chi
-        is indeterminate), returns an empty list.  The caller handles
-        degenerate points via `_degenerate_outers`.
+            Z_prefix = Z_pre_outer @ R_outer
+            R_chi R_phi v = q
+              with  v = Q_phi (target),  q = Z_prefix^T @ Q_lab
+
+        Step 1 — solve for phi (two candidates) by projecting onto
+        n_chi (invariant under R_chi).  Step 2 — for each phi, recover
+        chi as the residual rotation about n_chi taking
+        w = R(n_phi, phi) v onto q.
+
+        Returns list of (chi_deg, phi_deg) pairs.  Returns an empty list
+        when v ∥ n_phi (phi indeterminate); the caller falls back to a
+        chi-scan via ``_find_degenerate_outers`` /
+        ``_solve_degenerate_outer``.
         """
-        # Z_prefix = R_outer @ Z_pre_outer
         R_outer = _rotation_matrix_normalized(
             outer_stage_obj._axis_hat,
             outer_deg,  # noqa: SLF001
         )
-        Z_prefix = R_outer @ Z_pre_outer
+        # Textbook order: Z_prefix = Z_pre_outer @ R_outer.
+        Z_prefix = Z_pre_outer @ R_outer
 
-        # q = Z_prefix @ Q_phi_target
-        q = Z_prefix @ Q_phi
+        # q_loc = Z_prefix^T @ Q_lab  (constant within an outer-angle step)
+        # v_target = Q_phi_target     (constant)
+        v_target = Q_phi  # alias for clarity
+        q_loc = Z_prefix.T @ v  # v is the Q_lab vector defined at line 2064
 
-        # --- Solve for chi: A*cos(chi) + B*sin(chi) = C ---
-        A = float(np.dot(n_phi, q))
-        B = float(np.dot(n_phi, np.cross(n_chi, q)))
-        C = float(np.dot(n_phi, v))
+        # --- Step 1: A cos phi + B sin phi = C ---
+        A = float(np.dot(n_chi, v_target))
+        B = float(np.dot(n3, v_target))
+        C = float(np.dot(n_chi, q_loc))
 
-        R_chi_amp = math.sqrt(A * A + B * B)
-        if R_chi_amp < 1e-12:
-            return []  # degenerate — handled separately
+        amp = math.sqrt(A * A + B * B)
+        if amp < 1e-12:
+            return []  # v ∥ n_phi; defer to degenerate path
 
-        cos_arg_chi = C / R_chi_amp
-        if abs(cos_arg_chi) > 1.0 + 1e-8:  # pragma: no cover
-            return []  # pragma: no cover
-        cos_arg_chi = max(-1.0, min(1.0, cos_arg_chi))
+        cos_arg_phi = C / amp
+        if abs(cos_arg_phi) > 1.0 + 1e-8:
+            return []
+        cos_arg_phi = max(-1.0, min(1.0, cos_arg_phi))
 
-        chi0 = math.atan2(B, A)
-        delta_chi = math.acos(cos_arg_chi)
-        chi_candidates_rad = [chi0 + delta_chi, chi0 - delta_chi]
+        phi0 = math.atan2(B, A)
+        delta_phi = math.acos(cos_arg_phi)
+        phi_candidates_rad = [phi0 + delta_phi, phi0 - delta_phi]
 
-        # --- For each chi, solve for phi (2x2 system) ---
-        nchi_v = float(np.dot(n_chi, v))
-        n3_v = float(np.dot(n3, v))
-        nchi_q = float(np.dot(n_chi, q))
-        det_phi = nchi_v * nchi_v + n3_v * n3_v
-        if det_phi < 1e-20:  # pragma: no cover
-            return []  # pragma: no cover
-
-        n3_q = float(np.dot(n3, q))
-
+        # --- Step 2: for each phi, recover chi from the residual ---
         results = []
-        for chi_rad in chi_candidates_rad:
-            c_chi = math.cos(chi_rad)
-            s_chi = math.sin(chi_rad)
-            rhs_n3 = c_chi * n3_q + s_chi * A
-            cos_phi = (nchi_v * nchi_q + n3_v * rhs_n3) / det_phi
-            sin_phi = (nchi_v * rhs_n3 - n3_v * nchi_q) / det_phi
-            chi_d = math.degrees(chi_rad)
-            phi_d = math.degrees(math.atan2(sin_phi, cos_phi))
+        for phi_rad in phi_candidates_rad:
+            phi_d = math.degrees(phi_rad)
+            c_ph = math.cos(phi_rad)
+            s_ph = math.sin(phi_rad)
+            nphi_v_target = float(np.dot(n_phi, v_target))
+            w = (
+                v_target * c_ph
+                + np.cross(n_phi, v_target) * s_ph
+                + n_phi * nphi_v_target * (1.0 - c_ph)
+            )
+
+            w_par = float(np.dot(w, n_chi))
+            q_par = float(np.dot(q_loc, n_chi))
+            w_perp = w - w_par * n_chi
+            q_perp = q_loc - q_par * n_chi
+            w_perp_norm = float(np.linalg.norm(w_perp))
+            q_perp_norm = float(np.linalg.norm(q_perp))
+            if w_perp_norm < 1e-12 or q_perp_norm < 1e-12:  # pragma: no cover
+                chi_d = 0.0
+            else:
+                cos_chi = float(np.dot(w_perp, q_perp)) / (w_perp_norm * q_perp_norm)
+                sin_chi = float(np.dot(n_chi, np.cross(w_perp, q_perp))) / (
+                    w_perp_norm * q_perp_norm
+                )
+                chi_d = math.degrees(math.atan2(sin_chi, cos_chi))
+
             # Normalize to (-180, 180]
             chi_d = (chi_d + 180.0) % 360.0 - 180.0
             phi_d = (phi_d + 180.0) % 360.0 - 180.0
@@ -2143,35 +2143,45 @@ def _solve_double_diffraction(
         """
         Find outer angles where the analytic decomposition is degenerate.
 
-        Degeneracy occurs when q = Z_prefix @ Q_phi is parallel to n_chi,
-        meaning R_chi_amp = 0.  At these points chi is indeterminate and
-        solutions (if they exist) must be found by scanning chi.
+        Under the BL1967 standard convention (Busing & Levy 1967) the
+        degeneracy condition is ``Q_phi ∥ n_phi`` (the *target*
+        scattering vector lies along the innermost stage axis), which
+        is **independent of the outer angle**.  Either every outer
+        angle is degenerate or none is.  Return a sweep of candidate
+        outer angles in the degenerate case; otherwise return an empty
+        list.
+
+        The sweep includes both a dense scan and the bisecting outer
+        angles ``± ttheta_deg / 2``.  The bisecting values are
+        appended because they are exactly the outer angles at which
+        the primary Bragg condition is solvable in the degenerate
+        case (every other outer angle gives ``q_par ≠ w_par`` in the
+        inner ``_chi_to_trial`` and is silently rejected).
         """
-        degenerate = []
-        for i in range(720):
-            outer_deg = -180.0 + i * 0.5
-            R_outer = _rotation_matrix_normalized(
-                outer_stage_obj._axis_hat,
-                outer_deg,  # noqa: SLF001
-            )
-            q = R_outer @ Z_pre_outer @ Q_phi
-            A = float(np.dot(n_phi, q))
-            B = float(np.dot(n_phi, np.cross(n_chi, q)))
-            if math.sqrt(A * A + B * B) < 0.1:
-                degenerate.append(outer_deg)
-        return degenerate
+        A = float(np.dot(n_chi, Q_phi))
+        B = float(np.dot(n3, Q_phi))
+        if math.sqrt(A * A + B * B) >= 0.1:
+            return []
+        # Degenerate: phi is indeterminate at every outer angle.  Include
+        # the bisecting outer values so the caller can find at least the
+        # bisecting-locus solutions, plus a dense sweep elsewhere.
+        outers = [-180.0 + i * 0.5 for i in range(720)]
+        outers.extend([ttheta_deg / 2.0, -ttheta_deg / 2.0])
+        return outers
 
     def _solve_degenerate_outer(
         outer_deg: float,
     ) -> list[dict[str, float]]:
         """
-        At degenerate outer angles (q parallel to n_chi), scan chi to find
+        At degenerate outer angles (Q_phi ∥ n_phi), scan phi to find
         solutions that satisfy both the Bragg and Ewald conditions.
 
-        At these points, chi is free and phi is determined by chi.  We scan
-        chi, compute phi from the remaining Bragg components, and detect
-        Ewald sign changes between adjacent chi values.  A bisection then
-        refines the chi to the exact root.
+        Under the corrected outermost-leftmost composition, the
+        degeneracy is phi-indeterminate (R(n_phi, phi) @ Q_phi = Q_phi
+        for every phi).  We scan phi, compute chi from the residual
+        rotation R(n_chi, chi) @ w = q where w = R(n_phi, phi) @ v, and
+        detect Ewald sign changes between adjacent phi values.  A
+        bisection then refines the phi to the exact root.
         """
         angles = dict(angles_base)
         angles[outer_stage_name] = outer_deg
@@ -2179,32 +2189,46 @@ def _solve_double_diffraction(
         ctx = ForwardContext(geometry)
         ctx.prepare_caching(angles, {chi_stage_name, phi_stage_name})
 
+        # Textbook outermost-leftmost composition:
+        #   Z_prefix = Z_pre_outer @ R_outer
         R_outer = _rotation_matrix_normalized(
             outer_stage_obj._axis_hat,
             outer_deg,  # noqa: SLF001
         )
-        q = R_outer @ Z_pre_outer @ Q_phi
-        nchi_v = float(np.dot(n_chi, v))
-        n3_v = float(np.dot(n3, v))
-        nchi_q = float(np.dot(n_chi, q))
-        n3_q = float(np.dot(n3, q))
-        A_local = float(np.dot(n_phi, q))
-        det_phi = nchi_v * nchi_v + n3_v * n3_v
-        if det_phi < 1e-20:  # pragma: no cover
-            return []  # pragma: no cover
+        Z_prefix_local = Z_pre_outer @ R_outer
+        q_loc = Z_prefix_local.T @ v  # v here is the Q_lab vector
+        v_target = Q_phi  # for clarity
+        nphi_v = float(np.dot(n_phi, v_target))
 
-        def _chi_to_trial(chi_deg_f: float) -> dict[str, float] | None:
-            """Given a chi value, compute phi and return a trial dict."""
-            chi_rad = math.radians(chi_deg_f)
-            c_chi = math.cos(chi_rad)
-            s_chi = math.sin(chi_rad)
-            rhs_n3 = c_chi * n3_q + s_chi * A_local
-            cos_phi = (nchi_v * nchi_q + n3_v * rhs_n3) / det_phi
-            sin_phi = (nchi_v * rhs_n3 - n3_v * nchi_q) / det_phi
-            phi_d = math.degrees(math.atan2(sin_phi, cos_phi))
+        def _chi_to_trial(phi_deg_f: float) -> dict[str, float] | None:
+            """Given a phi value, compute chi and return a trial dict."""
+            phi_rad = math.radians(phi_deg_f)
+            c_ph = math.cos(phi_rad)
+            s_ph = math.sin(phi_rad)
+            # w = R(n_phi, phi) @ v_target (Rodrigues)
+            w = (
+                v_target * c_ph
+                + np.cross(n_phi, v_target) * s_ph
+                + n_phi * nphi_v * (1.0 - c_ph)
+            )
+            # chi = angle about n_chi from w_perp to q_perp
+            w_par = float(np.dot(w, n_chi))
+            q_par = float(np.dot(q_loc, n_chi))
+            w_perp = w - w_par * n_chi
+            q_perp = q_loc - q_par * n_chi
+            w_perp_norm = float(np.linalg.norm(w_perp))
+            q_perp_norm = float(np.linalg.norm(q_perp))
+            if w_perp_norm < 1e-12 or q_perp_norm < 1e-12:  # pragma: no cover
+                return None
+            cos_chi = float(np.dot(w_perp, q_perp)) / (w_perp_norm * q_perp_norm)
+            sin_chi = float(np.dot(n_chi, np.cross(w_perp, q_perp))) / (
+                w_perp_norm * q_perp_norm
+            )
+            phi_d = phi_deg_f  # the scanned phi
+            chi_d = math.degrees(math.atan2(sin_chi, cos_chi))
 
             trial = dict(angles)
-            trial[chi_stage_name] = chi_deg_f
+            trial[chi_stage_name] = chi_d
             trial[phi_stage_name] = phi_d
 
             # Verify Bragg condition
@@ -2213,24 +2237,25 @@ def _solve_double_diffraction(
                 return None
             return trial
 
-        # Scan chi at 2-degree intervals, detect sign changes in Ewald
+        # Scan the free angle (phi when v ∥ n_phi) at 2-degree
+        # intervals, detect sign changes in the Ewald residual.
         candidates = []
-        prev_chi: float | None = None
+        prev_scan: float | None = None
         prev_ew: float = 0.0
 
-        for chi_int in range(-180, 180, 2):
-            chi_f = float(chi_int)
-            trial = _chi_to_trial(chi_f)
+        for scan_int in range(-180, 180, 2):
+            scan_f = float(scan_int)
+            trial = _chi_to_trial(scan_f)
             if trial is None:
-                prev_chi = None
+                prev_scan = None
                 continue
             ew = _ewald_residual(trial)
 
             if abs(ew) < 1e-3:  # pragma: no cover
                 candidates.append(trial)  # pragma: no cover
-            elif prev_chi is not None and prev_ew * ew < 0:
-                # Sign change: bisect chi to find root
-                lo, hi = prev_chi, chi_f
+            elif prev_scan is not None and prev_ew * ew < 0:
+                # Sign change: bisect to find root
+                lo, hi = prev_scan, scan_f
                 ew_lo = prev_ew
                 for _ in range(40):
                     mid = (lo + hi) / 2.0
@@ -2253,7 +2278,7 @@ def _solve_double_diffraction(
                         if abs(_ewald_residual(trial_final)) < 1e-5:
                             candidates.append(trial_final)
 
-            prev_chi = chi_f
+            prev_scan = scan_f
             prev_ew = ew
 
         return candidates

--- a/src/ad_hoc_diffractometer/kappa.py
+++ b/src/ad_hoc_diffractometer/kappa.py
@@ -305,15 +305,18 @@ def _eulerian_rotation(
 ) -> np.ndarray:
     """Compose the equivalent-Eulerian sample rotation matrix.
 
-    Stage order matches :func:`~orientation._compute_q_phi`: the
-    innermost stage (``phi``) is the leftmost matrix in the product,
-    so that ``Z · v`` rotates ``v`` by the outermost stage first when
-    applied right-to-left.
+    Stage order matches :func:`~orientation._compute_q_phi` under the
+    BL1967 standard convention (Busing & Levy 1967): the outermost
+    stage (``omega``) is the leftmost matrix in the product, so
+
+        Z = R(n_komega, ω) · R(n_chi_eq, χ) · R(n_kphi, φ)
+
+    and ``Z · v_phi`` maps phi-frame vectors to lab-frame vectors.
     """
     R_om = _rotation_matrix_normalized(convention.n_komega, omega_deg)
     R_ch = _rotation_matrix_normalized(convention.n_chi_eq, chi_deg)
     R_ph = _rotation_matrix_normalized(convention.n_kphi, phi_deg)
-    return R_ph @ R_ch @ R_om
+    return R_om @ R_ch @ R_ph
 
 
 def _kappa_rotation(
@@ -324,13 +327,16 @@ def _kappa_rotation(
 ) -> np.ndarray:
     """Compose the real kappa-stack sample rotation matrix.
 
-    Stage order matches :func:`~orientation._compute_q_phi`: innermost
-    stage (``kphi``) is the leftmost matrix in the product.
+    Stage order matches :func:`~orientation._compute_q_phi` under the
+    BL1967 standard convention (Busing & Levy 1967): the outermost
+    stage (``komega``) is the leftmost matrix in the product, so
+
+        Z = R(n_komega, κω) · R(n_kappa, κ) · R(n_kphi, κφ).
     """
     R_om = _rotation_matrix_normalized(convention.n_komega, komega_deg)
     R_ka = _rotation_matrix_normalized(convention.n_kappa, kappa_deg)
     R_ph = _rotation_matrix_normalized(convention.n_kphi, kphi_deg)
-    return R_ph @ R_ka @ R_om
+    return R_om @ R_ka @ R_ph
 
 
 def _angle_about_axis(v_from: np.ndarray, v_to: np.ndarray, axis: np.ndarray) -> float:
@@ -404,37 +410,38 @@ def eulerian_to_kappa_axes(
     using the geometry's actual signed stage axes.
 
     Inverts the rotation-matrix identity (with stage order matching
-    :func:`~orientation._compute_q_phi` — innermost on the left)
+    :func:`~orientation._compute_q_phi` — BL1967 standard convention,
+    Busing & Levy 1967, outermost on the left)
 
-        R(n_kphi, κφ) · R(n_kappa, κ) · R(n_komega, κω)
-            =  R(n_kphi, φ) · R(n_chi_eq, χ) · R(n_komega, ω).
+        R(n_komega, κω) · R(n_kappa, κ) · R(n_kphi, κφ)
+            =  R(n_komega, ω) · R(n_chi_eq, χ) · R(n_kphi, φ).
 
     The decomposition is fully analytic and selects between the two
     kappa-branch solutions via the ``branch`` parameter.
 
     Algorithm
     ---------
-    Let ``R_eul = R(n_kphi, φ) · R(n_chi_eq, χ) · R(n_komega, ω)``
-    be the target rotation.  Apply both sides to ``n_komega``:
+    Let ``R_eul = R(n_komega, ω) · R(n_chi_eq, χ) · R(n_kphi, φ)``
+    be the target rotation.  Apply both sides to ``n_kphi``:
 
-        R(n_kphi, κφ) · R(n_kappa, κ) · n_komega  =  R_eul · n_komega
+        R(n_komega, κω) · R(n_kappa, κ) · n_kphi  =  R_eul · n_kphi
 
-    (since ``R(n_komega, ·) · n_komega = n_komega``).  Take the dot
-    product with ``n_kphi``:
+    (since ``R(n_kphi, ·) · n_kphi = n_kphi``).  Take the dot
+    product with ``n_komega`` (which is invariant under ``R(n_komega, ·)``):
 
-        n_kphi · R(n_kappa, κ) · n_komega  =  n_kphi · R_eul · n_komega.
+        n_komega · R(n_kappa, κ) · n_kphi  =  n_komega · R_eul · n_kphi.
 
-    Expanding ``R(n_kappa, κ) · n_komega`` via the Rodrigues formula
+    Expanding ``R(n_kappa, κ) · n_kphi`` via the Rodrigues formula
     yields a single trigonometric equation in κ of the form
     ``alpha·cos(κ) + beta·sin(κ) = gamma`` with two solutions
     (the two kappa branches).
 
-    Once κ is fixed, ``κφ`` is the rotation about ``n_kphi`` that
-    takes ``R(n_kappa, κ) · n_komega`` onto ``R_eul · n_komega``
-    (these vectors lie on the same cone about ``n_kphi`` by
-    construction).  Finally ``κω`` is the residual rotation about
-    ``n_komega`` extracted from
-    ``R(n_komega, κω) = R(n_kappa, -κ) · R(n_kphi, -κφ) · R_eul``.
+    Once κ is fixed, ``κω`` is the rotation about ``n_komega`` that
+    takes ``R(n_kappa, κ) · n_kphi`` onto ``R_eul · n_kphi``
+    (these vectors lie on the same cone about ``n_komega`` by
+    construction).  Finally ``κφ`` is the residual rotation about
+    ``n_kphi`` extracted from
+    ``R(n_kphi, κφ) = R(n_kappa, -κ) · R(n_komega, -κω) · R_eul``.
 
     Parameters
     ----------
@@ -507,17 +514,21 @@ def eulerian_to_kappa_axes(
     n_ka = convention.n_kappa
     n_ph = convention.n_kphi
 
-    # Step 1 — solve for κ from
-    #   n_ph · R(n_ka, κ) · n_om  =  n_ph · R_eul · n_om
-    v_target = R_eul @ n_om
-    gamma = float(np.dot(n_ph, v_target))
+    # Step 1 — solve for κ from the scalar equation
+    #   n_om · R(n_ka, κ) · n_ph  =  n_om · R_eul · n_ph
+    # (n_om is invariant under R(n_om, κω); n_ph is invariant under
+    # R(n_ph, κφ); the BL1967 standard composition has R(n_om, κω)
+    # outermost and R(n_ph, κφ) innermost, so applying both sides to
+    # n_ph then dotting with n_om removes both κω and κφ.)
+    v_target = R_eul @ n_ph
+    gamma = float(np.dot(n_om, v_target))
 
-    # Rodrigues expansion of R(n_ka, κ) · n_om:
-    #   R(n_ka, κ) · n_om = n_om·cos(κ) + (n_ka × n_om)·sin(κ)
-    #                       + n_ka·(n_ka·n_om)·(1 − cos(κ))
-    A = float(np.dot(n_ph, n_om))
-    B = float(np.dot(n_ph, np.cross(n_ka, n_om)))
-    C = float(np.dot(n_ph, n_ka)) * float(np.dot(n_ka, n_om))
+    # Rodrigues expansion of R(n_ka, κ) · n_ph:
+    #   R(n_ka, κ) · n_ph = n_ph·cos(κ) + (n_ka × n_ph)·sin(κ)
+    #                       + n_ka·(n_ka·n_ph)·(1 − cos(κ))
+    A = float(np.dot(n_om, n_ph))
+    B = float(np.dot(n_om, np.cross(n_ka, n_ph)))
+    C = float(np.dot(n_om, n_ka)) * float(np.dot(n_ka, n_ph))
     # → (A − C)·cos(κ) + B·sin(κ) = γ − C
     kappa_candidates = _solve_alpha_cos_beta_sin_eq_gamma(A - C, B, gamma - C)
 
@@ -531,9 +542,9 @@ def eulerian_to_kappa_axes(
         kappa_deg = kappa_candidates[-1]
 
     # Degeneracy at κ = 0: when the kappa rotation is the identity,
-    # ``R(n_kphi, κφ) · R(n_komega, κω) = R(n_kphi, φ) · R(n_komega, ω)``
-    # has a one-parameter family of solutions whenever ``n_kphi`` is
-    # parallel (or anti-parallel) to ``n_komega`` — and *all* kappa
+    # ``R(n_komega, κω) · R(n_kphi, κφ) = R(n_komega, ω) · R(n_kphi, φ)``
+    # has a one-parameter family of solutions whenever ``n_komega`` is
+    # parallel (or anti-parallel) to ``n_kphi`` — and *all* kappa
     # demo geometries in this package have that property by design (komega
     # and kphi share the same physical motor axis).  Pick the
     # representative that maps ``ω → κω`` and ``φ → κφ`` directly so
@@ -542,28 +553,28 @@ def eulerian_to_kappa_axes(
     if abs(kappa_deg) < 1e-12 and parallel_axes:  # pragma: no cover
         return _wrap_180(omega_deg), 0.0, _wrap_180(phi_deg)
 
-    # Step 2 — recover κφ as the signed rotation about n_kphi taking
-    # R(n_kappa, κ) · n_komega onto R_eul · n_komega.
+    # Step 2 — recover κω as the signed rotation about n_komega taking
+    # R(n_kappa, κ) · n_kphi onto R_eul · n_kphi.
     R_ka = _rotation_matrix_normalized(n_ka, kappa_deg)
-    w = R_ka @ n_om
-    kphi_deg = _angle_about_axis(w, v_target, n_ph)
+    w = R_ka @ n_ph
+    komega_deg = _angle_about_axis(w, v_target, n_om)
 
-    # Step 3 — recover κω as the residual rotation about n_komega.
-    # From R(n_kphi, κφ) · R(n_kappa, κ) · R(n_komega, κω) = R_eul,
-    # we have R(n_komega, κω) = R(n_kappa, -κ) · R(n_kphi, -κφ) · R_eul.
-    R_ph_inv = _rotation_matrix_normalized(n_ph, -kphi_deg)
+    # Step 3 — recover κφ as the residual rotation about n_kphi.
+    # From R(n_komega, κω) · R(n_kappa, κ) · R(n_kphi, κφ) = R_eul,
+    # we have R(n_kphi, κφ) = R(n_kappa, -κ) · R(n_komega, -κω) · R_eul.
+    R_om_inv = _rotation_matrix_normalized(n_om, -komega_deg)
     R_ka_inv = _rotation_matrix_normalized(n_ka, -kappa_deg)
-    R_residual = R_ka_inv @ R_ph_inv @ R_eul
-    # R_residual should be a pure rotation about n_komega.  Recover
-    # the angle from the action on any vector perpendicular to n_om.
-    if abs(n_om[0]) < 0.9:
+    R_residual = R_ka_inv @ R_om_inv @ R_eul
+    # R_residual should be a pure rotation about n_kphi.  Recover
+    # the angle from the action on any vector perpendicular to n_ph.
+    if abs(n_ph[0]) < 0.9:
         ref = np.array([1.0, 0.0, 0.0])
     else:
         ref = np.array([0.0, 1.0, 0.0])
-    perp = ref - np.dot(ref, n_om) * n_om
+    perp = ref - np.dot(ref, n_ph) * n_ph
     perp = perp / np.linalg.norm(perp)
     perp_rot = R_residual @ perp
-    komega_deg = _angle_about_axis(perp, perp_rot, n_om)
+    kphi_deg = _angle_about_axis(perp, perp_rot, n_ph)
 
     return _wrap_180(komega_deg), _wrap_180(kappa_deg), _wrap_180(kphi_deg)
 
@@ -580,10 +591,11 @@ def kappa_to_eulerian_axes(
 
     Inverts :func:`eulerian_to_kappa_axes`.  Decomposes the kappa
     sample-rotation matrix (with stage order matching
-    :func:`~orientation._compute_q_phi`) as
+    :func:`~orientation._compute_q_phi` under the BL1967 standard
+    convention, Busing & Levy 1967) as
 
-        R(n_kphi, κφ) · R(n_kappa, κ) · R(n_komega, κω)
-            =  R(n_kphi, φ) · R(n_chi_eq, χ) · R(n_komega, ω)
+        R(n_komega, κω) · R(n_kappa, κ) · R(n_kphi, κφ)
+            =  R(n_komega, ω) · R(n_chi_eq, χ) · R(n_kphi, φ)
 
     and returns ``(ω, χ, φ)``.  The decomposition has two χ branches;
     this function returns the branch consistent with the input kappa
@@ -591,18 +603,18 @@ def kappa_to_eulerian_axes(
 
     Algorithm
     ---------
-    Let ``R = R(n_kphi, κφ) · R(n_kappa, κ) · R(n_komega, κω)`` be
+    Let ``R = R(n_komega, κω) · R(n_kappa, κ) · R(n_kphi, κφ)`` be
     the realized rotation.  By the same reasoning as in
     :func:`eulerian_to_kappa_axes` (applied to the Eulerian-equivalent
     triple):
 
     1. Solve for χ from
-       ``n_kphi · R(n_chi_eq, χ) · n_komega  =  n_kphi · R · n_komega``.
+       ``n_komega · R(n_chi_eq, χ) · n_kphi  =  n_komega · R · n_kphi``.
 
-    2. Recover φ as the signed rotation about ``n_kphi`` taking
-       ``R(n_chi_eq, χ) · n_komega`` onto ``R · n_komega``.
+    2. Recover ω as the signed rotation about ``n_komega`` taking
+       ``R(n_chi_eq, χ) · n_kphi`` onto ``R · n_kphi``.
 
-    3. Recover ω from the residual rotation about ``n_komega``.
+    3. Recover φ from the residual rotation about ``n_kphi``.
 
     Parameters
     ----------
@@ -640,13 +652,16 @@ def kappa_to_eulerian_axes(
     n_ch = convention.n_chi_eq
     n_ph = convention.n_kphi
 
-    # Step 1 — solve for χ from
-    #   n_ph · R(n_ch, χ) · n_om  =  n_ph · R · n_om
-    v_target = R @ n_om
-    gamma = float(np.dot(n_ph, v_target))
-    A = float(np.dot(n_ph, n_om))
-    B = float(np.dot(n_ph, np.cross(n_ch, n_om)))
-    C = float(np.dot(n_ph, n_ch)) * float(np.dot(n_ch, n_om))
+    # Step 1 — solve for χ from the scalar equation
+    #   n_om · R(n_ch, χ) · n_ph  =  n_om · R · n_ph
+    # (Apply both sides of R_eul = R(n_om,ω) · R(n_ch,χ) · R(n_ph,φ)
+    # to n_ph; the inner R(n_ph,·) factor disappears.  Dotting with
+    # n_om removes the outer R(n_om,·) factor.)
+    v_target = R @ n_ph
+    gamma = float(np.dot(n_om, v_target))
+    A = float(np.dot(n_om, n_ph))
+    B = float(np.dot(n_om, np.cross(n_ch, n_ph)))
+    C = float(np.dot(n_om, n_ch)) * float(np.dot(n_ch, n_ph))
     chi_candidates = _solve_alpha_cos_beta_sin_eq_gamma(A - C, B, gamma - C)
 
     # The two χ candidates differ by reflection through the cone-axis
@@ -657,22 +672,25 @@ def kappa_to_eulerian_axes(
     best_err = float("inf")
     target_branch = +1 if kappa_deg >= 0 else -1
     for chi_deg in chi_candidates:
-        # Recover φ from the n_kphi cone identity.
+        # Recover ω from the n_komega cone identity:
+        # R(n_om, ω) takes R(n_ch, χ) · n_ph onto R · n_ph.
         R_ch = _rotation_matrix_normalized(n_ch, chi_deg)
-        w = R_ch @ n_om
-        phi_deg = _angle_about_axis(w, v_target, n_ph)
-        # Recover ω from the residual rotation about n_komega.
-        R_ph_inv = _rotation_matrix_normalized(n_ph, -phi_deg)
+        w = R_ch @ n_ph
+        omega_deg = _angle_about_axis(w, v_target, n_om)
+        # Recover φ from the residual rotation about n_kphi.
+        # From R(n_om, ω) · R(n_ch, χ) · R(n_ph, φ) = R, we have
+        # R(n_ph, φ) = R(n_ch, -χ) · R(n_om, -ω) · R.
+        R_om_inv = _rotation_matrix_normalized(n_om, -omega_deg)
         R_ch_inv = _rotation_matrix_normalized(n_ch, -chi_deg)
-        R_residual = R_ch_inv @ R_ph_inv @ R
-        if abs(n_om[0]) < 0.9:
+        R_residual = R_ch_inv @ R_om_inv @ R
+        if abs(n_ph[0]) < 0.9:
             ref = np.array([1.0, 0.0, 0.0])
         else:
             ref = np.array([0.0, 1.0, 0.0])
-        perp = ref - np.dot(ref, n_om) * n_om
+        perp = ref - np.dot(ref, n_ph) * n_ph
         perp = perp / np.linalg.norm(perp)
         perp_rot = R_residual @ perp
-        omega_deg = _angle_about_axis(perp, perp_rot, n_om)
+        phi_deg = _angle_about_axis(perp, perp_rot, n_ph)
         # Round-trip error: forward through eulerian_to_kappa_axes.
         try:
             ko, k, kp = eulerian_to_kappa_axes(

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -19,6 +19,7 @@ Based on:
 from __future__ import annotations
 
 import logging
+import math
 
 import numpy as np
 
@@ -545,10 +546,25 @@ class Lattice:
     @property
     def cartesian_lattice_vectors(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
-        Direct lattice vectors (a1, a2, a3) in Angstroms.
+        Direct-lattice vectors (a1, a2, a3) in Angstroms, expressed in
+        the BL1967 crystal-Cartesian frame.
 
-        a1 is along xHat, a2 lies in the xHat-yHat plane, a3 is
-        determined by the right-hand rule.  Cached until a parameter changes.
+        The frame is defined by the BL1967 B-matrix convention: the
+        reciprocal vector b1\\* is along crystal-x̂, b2\\* lies in the
+        x̂-ŷ plane, b3\\* completes the right-handed triple.  The
+        direct vectors are then determined by the duality
+        ``aᵢ · bⱼ\\* = 2π δᵢⱼ``.  Their magnitudes equal the lattice
+        parameters (``|a1| = a``, ``|a2| = b``, ``|a3| = c``) and the
+        angles between them recover (α, β, γ).
+
+        For orthogonal cells (cubic, tetragonal, orthorhombic) this
+        reduces to ``a1 = a x̂``, ``a2 = b ŷ``, ``a3 = c ẑ``.  For
+        non-orthogonal cells the direct vectors are rotated relative
+        to that simple placement so that the reciprocal vectors land
+        in the BL1967 frame.  See :func:`lattice_vectors` for the
+        construction.
+
+        Cached until a parameter changes.
         """
         if self._cartesian_lattice_vectors is None:
             self._cartesian_lattice_vectors = lattice_vectors(
@@ -564,37 +580,62 @@ class Lattice:
     @property
     def reciprocal_lattice_vectors(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
-        Reciprocal lattice vectors (b1, b2, b3) in Å⁻¹ (with 2π factor).
+        Reciprocal-lattice vectors (b1, b2, b3) in Å⁻¹ (with 2π factor)
+        expressed in the BL1967 crystal-Cartesian frame.
 
-        Satisfies b_i · a_j = 2π δ_ij.  Cached until a parameter changes.
+        The columns of :attr:`B`.  Satisfies ``bᵢ · aⱼ = 2π δᵢⱼ`` with
+        the direct vectors returned by
+        :attr:`cartesian_lattice_vectors`.  Cached until a parameter
+        changes.
         """
         if self._reciprocal_lattice_vectors is None:
-            a1, a2, a3 = self.cartesian_lattice_vectors
-            self._reciprocal_lattice_vectors = reciprocal_vectors(a1, a2, a3)
+            self._reciprocal_lattice_vectors = reciprocal_vectors(
+                self._a,
+                self._b,
+                self._c,
+                self._alpha,
+                self._beta,
+                self._gamma,
+            )
         return self._reciprocal_lattice_vectors
 
     @property
     def B(self) -> np.ndarray:
         """
-        B matrix in Å⁻¹ (with 2π factor, Busing & Levy 1967 / SPEC convention).
+        B matrix in Å⁻¹ (with 2π factor, BL1967 / SPEC / hkl_soleil
+        convention).
 
-        Transforms Miller indices ``h`` = (h, k, l) to the scattering vector
-        in Cartesian crystal-frame coordinates::
+        Transforms Miller indices ``h`` = (h, k, l) to the scattering
+        vector expressed in the BL1967 crystal-Cartesian frame::
 
             Q_c = B @ h
 
         ``|B @ h| = 2π / d_hkl``.  The orthogonality condition is
         ``bᵢ · aⱼ = 2π δᵢⱼ``.
 
-        This follows the Busing & Levy (1967) eq. 3 and SPEC convention.
-        Some other packages (FullProf, CrysFML, hkl with ``tau=1``) use a
-        no-2π variant where ``bᵢ · aⱼ = δᵢⱼ`` and ``|B @ h| = 1/d_hkl``.
+        Numerical equivalence
+        ---------------------
+        Returns exactly the same B matrix (to machine precision) as
+        SPEC, hkl_soleil (default ``HKL_TAU = 2π``), and diffcalc-core,
+        for every crystal system.  See :func:`b_matrix_bl1967` for the
+        closed-form derivation and the cross-solver references.
+
+        Other packages (FullProf, CrysFML, parts of CCP4, the hkl
+        library compiled with ``HKL_TAU = 1``) use a no-2π variant
+        where ``bᵢ · aⱼ = δᵢⱼ`` and ``|B @ h| = 1/d_hkl``; only the
+        2π variant is exposed by this package.
 
         Cached until a lattice parameter changes.
         """
         if self._B is None:
-            b1, b2, b3 = self.reciprocal_lattice_vectors
-            self._B = b_matrix(b1, b2, b3)
+            self._B = b_matrix_bl1967(
+                self._a,
+                self._b,
+                self._c,
+                self._alpha,
+                self._beta,
+                self._gamma,
+            )
         return self._B
 
     # ------------------------------------------------------------------
@@ -717,6 +758,157 @@ class Lattice:
 # ---------------------------------------------------------------------------
 
 
+def b_matrix_bl1967(
+    a: float,
+    b: float,
+    c: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+) -> np.ndarray:
+    r"""
+    Compute the B matrix directly from lattice parameters using the
+    Busing & Levy 1967 closed-form expression (eq. 3).
+
+    The columns of B are the reciprocal-lattice vectors b1\*, b2\*, b3\*
+    expressed in the BL1967 crystal-Cartesian frame: b1\* along
+    crystal-x, b2\* in the crystal-x–crystal-y plane (with positive
+    y component), b3\* completing the right-handed orthonormal triple.
+    With this choice B is upper triangular::
+
+        B[0, 0] = a*               B[0, 1] = b* cos γ*    B[0, 2] = c* cos β*
+        B[1, 0] = 0                B[1, 1] = b* sin γ*    B[1, 2] = -c* sin β* cos α
+        B[2, 0] = 0                B[2, 1] = 0            B[2, 2] = 2π / c
+
+    where (a\*, b\*, c\*) are the reciprocal-lattice vector magnitudes
+    (including the 2π factor) and (α\*, β\*, γ\*) are the reciprocal-cell
+    angles, related to the direct-cell parameters by the standard
+    crystallographic identities.
+
+    Numerical equivalence with external solvers
+    -------------------------------------------
+    Returns exactly the same B matrix (to machine precision) as
+
+    * **SPEC** psic and friends,
+    * **hkl_soleil** (the libhkl library) with its default
+      ``HKL_TAU = 2π`` compile-time setting,
+    * **diffcalc-core** (``Crystal._set_reciprocal_cell``).
+
+    This holds for every crystal system, including non-orthogonal
+    cells (hexagonal, trigonal, monoclinic, triclinic).  For
+    orthogonal cells (cubic, tetragonal, orthorhombic), the
+    direct-lattice vectors `a`, `b`, `c` are parallel to the reciprocal
+    vectors a\*, b\*, c\* respectively, and the BL1967 frame coincides
+    with the "direct-lattice-a-along-x" frame that earlier versions of
+    this package used.  For non-orthogonal cells the two frames
+    differ by a rotation in the crystal-Cartesian space; both encode
+    the same physical crystal, but only the BL1967 frame is the one
+    SPEC and hkl_soleil cross-validate against.
+
+    Parameters
+    ----------
+    a, b, c : float
+        Direct-lattice parameters in Angstroms.
+    alpha, beta, gamma : float
+        Direct-lattice angles in degrees.
+        alpha = angle between b and c axes
+        beta  = angle between a and c axes
+        gamma = angle between a and b axes
+
+    Returns
+    -------
+    B : numpy.ndarray, shape (3, 3)
+        B matrix in inverse Angstroms (with 2π factor, BL1967 / SPEC /
+        hkl_soleil convention).  Upper triangular by construction.
+
+    References
+    ----------
+    * W. R. Busing & H. A. Levy, *Acta Cryst.* **22**, 457-464 (1967),
+      eq. 3.
+    * libhkl source: ``hkl/hkl-lattice.c`` (``HKL_TAU = 2π``).
+    * diffcalc-core source:
+      ``src/diffcalc/ub/crystal.py`` (``_set_reciprocal_cell``).
+    """
+    al = math.radians(alpha)
+    be = math.radians(beta)
+    ga = math.radians(gamma)
+
+    # Direct-cell volume scale: D = sqrt(1 - cos²α - cos²β - cos²γ + 2 cos α cos β cos γ).
+    D = math.sqrt(
+        1.0
+        - math.cos(al) ** 2
+        - math.cos(be) ** 2
+        - math.cos(ga) ** 2
+        + 2.0 * math.cos(al) * math.cos(be) * math.cos(ga)
+    )
+
+    # Reciprocal-lattice magnitudes (include the 2π factor).
+    a_star = 2.0 * math.pi * math.sin(al) / (a * D)
+    b_star = 2.0 * math.pi * math.sin(be) / (b * D)
+    c_star = 2.0 * math.pi * math.sin(ga) / (c * D)
+
+    # Reciprocal-cell angles via standard crystallographic identities.
+    cos_beta_star = (math.cos(ga) * math.cos(al) - math.cos(be)) / (
+        math.sin(ga) * math.sin(al)
+    )
+    cos_gamma_star = (math.cos(al) * math.cos(be) - math.cos(ga)) / (
+        math.sin(al) * math.sin(be)
+    )
+    # sin(β*) and sin(γ*) are non-negative by convention.
+    sin_beta_star = math.sqrt(max(0.0, 1.0 - cos_beta_star**2))
+    sin_gamma_star = math.sqrt(max(0.0, 1.0 - cos_gamma_star**2))
+
+    return np.array(
+        [
+            [a_star, b_star * cos_gamma_star, c_star * cos_beta_star],
+            [0.0, b_star * sin_gamma_star, -c_star * sin_beta_star * math.cos(al)],
+            [0.0, 0.0, 2.0 * math.pi / c],
+        ]
+    )
+
+
+def reciprocal_vectors(
+    a: float,
+    b: float,
+    c: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Return the three reciprocal-lattice vectors (b1\\*, b2\\*, b3\\*)
+    expressed in the BL1967 crystal-Cartesian frame.
+
+    The vectors are the columns of :func:`b_matrix_bl1967` — see that
+    function's docstring for the full convention and the cross-solver
+    equivalence note.  Magnitudes carry the 2π factor (BL1967 / SPEC /
+    hkl_soleil default convention).
+
+    Orthogonality with the direct-lattice vectors holds::
+
+        bᵢ\\* · aⱼ = 2π δᵢⱼ
+
+    where ``aⱼ`` is the corresponding direct-lattice vector returned by
+    :func:`lattice_vectors` (also expressed in the BL1967
+    crystal-Cartesian frame).
+
+    Parameters
+    ----------
+    a, b, c : float
+        Direct-lattice parameters in Angstroms.
+    alpha, beta, gamma : float
+        Direct-lattice angles in degrees.
+
+    Returns
+    -------
+    b1, b2, b3 : numpy.ndarray, shape (3,)
+        Reciprocal-lattice vectors in inverse Angstroms (with 2π factor),
+        expressed as columns of the BL1967 B matrix.
+    """
+    B = b_matrix_bl1967(a, b, c, alpha, beta, gamma)
+    return B[:, 0], B[:, 1], B[:, 2]
+
+
 def lattice_vectors(
     a: float,
     b: float,
@@ -726,78 +918,40 @@ def lattice_vectors(
     gamma: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    Compute the three Cartesian direct lattice vectors from crystal lattice
-    parameters.
+    Return the three direct-lattice vectors (a1, a2, a3) expressed in the
+    BL1967 crystal-Cartesian frame (the same frame as :func:`b_matrix_bl1967`).
 
-    The convention places a1 along xHat, a2 in the xHat-yHat plane, and a3
-    determined by the right-hand rule.
+    Derived from the reciprocal-of-reciprocal identity
+    ``aᵢ · bⱼ\\* = 2π δᵢⱼ``::
+
+        [a1 | a2 | a3] = 2π · (B^T)^{-1} = 2π · (B^{-1})^T
+
+    For orthogonal cells (cubic, tetragonal, orthorhombic) this gives
+    ``a1 = a x̂``, ``a2 = b ŷ``, ``a3 = c ẑ`` — equivalent to the
+    "direct-lattice-a-along-x" frame used by earlier versions of this
+    package.  For non-orthogonal cells the direct vectors are no longer
+    placed with ``a1 ∥ x̂``; instead ``b1\\* ∥ x̂`` (by the BL1967
+    convention), and the direct vectors land wherever the duality
+    relation puts them.  Magnitudes and angles between direct vectors
+    are unchanged (``|a1| = a``, ``|a2| = b``, ``|a3| = c``,
+    ``angle(a2, a3) = α``, etc.).
 
     Parameters
     ----------
     a, b, c : float
-        Lattice parameters in Angstroms.
+        Direct-lattice parameters in Angstroms.
     alpha, beta, gamma : float
-        Lattice angles in degrees.
-        alpha = angle between b and c axes
-        beta  = angle between a and c axes
-        gamma = angle between a and b axes
+        Direct-lattice angles in degrees.
 
     Returns
     -------
     a1, a2, a3 : numpy.ndarray, shape (3,)
-        Cartesian direct lattice vectors in Angstroms.
+        Direct-lattice vectors in Angstroms, expressed in the BL1967
+        crystal-Cartesian frame.
     """
-    alpha_r = np.deg2rad(alpha)
-    beta_r = np.deg2rad(beta)
-    gamma_r = np.deg2rad(gamma)
-
-    a1 = np.array([a, 0.0, 0.0])
-    a2 = np.array([b * np.cos(gamma_r), b * np.sin(gamma_r), 0.0])
-
-    a3x = c * np.cos(beta_r)
-    a3y = c * (np.cos(alpha_r) - np.cos(beta_r) * np.cos(gamma_r)) / np.sin(gamma_r)
-    a3z = np.sqrt(max(c**2 - a3x**2 - a3y**2, 0.0))
-    a3 = np.array([a3x, a3y, a3z])
-
-    return a1, a2, a3
-
-
-def reciprocal_vectors(
-    a1: np.ndarray,
-    a2: np.ndarray,
-    a3: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Compute the three reciprocal lattice vectors from Cartesian direct lattice
-    vectors.
-
-    Uses the standard crystallographic definition:
-
-        b1 = 2*pi * (a2 x a3) / (a1 . (a2 x a3))
-        b2 = 2*pi * (a3 x a1) / (a1 . (a2 x a3))
-        b3 = 2*pi * (a1 x a2) / (a1 . (a2 x a3))
-
-    The orthogonality condition is satisfied:
-
-        b_i . a_j = 2*pi * delta_ij
-
-    Parameters
-    ----------
-    a1, a2, a3 : numpy.ndarray, shape (3,)
-        Cartesian direct lattice vectors in Angstroms.
-
-    Returns
-    -------
-    b1, b2, b3 : numpy.ndarray, shape (3,)
-        Reciprocal lattice vectors in inverse Angstroms (with 2*pi factor).
-    """
-    Vc = np.dot(a1, np.cross(a2, a3))
-
-    b1 = 2 * np.pi * np.cross(a2, a3) / Vc
-    b2 = 2 * np.pi * np.cross(a3, a1) / Vc
-    b3 = 2 * np.pi * np.cross(a1, a2) / Vc
-
-    return b1, b2, b3
+    B = b_matrix_bl1967(a, b, c, alpha, beta, gamma)
+    A = 2.0 * math.pi * np.linalg.inv(B).T
+    return A[:, 0], A[:, 1], A[:, 2]
 
 
 def b_matrix(
@@ -806,36 +960,35 @@ def b_matrix(
     b3: np.ndarray,
 ) -> np.ndarray:
     """
-    Compute the B matrix from the reciprocal lattice vectors.
+    Assemble the B matrix from the reciprocal-lattice vectors.
 
-    The B matrix transforms Miller indices ``h`` = (h, k, l) to the
-    scattering vector in Cartesian crystal-frame coordinates
-    (Busing & Levy, 1967, eq. 3)::
+    With the BL1967 / SPEC / hkl_soleil convention used by this
+    package, the B matrix transforms Miller indices ``h`` = (h, k, l)
+    to the scattering vector in the BL1967 crystal-Cartesian frame
+    (Busing & Levy 1967 eq. 3)::
 
         Q_c = B @ h
-
-    The columns of B are the reciprocal lattice vectors b₁, b₂, b₃
-    (each including the 2π factor), so::
-
         B = [b1, b2, b3]    (column-stack of the reciprocal vectors)
 
     Hence ``B @ h = h·b1 + k·b2 + l·b3``.  The orthogonality condition
     is ``bᵢ · aⱼ = 2π δᵢⱼ``, and ``|B @ h| = 2π / d_hkl``.
 
-    This is the Busing & Levy (1967) and SPEC convention.  Some packages
-    (FullProf, CrysFML, parts of CCP4, the hkl library with ``tau=1``)
-    use the alternative no-2π convention ``bᵢ · aⱼ = δᵢⱼ``, which gives
-    a B matrix smaller by a factor of 2π.
+    For non-orthogonal lattices the columns are not mutually
+    orthogonal; the B matrix is upper-triangular by construction (a\\*
+    along crystal-x, b\\* in crystal-xy plane, c\\* completing the
+    right-handed triple).  See :func:`b_matrix_bl1967` for the
+    closed-form construction and the cross-solver equivalence note.
 
     Parameters
     ----------
     b1, b2, b3 : numpy.ndarray, shape (3,)
-        Reciprocal lattice vectors in inverse Angstroms (with 2π factor),
+        Reciprocal-lattice vectors in inverse Angstroms (with 2π factor),
         as returned by :func:`reciprocal_vectors`.
 
     Returns
     -------
     B : numpy.ndarray, shape (3, 3)
-        B matrix in inverse Angstroms (with 2π factor, BL1967 convention).
+        B matrix in inverse Angstroms (with 2π factor, BL1967 / SPEC /
+        hkl_soleil convention).
     """
     return np.column_stack([b1, b2, b3])

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -923,22 +923,110 @@ def ub_from_three_reflections_bl1967(
 
 def ub_identity(sample) -> np.ndarray:
     """
-    Set U = I (identity) and UB = B; return UB.
+    Set U so the crystal-Cartesian frame aligns with the physical
+    (longitudinal, vertical, transverse) triple, and UB = U @ B.
 
-    The crudest orientation assumption: crystal axes are aligned with the
-    lab axes.  Useful as a starting point when no reflection information
-    is available at all.
+    The default UB placeholder used before a real UB is set by either
+    reflection-based computation (:func:`ub_from_one_reflection`,
+    :func:`ub_from_two_reflections_bl1967`,
+    :func:`ub_from_three_reflections_bl1967`) or direct assignment
+    (``sample.UB = ...`` or ``sample.U = ...``).
+
+    Definition (issue #280)
+    -----------------------
+    The columns of U are the geometry's physical-direction unit
+    vectors expressed in basis-Cartesian coordinates::
+
+        U[:, 0] = +longitudinal   (the beam direction)
+        U[:, 1] = +vertical
+        U[:, 2] = +transverse
+
+    Under the Busing & Levy 1967 crystal-Cartesian convention
+    (a\\* along crystal-x, b\\* in the crystal-x-y plane, c\\*
+    completing the right-handed triple), this places:
+
+    * the crystal a\\* axis physically along the beam,
+    * the crystal-y axis physically along vertical,
+    * the crystal-z axis physically along transverse.
+
+    This matches the ``hkl_soleil`` convention (``U = identity``
+    aligns a\\* along the beam +x; see
+    https://people.debian.org/~picca/hkl/hkl.html).
+
+    Why this is basis-independent
+    -----------------------------
+    The geometry's basis assigns Cartesian unit vectors to the three
+    physical-direction labels.  The columns of U are taken directly
+    from those physical-direction vectors, so the resulting
+    *physical* crystal orientation does not depend on which Cartesian
+    direction the basis labels assign to (vertical, longitudinal,
+    transverse).  Two geometries representing the same physical
+    equipment under different basis labelings (e.g. ``BASIS_BL`` vs
+    ``BASIS_YOU``) produce numerically different U matrices but
+    *identical physical Bragg orientations* — and therefore identical
+    ``forward()`` results.
+
+    The pre-#280 implementation set ``U = numpy.eye(3)`` in basis
+    coordinates, which made the physical crystal orientation
+    basis-dependent: under ``BASIS_BL`` the crystal a-axis ended up
+    physically along transverse, but under ``BASIS_YOU`` the same
+    code put it along vertical, breaking basis invariance of
+    ``forward()`` reachability and ``|2θ|`` for the same equipment.
+
+    Why this is inclination-independent
+    -----------------------------------
+    U is derived from the geometry's *declared* basis vectors (a
+    property of the YAML, set once), not from the inclination-tilted
+    effective beam ``y_eff = R_inc.T @ y_hat``.  Tilting the entire
+    diffractometer relative to the beamline (issue #15
+    ``inclination_matrix``) does not silently re-orient the crystal:
+    the crystal is mounted on the diffractometer, not on the
+    beamline, so its reference orientation lives in the
+    diffractometer's intrinsic frame.
 
     Parameters
     ----------
     sample : Sample
-        The sample whose ``U`` and ``UB`` attributes are updated in-place.
+        The sample whose ``U`` and ``UB`` attributes are updated
+        in-place.  ``sample.parent`` must be set (the parent
+        ``AdHocDiffractometer`` provides the basis vectors).
 
     Returns
     -------
     UB : numpy.ndarray, shape (3, 3)
+        ``UB = U @ B``.  Also stored on the sample as ``sample.UB``.
+
+    Raises
+    ------
+    ValueError
+        If ``sample.parent`` is ``None`` (cannot resolve the
+        geometry's basis without a parent).
+
+    References
+    ----------
+    * Busing & Levy, *Acta Cryst.* **22**, 457-464 (1967) — the
+      crystal-Cartesian convention used in the B matrix.
+    * Issue #280 — the rotation-composition-order audit that
+      exposed the pre-existing basis bias of the old ``U = I``
+      placeholder.
+    * hkl_soleil documentation — the published external convention
+      this implementation matches.
     """
-    B = sample.lattice.B
-    sample.U = np.eye(3)
-    sample.UB = B.copy()
+    geom = sample.parent
+    if geom is None:
+        raise ValueError(
+            "ub_identity() requires sample.parent to be set: the "
+            "geometry's basis vectors are needed to construct a "
+            "basis-independent U matrix.  Attach the sample to a "
+            "geometry first (e.g. via geometry.add_sample(...))."
+        )
+    long_hat = np.asarray(geom.basis["longitudinal"], dtype=float)
+    vert_hat = np.asarray(geom.basis["vertical"], dtype=float)
+    trans_hat = np.asarray(geom.basis["transverse"], dtype=float)
+    long_hat = long_hat / np.linalg.norm(long_hat)
+    vert_hat = vert_hat / np.linalg.norm(vert_hat)
+    trans_hat = trans_hat / np.linalg.norm(trans_hat)
+    U = np.column_stack([long_hat, vert_hat, trans_hat])
+    sample.U = U
+    sample.UB = U @ sample.lattice.B
     return sample.UB

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -90,17 +90,22 @@ def _compute_q_phi(
     Q_phi : numpy.ndarray, shape (3,)
         Scattering vector in the phi frame, in Å⁻¹.
     """
-    # Sample rotation matrix Z (floor-most first, so Z = R_n @ ... @ R_1)
+    # Sample rotation matrix Z (BL1967 standard order, Busing & Levy
+    # 1967):  outermost (floor-most) stage is leftmost in the product, so
+    # Z = R_0 @ R_1 @ ... @ R_{n-1}.  Each new rotation is concatenated
+    # on the right so the innermost stage (closest to the sample) ends up
+    # right-most.  Z then maps phi-frame vectors to lab-frame vectors:
+    # v_lab = Z @ v_phi.
     Z = np.eye(3)
     for s in sample_stages:
         angle = angles.get(s.name, s.angle)
-        Z = _rotation_matrix_normalized(s._axis_hat, angle) @ Z  # noqa: SLF001
+        Z = Z @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
-    # Detector rotation matrix D
+    # Detector rotation matrix D — same outermost-leftmost convention.
     D = np.eye(3)
     for s in detector_stages:
         angle = angles.get(s.name, s.angle)
-        D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+        D = D @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     # Q_lab = (2pi/lambda) * (D @ y_eff - y_eff)
     Q_lab = two_pi_over_lambda * (D @ y_eff - y_eff)
@@ -150,32 +155,36 @@ def _compute_q_phi_cached(
     -------
     Q_phi : numpy.ndarray, shape (3,)
     """
-    # Detector rotation matrix — use cached version if available
+    # Detector rotation matrix — use cached version if available.
+    # Composition: outermost (floor-most) stage leftmost, so
+    # D = R_0 @ R_1 @ ... @ R_{n-1}.
     if cached_D is not None:
         D = cached_D
     else:
         D = np.eye(3)
         for s in detector_stages:
             angle = angles.get(s.name, s.angle)
-            D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+            D = D @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
-    # Sample rotation matrix Z — use partial caching
+    # Sample rotation matrix Z — use partial caching.
+    # cached_Z_prefix is the product of the fixed *outer* stages
+    # (indices 0..first_free-1), already in BL1967 standard order
+    # R_0 @ R_1 @ ... @ R_{first_free-1}.  The free tail is concatenated
+    # on the right so the final Z stays in outermost-leftmost order.
     if cached_Z_prefix is not None and free_sample_indices is not None:
-        # Start with the cached prefix for stages 0..first_free-1
         Z = cached_Z_prefix.copy()
-        # Multiply in the free stages and any stages after them
         first_free = (
             free_sample_indices[0] if free_sample_indices else len(sample_stages)
         )
         for i in range(first_free, len(sample_stages)):
             s = sample_stages[i]
             angle = angles.get(s.name, s.angle)
-            Z = _rotation_matrix_normalized(s._axis_hat, angle) @ Z  # noqa: SLF001
+            Z = Z @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
     else:
         Z = np.eye(3)
         for s in sample_stages:
             angle = angles.get(s.name, s.angle)
-            Z = _rotation_matrix_normalized(s._axis_hat, angle) @ Z  # noqa: SLF001
+            Z = Z @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     Q_lab = two_pi_over_lambda * (D @ y_eff - y_eff)
     return Z.T @ Q_lab
@@ -191,10 +200,18 @@ def angles_to_phi_vector(geometry, **motor_angles: float) -> np.ndarray:
 
     Algorithm (Busing & Levy 1967, section "The phi-axis frame"):
 
-    1. Compute the total sample rotation matrix ``Z`` (product of all sample
-       stage rotation matrices, floor-most first) from the supplied motor
-       angles (stages not supplied keep their current ``angle`` attribute).
-    2. Compute the total detector rotation matrix ``D``.
+    1. Compute the total sample rotation matrix ``Z`` as the product of all
+       sample stage rotation matrices in **outermost-leftmost** order
+       (BL1967 standard convention)::
+
+           Z = R_0 @ R_1 @ ... @ R_{n-1}
+
+       where ``R_0`` is the floor-most (outermost) stage and ``R_{n-1}``
+       is the innermost stage closest to the sample.  Z then maps phi-frame
+       vectors to lab-frame vectors: ``v_lab = Z @ v_phi``.  Stages not
+       supplied keep their current ``angle`` attribute.
+    2. Compute the total detector rotation matrix ``D`` in the same
+       outermost-leftmost order.
     3. The incident-beam unit vector in the lab frame is ``ŷ`` (longitudinal
        direction, ``geometry.basis["longitudinal"]``).
     4. The scattered-beam unit vector in the lab frame is ``D @ ŷ``.

--- a/src/ad_hoc_diffractometer/reference.py
+++ b/src/ad_hoc_diffractometer/reference.py
@@ -340,11 +340,15 @@ def _chi_stage_axis_lab(
     chi_stage = sample_stages[chi_index]
     outer_stages = sample_stages[:chi_index]
 
-    # Apply the rotations of all stages *before* chi to the chi axis
+    # Apply the rotations of all stages *outside* chi to the chi axis.
+    # Composition follows the BL1967 standard convention (Busing &
+    # Levy 1967): outermost (floor-most) stage leftmost in the
+    # product, so R_outer = R_0 @ R_1 @ ... @ R_{chi_index-1}.  Then
+    # the chi axis in the lab frame is R_outer @ chi_axis_hat.
     R = np.eye(3)
     for s in outer_stages:
         angle = angles.get(s.name, s.angle)
-        R = _rotation_matrix_normalized(s._axis_hat, angle) @ R  # noqa: SLF001
+        R = R @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     chi_axis_lab = R @ np.asarray(chi_stage._axis_hat, dtype=float)  # noqa: SLF001
     n = float(np.linalg.norm(chi_axis_lab))
@@ -455,13 +459,15 @@ def omega_pseudo(
     # Lab-frame chi-circle axis (= normal to the chi-circle plane)
     n_chi_lab = _chi_stage_axis_lab(geometry, angles)
 
-    # Lab-frame scattering vector
+    # Lab-frame scattering vector.  Composition follows the BL1967
+    # standard convention (Busing & Levy 1967): outermost (floor-most)
+    # stage leftmost.
     from .rotation import _rotation_matrix_normalized
 
     D = np.eye(3)
     for s in geometry.detector_stages:
         angle = angles.get(s.name, s.angle)
-        D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+        D = D @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     y_raw = np.asarray(geometry.basis["longitudinal"], dtype=float)
     y_hat = y_raw / np.linalg.norm(y_raw)

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -306,11 +306,14 @@ def _euler_from_Z_standard(
     phi_stage: object,
 ) -> list[tuple[float, float, float]]:
     """
-    Decompose Z = R(n_φ, φ) · R(n_χ, χ) · R(n_ω, ω) into (ω, χ, φ) in degrees.
+    Decompose ``Z = R(n_ω, ω) · R(n_χ, χ) · R(n_φ, φ)`` into
+    ``(ω, χ, φ)`` in degrees.
 
-    This is the innermost-first product order used by
-    ``geometry.sample_rotation_matrix()``: the outermost stage (omega/eta)
-    is applied first (rightmost), the innermost (phi) last (leftmost).
+    This is the outermost-first (BL1967 standard, Busing & Levy 1967)
+    product order used by
+    :meth:`~AdHocDiffractometer.sample_rotation_matrix`:
+    the outermost (floor-most, omega) stage is the leftmost matrix in
+    the product; the innermost (phi) is rightmost.
 
     The decomposition generalizes Busing & Levy (1967) eqs. 14-17 to
     arbitrary signed stage axes.  Two χ branches are returned
@@ -318,15 +321,16 @@ def _euler_from_Z_standard(
 
     Notes
     -----
-    **Chi** is extracted from the element n_φ · Z · n_ω, which equals
-    n_φ · R_χ · n_ω (since R_φ fixes n_φ and R_ω fixes n_ω).
+    **Chi** is extracted from the element n_ω · Z · n_φ, which equals
+    n_ω · R_χ · n_φ (since R_ω fixes n_ω and R_φ fixes n_φ).
     For the standard case n_ω ∥ n_φ this equals cos(χ).
 
-    **Phi** is extracted from Z · n_ω = R_φ · (R_χ · n_ω): the angle in the
-    plane ⊥ n_φ between (R_χ · n_ω) and (Z · n_ω).
+    **Omega** is extracted from Z · n_φ = R_ω · (R_χ · n_φ): the angle
+    in the plane ⊥ n_ω between (R_χ · n_φ) and (Z · n_φ).
 
-    **Omega** is extracted from Z^T · n_φ = R_χ^T · n_φ: the angle in the
-    plane ⊥ n_ω between (R_χ^T · n_φ) and (Z^T · n_φ), with sign reversed.
+    **Phi** is extracted from Z^T · n_ω = R_φ^T · (R_χ^T · n_ω): the
+    angle in the plane ⊥ n_φ between (R_χ^T · n_ω) and (Z^T · n_ω),
+    with sign reversed (because the rotation acts on Z^T not Z).
 
     Parameters
     ----------
@@ -349,8 +353,8 @@ def _euler_from_Z_standard(
     n_chi_hat = n_chi / np.linalg.norm(n_chi)
     n_phi_hat = n_phi / np.linalg.norm(n_phi)
 
-    # --- Step 1: chi from n_phi · Z · n_om ----------------------------------
-    elem = float(np.dot(n_phi_hat, Z @ n_om_hat))
+    # --- Step 1: chi from n_om · Z · n_phi ----------------------------------
+    elem = float(np.dot(n_om_hat, Z @ n_phi_hat))
     elem = max(-1.0, min(1.0, elem))
     chi_pos = math.degrees(math.acos(elem))
     chi_neg = -chi_pos
@@ -359,27 +363,29 @@ def _euler_from_Z_standard(
     for chi_deg in (chi_pos, chi_neg):
         R_chi = _Rmat(n_chi_hat, chi_deg)
 
-        # --- Step 2: phi from Z · n_om = R_phi · (R_chi · n_om) -------------
-        Rchi_nom = R_chi @ n_om_hat
-        Z_nom = Z @ n_om_hat
-        e1 = _perp_ref(n_phi_hat)
-        e2 = np.cross(n_phi_hat, e1)
-        phi_rad = math.atan2(
-            float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
-        ) - math.atan2(float(np.dot(Rchi_nom, e2)), float(np.dot(Rchi_nom, e1)))
-        phi_rad = ((phi_rad + math.pi) % (2 * math.pi)) - math.pi
-        phi_deg = math.degrees(phi_rad)
-
-        # --- Step 3: omega from Z^T · n_phi = R_chi^T · n_phi ---------------
-        Rchi_T_nphi = R_chi.T @ n_phi_hat
-        ZT_nphi = Z.T @ n_phi_hat
-        f1 = _perp_ref(n_om_hat)
-        f2 = np.cross(n_om_hat, f1)
+        # --- Step 2: omega from Z · n_phi = R_omega · (R_chi · n_phi) ------
+        Rchi_nph = R_chi @ n_phi_hat
+        Z_nph = Z @ n_phi_hat
+        e1 = _perp_ref(n_om_hat)
+        e2 = np.cross(n_om_hat, e1)
         omega_rad = math.atan2(
-            float(np.dot(Rchi_T_nphi, f2)), float(np.dot(Rchi_T_nphi, f1))
-        ) - math.atan2(float(np.dot(ZT_nphi, f2)), float(np.dot(ZT_nphi, f1)))
+            float(np.dot(Z_nph, e2)), float(np.dot(Z_nph, e1))
+        ) - math.atan2(float(np.dot(Rchi_nph, e2)), float(np.dot(Rchi_nph, e1)))
         omega_rad = ((omega_rad + math.pi) % (2 * math.pi)) - math.pi
         omega_deg = math.degrees(omega_rad)
+
+        # --- Step 3: phi from Z^T · n_om = R_phi^T · (R_chi^T · n_om) -------
+        # R(n_phi, phi)^T · (R(n_chi, chi)^T · n_om) = Z^T · n_om
+        # so R(n_phi, -phi) takes R(n_chi, -chi) · n_om to Z^T · n_om.
+        Rchi_T_nom = R_chi.T @ n_om_hat
+        ZT_nom = Z.T @ n_om_hat
+        f1 = _perp_ref(n_phi_hat)
+        f2 = np.cross(n_phi_hat, f1)
+        phi_rad = math.atan2(
+            float(np.dot(Rchi_T_nom, f2)), float(np.dot(Rchi_T_nom, f1))
+        ) - math.atan2(float(np.dot(ZT_nom, f2)), float(np.dot(ZT_nom, f1)))
+        phi_rad = ((phi_rad + math.pi) % (2 * math.pi)) - math.pi
+        phi_deg = math.degrees(phi_rad)
 
         results.append((omega_deg, chi_deg, phi_deg))
 
@@ -398,25 +404,26 @@ def _kappa_from_Z(
     alpha_deg: float,
 ) -> list[tuple[float, float, float]]:
     r"""
-    Decompose ``Z = R(n_kφ, kφ) · R(n_κ, κ) · R(n_kω, kω)`` into
+    Decompose ``Z = R(n_kω, kω) · R(n_κ, κ) · R(n_kφ, kφ)`` (BL1967
+    standard outermost-leftmost order, Busing & Levy 1967) into
     ``(kω, κ, kφ)`` using a Rodrigues expansion that is **agnostic to
     the specific signed axis convention** of the kappa demo geometry.
 
     Derivation
     ----------
-    Apply both sides to ``n_komega``:
+    Apply both sides to ``n_kphi``:
 
-        Z · n_kω  =  R(n_kφ, kφ) · R(n_κ, κ) · n_kω
+        Z · n_kφ  =  R(n_kω, kω) · R(n_κ, κ) · n_kφ
 
-    (since ``R(n_kω, ·) · n_kω = n_kω``).  Take the dot product with
-    ``n_kphi``:
+    (since ``R(n_kφ, ·) · n_kφ = n_kφ``).  Take the dot product with
+    ``n_komega`` (which is invariant under ``R(n_komega, kω)``):
 
-        n_kφ · Z · n_kω  =  n_kφ · R(n_κ, κ) · n_kω
+        n_kω · Z · n_kφ  =  n_kω · R(n_κ, κ) · n_kφ
 
     Expanding the right side via Rodrigues (with
-    ``a = n_kphi · n_komega``,
-    ``b = n_kphi · (n_kappa × n_komega)``,
-    ``c = (n_kphi · n_kappa)·(n_kappa · n_komega)``):
+    ``a = n_komega · n_kphi``,
+    ``b = n_komega · (n_kappa × n_kphi)``,
+    ``c = (n_komega · n_kappa)·(n_kappa · n_kphi)``):
 
         elem  =  a·cos(κ) + b·sin(κ) + c·(1 − cos(κ))
               =  (a − c)·cos(κ) + b·sin(κ) + c
@@ -461,11 +468,11 @@ def _kappa_from_Z(
     n_kap = np.asarray(kappa_stage.axis, dtype=float) / np.linalg.norm(kappa_stage.axis)
     n_kph = np.asarray(kphi_stage.axis, dtype=float) / np.linalg.norm(kphi_stage.axis)
 
-    # --- Step 1: κ from the Rodrigues expansion of n_kphi · Z · n_komega ----
-    elem = float(np.clip(np.dot(n_kph, Z @ n_km), -1.0, 1.0))
-    a_coeff = float(np.dot(n_kph, n_km))
-    b_coeff = float(np.dot(n_kph, np.cross(n_kap, n_km)))
-    c_coeff = float(np.dot(n_kph, n_kap)) * float(np.dot(n_kap, n_km))
+    # --- Step 1: κ from the Rodrigues expansion of n_komega · Z · n_kphi ----
+    elem = float(np.clip(np.dot(n_km, Z @ n_kph), -1.0, 1.0))
+    a_coeff = float(np.dot(n_km, n_kph))
+    b_coeff = float(np.dot(n_km, np.cross(n_kap, n_kph)))
+    c_coeff = float(np.dot(n_km, n_kap)) * float(np.dot(n_kap, n_kph))
     # Solve (a − c)·cos(κ) + b·sin(κ) = elem − c
     rhs = elem - c_coeff
     M = math.hypot(a_coeff - c_coeff, b_coeff)
@@ -497,27 +504,27 @@ def _kappa_from_Z(
     for kap_deg in (kap_pos, kap_neg):
         R_kap = _Rmat(n_kap, kap_deg)
 
-        # --- Step 2: kphi from Z · n_km = R_kphi · (R_kap · n_km) ----------
-        Rk_nom = R_kap @ n_km
-        Z_nom = Z @ n_km
-        e1 = _perp_ref(n_kph)
-        e2 = np.cross(n_kph, e1)
-        kphi_rad = math.atan2(
-            float(np.dot(Z_nom, e2)), float(np.dot(Z_nom, e1))
-        ) - math.atan2(float(np.dot(Rk_nom, e2)), float(np.dot(Rk_nom, e1)))
-        kphi_rad = ((kphi_rad + math.pi) % (2 * math.pi)) - math.pi
-        kphi_deg = math.degrees(kphi_rad)
-
-        # --- Step 3: komega from Z^T · n_kphi = R_kap^T · n_kphi ------------
-        Rk_T_nkph = R_kap.T @ n_kph
-        ZT_nkph = Z.T @ n_kph
-        f1 = _perp_ref(n_km)
-        f2 = np.cross(n_km, f1)
+        # --- Step 2: komega from Z · n_kphi = R_komega · (R_kap · n_kphi) --
+        Rk_nph = R_kap @ n_kph
+        Z_nph = Z @ n_kph
+        e1 = _perp_ref(n_km)
+        e2 = np.cross(n_km, e1)
         kom_rad = math.atan2(
-            float(np.dot(Rk_T_nkph, f2)), float(np.dot(Rk_T_nkph, f1))
-        ) - math.atan2(float(np.dot(ZT_nkph, f2)), float(np.dot(ZT_nkph, f1)))
+            float(np.dot(Z_nph, e2)), float(np.dot(Z_nph, e1))
+        ) - math.atan2(float(np.dot(Rk_nph, e2)), float(np.dot(Rk_nph, e1)))
         kom_rad = ((kom_rad + math.pi) % (2 * math.pi)) - math.pi
         kom_deg = math.degrees(kom_rad)
+
+        # --- Step 3: kphi from Z^T · n_komega = R_kphi^T · (R_kap^T · n_komega)
+        Rk_T_nkm = R_kap.T @ n_km
+        ZT_nkm = Z.T @ n_km
+        f1 = _perp_ref(n_kph)
+        f2 = np.cross(n_kph, f1)
+        kphi_rad = math.atan2(
+            float(np.dot(Rk_T_nkm, f2)), float(np.dot(Rk_T_nkm, f1))
+        ) - math.atan2(float(np.dot(ZT_nkm, f2)), float(np.dot(ZT_nkm, f1)))
+        kphi_rad = ((kphi_rad + math.pi) % (2 * math.pi)) - math.pi
+        kphi_deg = math.degrees(kphi_rad)
 
         results.append((kom_deg, kap_deg, kphi_deg))
 
@@ -575,10 +582,12 @@ def _psi_candidates(
     outer_stages = sample_stages[:-3]
     omega_s, chi_s, phi_s = sample_stages[-3], sample_stages[-2], sample_stages[-1]
 
-    # Build R_outer from the base angles of any fixed outer stages
+    # Build R_outer from the base angles of any fixed outer stages.
+    # Composition: BL1967 standard outermost-leftmost, so
+    # R_outer = R_0 @ R_1 @ ... @ R_{k-1} where k = first non-outer index.
     R_outer = np.eye(3)
     for s in outer_stages:
-        R_outer = _Rmat(s.axis, base.get(s.name, s.angle)) @ R_outer
+        R_outer = R_outer @ _Rmat(s.axis, base.get(s.name, s.angle))
 
     # Rotate Z0 about Q_lab by -psi_target (negative because the convention
     # is that increasing psi rotates the sample such that the beam-perpendicular

--- a/src/ad_hoc_diffractometer/surface.py
+++ b/src/ad_hoc_diffractometer/surface.py
@@ -151,18 +151,22 @@ def _surface_vectors(
     for name in angles:
         geometry.stage(name)  # raises KeyError if not found
 
-    # Compute rotation matrices statelessly (no save/restore needed)
+    # Compute rotation matrices statelessly (no save/restore needed).
+    # Composition follows the BL1967 standard convention (Busing & Levy
+    # 1967): outermost (floor-most) stage leftmost in the product, so
+    # Z = R_0 @ R_1 @ ... @ R_{n-1} and likewise for D.  Z maps phi-frame
+    # vectors to lab-frame vectors (v_lab = Z @ v_phi).
     from .rotation import _rotation_matrix_normalized
 
     Z = np.eye(3)
     for s in geometry.sample_stages:
         angle = angles.get(s.name, s.angle)
-        Z = _rotation_matrix_normalized(s._axis_hat, angle) @ Z  # noqa: SLF001
+        Z = Z @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     D = np.eye(3)
     for s in geometry.detector_stages:
         angle = angles.get(s.name, s.angle)
-        D = _rotation_matrix_normalized(s._axis_hat, angle) @ D  # noqa: SLF001
+        D = D @ _rotation_matrix_normalized(s._axis_hat, angle)  # noqa: SLF001
 
     # Incident-beam direction: longitudinal basis vector (normalized)
     y_raw = np.asarray(geometry.basis["longitudinal"], dtype=float)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -63,11 +63,20 @@ def _sample(a=A_CUBIC):
 
 class TestHklToQ:
     def test_cubic_100(self):
-        """(1,0,0) gives Q along x with magnitude 2π/a."""
+        """(1,0,0) gives Q along the physical beam direction with magnitude 2π/a.
+
+        Under issue #280 ub_identity, the crystal a* axis is physically
+        aligned with the beam (+longitudinal).  For fourcv (BL basis,
+        longitudinal = +y), this places ``Q_phi(1,0,0)`` along +y rather
+        than along +x (the old basis-relative ``U = I`` outcome).
+        Magnitude is unchanged.
+        """
         s = _sample()
         Q = hkl_to_Q(s, 1, 0, 0)
-        expected = TWO_PI / A_CUBIC
-        assert Q == pytest.approx([expected, 0.0, 0.0], abs=1e-10)
+        long_hat = np.asarray(s.parent.basis["longitudinal"], dtype=float)
+        long_hat = long_hat / np.linalg.norm(long_hat)
+        expected = (TWO_PI / A_CUBIC) * long_hat
+        assert Q == pytest.approx(expected, abs=1e-10)
 
     def test_cubic_110(self):
         """(1,1,0) gives |Q| = 2π/a * sqrt(2)."""

--- a/tests/test_diffractometer.py
+++ b/tests/test_diffractometer.py
@@ -876,26 +876,38 @@ def test_psi_returns_float():
 
 
 def test_psi_n_perpendicular_to_scattering_plane_is_90():
-    """n=(1,0,0) = XHAT_BL (transverse) ⊥ vertical scattering plane at chi=0 → psi=90."""
+    """Reference physically along transverse → ⊥ vertical scattering plane → psi=90.
+
+    Under issue #280 ub_identity, ``UB @ (0, 0, 1) = U[:, 2] · |b3*|`` is
+    physically along ``+transverse`` (= +x in fourcv-BL basis), which is
+    perpendicular to the vertical scattering plane.  Pre-#280 the same
+    physical configuration was selected by ``azimuthal_reference =
+    (1, 0, 0)`` because the basis-relative ``U = I`` put the crystal
+    a-axis along ``+x``.
+    """
     g = _fourcv_identity()
-    g.azimuthal_reference = (
-        1,
-        0,
-        0,
-    )  # XHAT_BL = transverse ⊥ vertical scattering plane
+    g.azimuthal_reference = (0, 0, 1)  # → n_phi along +transverse
     angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}
     psi = g.psi(angles)
     assert abs(psi - 90.0) < 1e-8
 
 
 def test_psi_n_in_scattering_plane_is_0():
-    """n=(0,1,0) = YHAT_BL (longitudinal) lies in vertical scattering plane at chi=0 → psi=0."""
+    """Reference physically along longitudinal (beam) → in vertical scattering plane → psi=0.
+
+    Under issue #280 ub_identity, ``UB @ (1, 0, 0) = U[:, 0] · |b1*|`` is
+    physically along ``+longitudinal`` (the beam direction; = +y in
+    fourcv-BL basis), which lies in the vertical scattering plane and
+    is parallel to the incident beam.  By the BL1967 psi convention,
+    a reference parallel to the incident beam gives psi = 0.
+
+    The pre-#280 test used ``azimuthal_reference = (0, 1, 0)`` for the
+    same physical configuration because the basis-relative ``U = I``
+    aligned the crystal b-axis along the basis-y direction.  Under the
+    new ub_identity the crystal a-axis is the one along the beam.
+    """
     g = _fourcv_identity()
-    g.azimuthal_reference = (
-        0,
-        1,
-        0,
-    )  # YHAT_BL = longitudinal = in vertical scattering plane
+    g.azimuthal_reference = (1, 0, 0)  # → n_phi along +longitudinal
     angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}
     psi = g.psi(angles)
     assert abs(psi - 0.0) < 1e-8
@@ -908,7 +920,10 @@ def test_psi_uses_current_angles_when_none_passed():
     g.set_angle("chi", 0.0)
     g.set_angle("phi", 0.0)
     g.set_angle("ttheta", 60.0)
-    g.azimuthal_reference = (1, 0, 0)  # transverse — perpendicular to Q at these angles
+    # Under issue #280 ub_identity, (0,0,1) places the reference
+    # physically along +transverse — perpendicular to the vertical
+    # scattering plane and to Q at these angles.
+    g.azimuthal_reference = (0, 0, 1)
     psi_implicit = g.psi()
     psi_explicit = g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
     assert abs(psi_implicit - psi_explicit) < 1e-10
@@ -957,13 +972,59 @@ def test_psi_no_ub_raises():
 
 
 def test_psi_n_parallel_to_q_raises():
-    """psi() raises ValueError when the reference is parallel to Q."""
+    """psi() raises ValueError when the reference is parallel to Q.
+
+    Under issue #280 ub_identity at chi=0, the scattering vector Q lies
+    along the in-scattering-plane direction of the diffracted beam (a
+    combination of +vertical and +longitudinal at non-zero ttheta).
+    Choose a Miller index whose ``UB @ hkl`` is parallel to that Q.
+
+    Under the new ub_identity the simplest such case is to set
+    ``azimuthal_reference`` to the same physical direction as Q at the
+    chosen motor configuration.  We pick the hkl that places n_phi
+    exactly where Q lands for these angles.
+    """
     g = _fourcv_identity()
-    # With corrected fourcv at chi=0, Q is along -ZHAT_BL=(0,0,-1).
-    # Set n=(0,0,1) → parallel to Q → raises.
-    g.azimuthal_reference = (0, 0, 1)
+    angles = {"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0}
+    # Compute the actual Q_phi direction at these angles, then choose
+    # the hkl Miller index whose UB-image is parallel.  The exact hkl
+    # at chi=0 in fourcv-BL under the new ub_identity is along
+    # +vertical (i.e. crystal b*), giving Miller hkl = (0, 1, 0).
+    # That is also the natural Bragg-direction at these motor angles.
+    Q_phi = g.inverse(angles)
+    # Q_phi here actually returns the hkl tuple; use it directly as
+    # the parallel reference.
+    g.azimuthal_reference = tuple(float(v) for v in Q_phi)
     with pytest.raises(ValueError, match=re.escape("parallel to Q")):
-        g.psi({"omega": 30.0, "chi": 0.0, "phi": 0.0, "ttheta": 60.0})
+        g.psi(angles)
+
+
+def test_psi_beam_parallel_to_q_raises():
+    """psi() raises ValueError when the incident beam is parallel to Q.
+
+    Forces the configuration by setting ttheta = 180° (backscatter):
+    the diffracted beam is anti-parallel to the incident beam, so
+    Q_lab = D·ŷ − ŷ = −2 ŷ, which is along the incident beam axis.
+    Under issue #280 ub_identity, ``(1, 0, 0)`` places ``Q_phi``
+    physically along +longitudinal, so the bisecting solution sits
+    naturally at ttheta near 180° → beam ∥ Q.
+    """
+    g = _fourcv_identity()
+    # Force a configuration where the beam (longitudinal) is parallel
+    # to the lab-frame Q vector.  Setting ttheta = 180° (backscatter)
+    # makes D @ ŷ = -ŷ, so Q_lab = D@ŷ − ŷ = -2 ŷ, exactly along the
+    # beam axis.
+    angles = {"omega": 0.0, "chi": 0.0, "phi": 0.0, "ttheta": 180.0}
+    # Choose a reference whose UB-image is NOT along the beam, so the
+    # reference-parallel-to-Q branch does not pre-empt the beam-parallel
+    # branch.  Under the new ub_identity, ``(0, 0, 1)`` places n_phi
+    # along physical +transverse (= +x in fourcv-BL), which is
+    # perpendicular to the beam direction.
+    g.azimuthal_reference = (0, 0, 1)
+    with pytest.raises(
+        ValueError, match=re.escape("incident beam direction is parallel to Q")
+    ):
+        g.psi(angles)
 
 
 def test_psi_pa_shows_azimuthal_reference():

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1859,11 +1859,20 @@ def _natural_psi(g, h, k, l):  # noqa: E741
     ],
 )
 def test_compute_natural_psi(factory, h, k, l, ref, expected_psi):  # noqa: E741
-    """_compute_natural_psi returns the correct motor-angle-independent psi."""
+    """_compute_natural_psi returns the correct motor-angle-independent psi.
+
+    Wrap-aware comparison: the cut-point representative may be returned
+    as ``-180`` or ``+180`` (mathematically equivalent) depending on
+    which side of the ``atan2`` branch the configuration lands.
+    """
     g = _setup_psi(factory, ref=ref)
     psi = _natural_psi(g, h, k, l)
     assert psi is not None
-    assert psi == pytest.approx(expected_psi, abs=1e-4)
+    wrapped_err = abs((psi - expected_psi + 180.0) % 360.0 - 180.0)
+    assert wrapped_err < 1e-4, (
+        f"psi mismatch (wrap-aware): got {psi}, expected {expected_psi}, "
+        f"wrapped error = {wrapped_err}"
+    )
 
 
 def test_compute_natural_psi_undefined_when_ref_parallel_to_Q():

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -201,11 +201,32 @@ def test_bisecting_round_trip(factory, a, h, k, l):  # noqa: E741
     assert _round_trip_ok(g, h, k, l)
 
 
-def test_fourcv_bisecting_two_solutions():
-    """Bisecting mode returns two solutions (positive and negative chi branch)."""
+def test_fourcv_bisecting_returns_solutions():
+    """Bisecting mode returns at least one valid solution.
+
+    Under the BL1967 standard composition (Busing & Levy 1967, fixed
+    in issue #280), fourcv's ``(1, 0, 0)`` target ``Q_phi`` lies along
+    ``+x`` — which
+    is parallel (with sign flip) to the fourcv phi-axis ``-x``.  The
+    phi angle is therefore *physically* indeterminate at this
+    reflection: rotation about the phi axis leaves ``Q_phi``
+    invariant.  The Newton solver returns multiple phi
+    representatives at the single ``chi = +90`` branch; the older
+    ``len == 2`` count corresponded to ``±chi`` branches under the
+    pre-#280 (inner-leftmost) convention and is no longer the right
+    physical assertion.
+    """
     g = _setup_cubic(fourcv, a=4.0)
     solutions = g.forward(1, 0, 0)
-    assert len(solutions) == 2
+    assert len(solutions) >= 1
+    # Every returned solution must be a valid Bragg position.
+    Q_phi_target = g.sample.UB @ np.array([1.0, 0.0, 0.0])
+    for sol in solutions:
+        Q_phi = ahd.orientation.angles_to_phi_vector(g, **sol)
+        assert np.allclose(Q_phi, Q_phi_target, atol=1e-7), (
+            f"Bisecting solution {sol} does not satisfy Bragg: "
+            f"Q_phi={Q_phi} vs target={Q_phi_target}"
+        )
 
 
 def test_fourcv_bisecting_omega_equals_ttheta_half():
@@ -378,8 +399,13 @@ def test_kappa4_fixed_kphi_value_in_solution(factory):
         pytest.param(kappa4cv, "fixed_omega", 0, 0, 1, id="kappa4cv-fixed_omega"),
         pytest.param(kappa4cv, "fixed_chi", 0, 0, 1, id="kappa4cv-fixed_chi"),
         pytest.param(kappa4cv, "fixed_phi", 0, 1, 0, id="kappa4cv-fixed_phi"),
-        # kappa4ch (horizontal scattering plane — different reachable reflections)
-        pytest.param(kappa4ch, "fixed_omega", 0, 0, 1, id="kappa4ch-fixed_omega"),
+        # kappa4ch (horizontal scattering plane).  Under the corrected
+        # BL1967 standard composition (issue #280) ``(0, 0, 1)`` is no
+        # longer reachable in ``fixed_omega`` — its ``Q_phi`` is
+        # parallel to the kphi axis, leaving no DOF to generate the
+        # required diffracted-beam direction.  ``(1, 0, 0)`` is
+        # reachable in this mode and exercises the same code path.
+        pytest.param(kappa4ch, "fixed_omega", 1, 0, 0, id="kappa4ch-fixed_omega"),
         pytest.param(kappa4ch, "fixed_chi", 0, 0, 1, id="kappa4ch-fixed_chi"),
         pytest.param(kappa4ch, "fixed_phi", 0, 1, 0, id="kappa4ch-fixed_phi"),
     ],
@@ -520,7 +546,12 @@ def test_four_circle_stub_not_implemented(factory, mode_name):
 @pytest.mark.parametrize(
     "factory, h, k, l",
     [
-        pytest.param(fourcv, 1, 0, 0, id="fourcv-100"),
+        # The (1, 0, 0) case is unreachable in ``fixed_omega`` under the
+        # BL1967 standard composition (issue #280): ``Q_phi = (π/2, 0, 0)`` is
+        # parallel to the phi-axis (-x in BL basis), and ``R(chi, +y)``
+        # cannot generate a y-component while phi rotation is a no-op.
+        # See ``test_four_circle_fixed_omega_unreachable_along_phi_axis``
+        # below for the explicit (0-solutions) check.
         pytest.param(fourcv, 0, 1, 0, id="fourcv-010"),
         pytest.param(fourcv, 1, 1, 1, id="fourcv-111"),
         pytest.param(fourch, 1, 0, 0, id="fourch-100"),
@@ -536,20 +567,47 @@ def test_four_circle_fixed_omega_round_trip(factory, h, k, l):  # noqa: E741
 
 
 @pytest.mark.parametrize(
-    "factory",
+    "factory, h, k, l",
     [
-        pytest.param(fourcv, id="fourcv"),
-        pytest.param(fourch, id="fourch"),
+        pytest.param(fourcv, 0, 1, 0, id="fourcv"),
+        pytest.param(fourch, 1, 0, 0, id="fourch"),
     ],
 )
-def test_four_circle_fixed_omega_value_in_solution(factory):
-    """fixed_omega: omega=0 in all returned solutions."""
+def test_four_circle_fixed_omega_value_in_solution(factory, h, k, l):  # noqa: E741
+    """fixed_omega: omega=0 in all returned solutions.
+
+    Uses a reflection whose ``Q_phi`` is not parallel to the phi-axis
+    (which would be degenerate; see ``test_four_circle_fixed_omega_
+    unreachable_along_phi_axis``).
+    """
     g = _setup_cubic(factory, a=4.0)
     g.mode_name = "fixed_omega"
-    solutions = g.forward(1, 0, 0)
+    solutions = g.forward(h, k, l)
     assert len(solutions) > 0
     for sol in solutions:
         assert sol["omega"] == pytest.approx(0.0, abs=1e-8)
+
+
+def test_four_circle_fixed_omega_unreachable_along_phi_axis():
+    """fourcv fixed_omega: (1, 0, 0) returns no solutions under #280.
+
+    With the BL1967 standard composition (Busing & Levy 1967),
+    ``Q_phi`` for ``(1, 0, 0)`` lies along the phi-axis ``-x`` (BL
+    basis), making
+    the phi rotation a no-op.  At ``omega = 0`` the remaining chi
+    rotation (about ``+y``) can only place the rotated Q in the
+    ``x-z`` plane, but the diffracted-beam direction (rotated about
+    ``-x``) requires a non-zero ``y`` component when ``ttheta > 0``.
+    Therefore no motor configuration satisfies the Bragg condition at
+    ``omega = 0`` for this reflection.
+
+    This is a *physical* asymmetry made visible by the corrected
+    composition; under the pre-#280 (inner-leftmost) convention the
+    self-consistent reversal hid it.
+    """
+    g = _setup_cubic(fourcv, a=4.0)
+    g.mode_name = "fixed_omega"
+    assert g.forward(1, 0, 0) == []
 
 
 @pytest.mark.parametrize(
@@ -1502,12 +1560,33 @@ def test_kappa6c_stub_not_implemented(mode_name):
 
 
 def test_kappa6c_bisecting_vertical_invariants():
-    """bisecting_vertical: komega=delta/2, mu=0, nu=0 in all solutions."""
+    """bisecting_vertical: virtual omega = delta/2, mu = 0, nu = 0.
+
+    The constraint set is::
+
+        virtual_bisect(omega, delta), sample(mu, 0), detector(nu, 0)
+
+    The bisecting condition holds on the *virtual* Eulerian ``omega``,
+    not on the real ``komega``.  Only at the degenerate ``kappa = 0``
+    solution does ``komega == omega_virtual``; the other three
+    branches have ``kappa ≠ 0`` and a correspondingly shifted
+    ``komega``.  Under the pre-#280 (inner-leftmost) composition the
+    virtual-to-real mapping happened to make ``komega == delta/2``
+    for every branch — a coincidence of the buggy decomposition that
+    the corrected BL1967 standard composition (issue #280) no longer
+    produces.
+    """
+    from ad_hoc_diffractometer.kappa import kappa_to_eulerian_axes
+
     g = _setup_cubic(kappa6c, a=4.0)
     solutions = g.forward(1, 0, 0)
     assert len(solutions) > 0
+    conv = g.kappa_pseudo_angle_convention
     for sol in solutions:
-        assert sol["komega"] == pytest.approx(sol["delta"] / 2.0, abs=1e-10)
+        omega_virtual, _chi_v, _phi_v = kappa_to_eulerian_axes(
+            sol["komega"], sol["kappa"], sol["kphi"], conv
+        )
+        assert omega_virtual == pytest.approx(sol["delta"] / 2.0, abs=1e-8)
         assert sol["mu"] == pytest.approx(0.0, abs=1e-8)
         assert sol["nu"] == pytest.approx(0.0, abs=1e-8)
 
@@ -1973,12 +2052,15 @@ def test_fixed_psi_psi_verified_in_solutions(
         pytest.param(
             "fixed_psi_vertical", 1, 0, 0, (0, 0, 1), id="kappa6c-psi_vert-100"
         ),
-        # (-2,1,1) was previously here but is NOT accessible in true
-        # virtual bisecting on kappa6c with the kappa axis in the
-        # transverse-vertical plane (issue #252).  Use (2,1,-1) instead
-        # — non-degenerate kappa (≈78°), accessible.
+        # ``(-2, 1, 1)`` was originally here.  Issue #252 substituted
+        # ``(2, 1, -1)`` after the kappa-axis re-derivation; issue
+        # #280 further restricts reachability under the corrected
+        # BL1967 standard composition, and only ``(h, h, 0)`` and
+        # ``(h, 0, 0)`` reflections remain accessible in
+        # fixed_psi_vertical on this cubic kappa6c.  ``(1, 1, 0)``
+        # exercises the same code path with a non-degenerate kappa.
         pytest.param(
-            "fixed_psi_vertical", 2, 1, -1, (0, 0, 1), id="kappa6c-psi_vert-21m1"
+            "fixed_psi_vertical", 1, 1, 0, (0, 0, 1), id="kappa6c-psi_vert-110"
         ),
     ],
 )
@@ -2012,9 +2094,18 @@ def test_kappa6c_fixed_psi_round_trip(mode_name, h, k, l, ref):  # noqa: E741
 
 
 def test_kappa4cv_fixed_psi_round_trip():
-    """kappa4cv fixed_psi returns bisecting solutions via synthetic bisect."""
+    """kappa4cv fixed_psi returns bisecting solutions via synthetic bisect.
+
+    Uses ``(-1, 1, 0)`` rather than the older ``(1, 1, 0)``: under
+    the BL1967 standard composition (Busing & Levy 1967, fixed in
+    issue #280), ``(1, 1, 0)`` has a phi-axis-parallel component that
+    leaves no DOF for the
+    fixed-psi solver to satisfy both psi and Bragg simultaneously on
+    this cubic kappa4cv-BL geometry.  ``(-1, 1, 0)`` produces a
+    non-degenerate solution at natural psi.
+    """
     g = _setup_psi(kappa4cv, ref=(0, 0, 1))
-    natural = _natural_psi(g, 1, 1, 0)
+    natural = _natural_psi(g, -1, 1, 0)
     assert natural is not None
 
     from ad_hoc_diffractometer import REQUIRED
@@ -2027,7 +2118,7 @@ def test_kappa4cv_fixed_psi_round_trip():
         extras={"n_hat": REQUIRED, "psi": None},
     )
     g.mode_name = "fixed_psi"
-    assert _round_trip_ok(g, 1, 1, 0)
+    assert _round_trip_ok(g, -1, 1, 0)
 
 
 # --- psi undefined → empty solutions ---
@@ -2136,23 +2227,31 @@ def test_double_diffraction_raises_without_extras(factory, mode_name):
         pytest.param(fourcv, "double_diffraction", 1, 0, 0, (0, 1, 0), id="fourcv-100"),
         pytest.param(fourcv, "double_diffraction", 1, 1, 0, (0, 0, 1), id="fourcv-110"),
         pytest.param(fourch, "double_diffraction", 1, 0, 0, (0, 1, 0), id="fourch-100"),
+        # psic DD: under the corrected outermost-leftmost composition
+        # (issue #280), the primary ``(1, 0, 0)`` reflection lands on
+        # the diffractometer's vertical axis (= ``+x`` in YOU basis),
+        # which causes the secondary Ewald-sphere residual to be
+        # sign-constant over every outer angle (no simultaneous
+        # diffraction exists).  Use ``(1, 1, 1)`` instead: it is
+        # off-axis and produces valid double-diffraction solutions in
+        # both psic DD modes.
         pytest.param(
             psic,
             "double_diffraction_vertical",
             1,
-            0,
-            0,
+            1,
+            1,
             (0, 1, 0),
-            id="psic-vert-100",
+            id="psic-vert-111",
         ),
         pytest.param(
             psic,
             "double_diffraction_horizontal",
             1,
-            0,
-            0,
+            1,
+            1,
             (0, 1, 0),
-            id="psic-horiz-100",
+            id="psic-horiz-111",
         ),
     ],
 )
@@ -2412,20 +2511,24 @@ def test_forward_context_all_stages_constrained():
 
 
 def test_bisecting_early_termination_stale():
-    """Bisecting solver terminates early after enough stale seeds."""
-    # Use a reflection that has exactly 2 solutions so that:
-    # - The first 2 solutions are found from the analytic seeds
-    # - Subsequent seeds are all stale (converge to duplicates)
-    # - The solver breaks after _MAX_STALE consecutive stale seeds
-    # If it didn't early-terminate, it would try all 24 seeds.
+    """Bisecting solver terminates early after enough stale seeds.
+
+    Uses ``(1, 1, 0)`` (exactly 2 solutions: ±chi branches).  Under
+    the issue #280 corrected composition, ``(1, 0, 0)`` would have
+    been ambiguous: its ``Q_phi`` is parallel to the fourcv phi-axis
+    so phi is indeterminate and the Newton solver returns three
+    phi-equivalent solutions, defeating the "exactly 2" assertion.
+    ``(1, 1, 0)`` has an off-axis Q_phi and still exercises the same
+    code path (analytic-then-stale Newton sweep).
+    """
     g = _setup_cubic(fourcv, a=4.0)
-    solutions = g.forward(1, 0, 0)
+    solutions = g.forward(1, 1, 0)
     assert len(solutions) == 2  # noqa: PLR2004
     # Verify round-trip for both solutions
     for sol in solutions:
         hkl_back = g.inverse(sol)
         assert abs(hkl_back[0] - 1.0) < 1e-6
-        assert abs(hkl_back[1]) < 1e-6
+        assert abs(hkl_back[1] - 1.0) < 1e-6
         assert abs(hkl_back[2]) < 1e-6
 
 
@@ -2455,8 +2558,18 @@ def test_bisecting_max_solutions_termination():
 # ---------------------------------------------------------------------------
 
 
-def _bisect_fchi_fourcv(chi_value=90.0):
-    """fourcv with a custom bisecting + fixed_chi mode (only phi free)."""
+def _bisect_fchi_fourcv(chi_value=0.0):
+    """fourcv with a custom bisecting + fixed_chi mode (only phi free).
+
+    The default ``chi_value`` was changed from 90° to 0° under issue
+    #280: with the BL1967 standard outermost-leftmost composition, the
+    bisecting condition at chi=90 reaches only ``(1, 0, 0)`` (a
+    phi-degenerate target along the phi axis), which the analytic
+    one-free-angle helper correctly refuses (returns None) because
+    phi is mathematically indeterminate.  At chi=0 the bisecting
+    locus reaches off-axis reflections such as ``(0, 1, 0)`` with a
+    well-defined unique phi, exercising the analytic fast path.
+    """
     g = _setup_cubic(fourcv, a=4.0)
     g.modes["bisect_fchi"] = ConstraintSet(
         [BisectConstraint("omega", "ttheta"), SampleConstraint("chi", chi_value)],
@@ -2494,7 +2607,14 @@ def test_is_cardinal_axis(n, expected):
 
 
 def test_one_free_angle_analytic_invokes_fast_path():
-    """The analytic helper is invoked when the free-stage axis is cardinal."""
+    """The analytic helper is invoked when the free-stage axis is cardinal.
+
+    Uses ``(0, 1, 0)`` with ``chi = 0`` (the new ``_bisect_fchi_fourcv``
+    default).  Under issue #280 the older choice ``(1, 0, 0)`` at
+    ``chi = 90`` produced a Q_phi parallel to the phi axis, making
+    phi indeterminate and the analytic helper correctly return
+    ``None``.
+    """
     from ad_hoc_diffractometer import forward as fmod
 
     g = _bisect_fchi_fourcv()
@@ -2508,7 +2628,7 @@ def test_one_free_angle_analytic_invokes_fast_path():
 
     fmod._solve_one_free_angle_analytic = spy
     try:
-        g.forward(1, 0, 0)
+        g.forward(0, 1, 0)
     finally:
         fmod._solve_one_free_angle_analytic = orig
 
@@ -2516,17 +2636,17 @@ def test_one_free_angle_analytic_invokes_fast_path():
     assert len(calls) == 1
     name, theta = calls[0]
     assert name == "phi"
-    assert theta is not None  # solution exists for (1,0,0)
+    assert theta is not None  # solution exists for (0,1,0) with chi=0
 
 
 def test_one_free_angle_analytic_round_trip():
     """Analytic solution round-trips exactly through forward/inverse."""
     g = _bisect_fchi_fourcv()
-    sols = g.forward(1, 0, 0)
+    sols = g.forward(0, 1, 0)
     assert len(sols) >= 1
     for sol in sols:
         hkl_back = g.inverse(sol)
-        assert np.allclose(hkl_back, [1.0, 0.0, 0.0], atol=1e-9)
+        assert np.allclose(hkl_back, [0.0, 1.0, 0.0], atol=1e-9)
 
 
 def test_one_free_angle_analytic_matches_newton():
@@ -2534,7 +2654,7 @@ def test_one_free_angle_analytic_matches_newton():
     from ad_hoc_diffractometer import forward as fmod
 
     g = _bisect_fchi_fourcv()
-    sols_analytic = g.forward(1, 0, 0)
+    sols_analytic = g.forward(0, 1, 0)
     assert len(sols_analytic) == 1
     phi_analytic = sols_analytic[0]["phi"]
 
@@ -2542,7 +2662,7 @@ def test_one_free_angle_analytic_matches_newton():
     orig_check = fmod._is_cardinal_axis
     fmod._is_cardinal_axis = lambda n, atol=1e-12: False
     try:
-        sols_newton = g.forward(1, 0, 0)
+        sols_newton = g.forward(0, 1, 0)
     finally:
         fmod._is_cardinal_axis = orig_check
     assert len(sols_newton) == 1

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -393,18 +393,13 @@ def test_kappa4_fixed_kphi_value_in_solution(factory):
 @pytest.mark.parametrize(
     "factory, mode_name, h, k, l",
     [
-        # kappa4cv (BL basis: transverse=x, longitudinal=y, vertical=z)
-        # Note: (0,1,0) is NOT reachable for kappa4cv with omega=0
-        # because (0,1,0) is along the beam axis; use (0,0,1) instead.
-        pytest.param(kappa4cv, "fixed_omega", 0, 0, 1, id="kappa4cv-fixed_omega"),
+        # Reachable hkls under issue #280 ub_identity (crystal a* along
+        # the beam direction).  Hkls along the c-axis (0,0,*) or along
+        # the beam-axis direction are degenerate in fixed_omega on these
+        # kappa geometries; pick orthogonal-to-beam reflections instead.
+        pytest.param(kappa4cv, "fixed_omega", 1, 0, 0, id="kappa4cv-fixed_omega"),
         pytest.param(kappa4cv, "fixed_chi", 0, 0, 1, id="kappa4cv-fixed_chi"),
         pytest.param(kappa4cv, "fixed_phi", 0, 1, 0, id="kappa4cv-fixed_phi"),
-        # kappa4ch (horizontal scattering plane).  Under the corrected
-        # BL1967 standard composition (issue #280) ``(0, 0, 1)`` is no
-        # longer reachable in ``fixed_omega`` — its ``Q_phi`` is
-        # parallel to the kphi axis, leaving no DOF to generate the
-        # required diffracted-beam direction.  ``(1, 0, 0)`` is
-        # reachable in this mode and exercises the same code path.
         pytest.param(kappa4ch, "fixed_omega", 1, 0, 0, id="kappa4ch-fixed_omega"),
         pytest.param(kappa4ch, "fixed_chi", 0, 0, 1, id="kappa4ch-fixed_chi"),
         pytest.param(kappa4ch, "fixed_phi", 0, 1, 0, id="kappa4ch-fixed_phi"),
@@ -422,10 +417,11 @@ def test_kappa4_virtual_angle_round_trip(factory, mode_name, h, k, l):  # noqa: 
 @pytest.mark.parametrize(
     "factory, mode_name, virtual_angle, expected_value, h, k, l",
     [
-        # (0,1,0) is along the beam axis and cannot diffract with omega=0
-        # on kappa4cv (vertical scattering plane); use (0,0,1) instead.
+        # Under issue #280 ub_identity (crystal a* along the beam), the
+        # ``(0, 0, 1)`` reflection is no longer in the fixed_omega
+        # reachable locus on kappa4cv; ``(1, 0, 0)`` is.
         pytest.param(
-            kappa4cv, "fixed_omega", "omega", 0.0, 0, 0, 1, id="kappa4cv-omega=0"
+            kappa4cv, "fixed_omega", "omega", 0.0, 1, 0, 0, id="kappa4cv-omega=0"
         ),
         pytest.param(kappa4cv, "fixed_chi", "chi", 90.0, 0, 0, 1, id="kappa4cv-chi=90"),
         pytest.param(kappa4cv, "fixed_phi", "phi", 0.0, 0, 1, 0, id="kappa4cv-phi=0"),
@@ -546,12 +542,13 @@ def test_four_circle_stub_not_implemented(factory, mode_name):
 @pytest.mark.parametrize(
     "factory, h, k, l",
     [
-        # The (1, 0, 0) case is unreachable in ``fixed_omega`` under the
-        # BL1967 standard composition (issue #280): ``Q_phi = (π/2, 0, 0)`` is
-        # parallel to the phi-axis (-x in BL basis), and ``R(chi, +y)``
-        # cannot generate a y-component while phi rotation is a no-op.
-        # See ``test_four_circle_fixed_omega_unreachable_along_phi_axis``
-        # below for the explicit (0-solutions) check.
+        # Under issue #280 ub_identity (crystal a* along the beam), the
+        # ``(0, 0, 1)`` reflection on fourcv has Q_phi along the phi axis
+        # (-transverse = -x in BL basis), making phi rotation a no-op and
+        # the configuration unreachable at omega = 0.  See
+        # ``test_four_circle_fixed_omega_unreachable_along_phi_axis`` for
+        # the explicit zero-solutions check.  Pick hkls whose Q_phi is
+        # off-axis.
         pytest.param(fourcv, 0, 1, 0, id="fourcv-010"),
         pytest.param(fourcv, 1, 1, 1, id="fourcv-111"),
         pytest.param(fourch, 1, 0, 0, id="fourch-100"),
@@ -589,25 +586,31 @@ def test_four_circle_fixed_omega_value_in_solution(factory, h, k, l):  # noqa: E
 
 
 def test_four_circle_fixed_omega_unreachable_along_phi_axis():
-    """fourcv fixed_omega: (1, 0, 0) returns no solutions under #280.
+    """fourcv fixed_omega: (0, 0, 1) returns no solutions under #280.
 
-    With the BL1967 standard composition (Busing & Levy 1967),
-    ``Q_phi`` for ``(1, 0, 0)`` lies along the phi-axis ``-x`` (BL
-    basis), making
-    the phi rotation a no-op.  At ``omega = 0`` the remaining chi
-    rotation (about ``+y``) can only place the rotated Q in the
-    ``x-z`` plane, but the diffracted-beam direction (rotated about
-    ``-x``) requires a non-zero ``y`` component when ``ttheta > 0``.
-    Therefore no motor configuration satisfies the Bragg condition at
-    ``omega = 0`` for this reflection.
+    Under issue #280 ub_identity (crystal a* along the beam direction
+    = +longitudinal, b* along +vertical, c* along +transverse), the
+    reflection ``(0, 0, 1)`` produces ``Q_phi`` along the physical
+    transverse direction (-x in BL basis).  fourcv's phi axis is
+    -transverse, so ``Q_phi`` is parallel to the phi axis and the
+    phi rotation is a no-op.  At ``omega = 0`` the remaining chi
+    rotation (about ``+longitudinal``) can only place the rotated Q
+    in the longitudinal-transverse plane, but the diffracted-beam
+    direction (rotated about ``-transverse``) requires a non-zero
+    vertical component when ``ttheta > 0``.  Therefore no motor
+    configuration satisfies the Bragg condition at ``omega = 0`` for
+    this reflection.
 
-    This is a *physical* asymmetry made visible by the corrected
-    composition; under the pre-#280 (inner-leftmost) convention the
-    self-consistent reversal hid it.
+    Under the pre-#280 (basis-relative) ``ub_identity`` the
+    corresponding unreachable hkl on fourcv was ``(1, 0, 0)``
+    (because the crystal a-axis was put physically along whatever the
+    basis labeled +x); the new ``ub_identity`` makes the placement
+    basis-independent, so the unreachable hkl is ``(0, 0, 1)``
+    instead.
     """
     g = _setup_cubic(fourcv, a=4.0)
     g.mode_name = "fixed_omega"
-    assert g.forward(1, 0, 0) == []
+    assert g.forward(0, 0, 1) == []
 
 
 @pytest.mark.parametrize(
@@ -1228,7 +1231,16 @@ def test_fixed_sample_all_constrained_out_of_limits():
 
 
 def test_fixed_sample_one_free():
-    """_solve_fixed_sample: one free stage (chi fixed, phi free) round-trips."""
+    """_solve_fixed_sample: one free stage (chi fixed, phi free) round-trips.
+
+    Under issue #280 ub_identity, the crystal a* axis is physically along
+    the beam.  ``(1, 0, 0)`` therefore has ``Q_phi`` along the beam, and
+    the bisecting locus is reached with ``chi = 0`` (no rotation needed
+    to bring the crystal direction into the scattering plane).  Pre-#280
+    the same test used ``chi = 90`` because ``U = I`` put the a-axis
+    along the basis +x direction; the new ub_identity makes that
+    rotation unnecessary.
+    """
     from ad_hoc_diffractometer.forward import _solve_fixed_sample
 
     g = _setup_cubic(fourcv, a=4.0)
@@ -1238,12 +1250,12 @@ def test_fixed_sample_one_free():
     sin_theta = float(np.linalg.norm(Q_phi)) * WAVELENGTH / (4.0 * math.pi)
     ttheta_deg = 2.0 * math.degrees(math.asin(sin_theta))
 
-    # Fix omega and chi; phi is free
+    # Fix omega and chi; phi is free.
     omega_val = ttheta_deg / 2.0
     mode = ConstraintSet(
         [
             SampleConstraint("omega", omega_val),
-            SampleConstraint("chi", 90.0),
+            SampleConstraint("chi", 0.0),
         ]
     )
     result = _solve_fixed_sample(g, Q_phi, ttheta_deg, mode)
@@ -1682,18 +1694,25 @@ def test_psic_lifting_detector_mu_limits_filter_solutions():
     The mu stage is the only free sample stage, so restricting its
     limits gives a clean filter that drops every solution that lands
     outside the allowed mu range.
+
+    Uses ``(1, 1, 0)`` under issue #280 ub_identity: it produces two
+    branches (mu ≈ ±112°), one inside and one outside the (0°, 180°)
+    range, suitable for the limit-filtering test.  Pre-#280 the test
+    used ``(0, 1, 1)``, which under the new ub_identity gives a single
+    unrestricted solution and cannot exercise the filter.
     """
     g = _setup_cubic(psic, a=4.0)
     g.mode_name = "lifting_detector_mu"
-    # (0, 1, 1) reaches at mu ~= ±70°
-    sols_unrestricted = g.forward(0, 1, 1)
-    assert len(sols_unrestricted) > 0
+    sols_unrestricted = g.forward(1, 1, 0)
+    assert len(sols_unrestricted) > 1, (
+        "test setup requires multiple solutions for the filter to drop one"
+    )
     # Restrict mu to the positive range — the negative-mu solutions drop out
-    g.stage("mu").limits = (0.0, 90.0)
-    sols_restricted = g.forward(0, 1, 1)
+    g.stage("mu").limits = (0.0, 180.0)
+    sols_restricted = g.forward(1, 1, 0)
     assert 0 < len(sols_restricted) < len(sols_unrestricted)
     for sol in sols_restricted:
-        assert 0.0 <= sol["mu"] <= 90.0
+        assert 0.0 <= sol["mu"] <= 180.0
 
 
 def test_qaz_residual_two_detector_stages_required():
@@ -1730,8 +1749,11 @@ def test_qaz_residual_two_detector_stages_required():
         # three sample stages and let both detector stages float to satisfy
         # the Bragg condition.  The qaz pseudo-angle is no longer pinned;
         # the test verifies forward/inverse round-trip and the expected
-        # frozen sample angles instead.
-        pytest.param("lifting_detector_mu", 0, 1, 0, id="psic-liftmu-010"),
+        # frozen sample angles instead.  Under issue #280 ub_identity,
+        # ``(0, 1, 0)`` is unreachable on psic lifting_detector_mu;
+        # ``(1, 0, 0)`` is the analogous reachable case.  Similarly,
+        # ``(0, 0, 1)`` is unreachable on psic lifting_detector_phi.
+        pytest.param("lifting_detector_mu", 1, 0, 0, id="psic-liftmu-100"),
         pytest.param("lifting_detector_mu", 1, 1, 1, id="psic-liftmu-111"),
         pytest.param("lifting_detector_phi", 1, 0, 0, id="psic-liftphi-100"),
         pytest.param("lifting_detector_phi", 1, 1, 1, id="psic-liftphi-111"),
@@ -1824,10 +1846,15 @@ def _natural_psi(g, h, k, l):  # noqa: E741
 @pytest.mark.parametrize(
     "factory, h, k, l, ref, expected_psi",
     [
-        pytest.param(fourcv, 1, 0, 0, (0, 0, 1), 90.0, id="fourcv-100-ref001"),
-        pytest.param(fourcv, 1, 1, 1, (0, 0, 1), 120.0, id="fourcv-111-ref001"),
-        pytest.param(fourcv, 1, 0, 1, (0, 0, 1), 90.0, id="fourcv-101-ref001"),
-        pytest.param(psic, 1, 0, 0, (0, 0, 1), 90.0, id="psic-100-ref001"),
+        # Hand-derived expected values for the issue #280 ub_identity (U places
+        # crystal a* along the beam, b* along vertical, c* along transverse).
+        # Sign of expected_psi depends on basis handedness (BL vs YOU), hence
+        # fourcv/fourch (BL) and psic (YOU) report opposite signs of psi for
+        # the same hkl/ref.
+        pytest.param(fourcv, 0, 1, 0, (0, 0, 1), -90.0, id="fourcv-010-ref001"),
+        pytest.param(fourcv, 1, 1, 1, (0, 0, 1), -120.0, id="fourcv-111-ref001"),
+        pytest.param(fourcv, 1, 0, 1, (0, 0, 1), 180.0, id="fourcv-101-ref001"),
+        pytest.param(psic, 0, 1, 0, (0, 0, 1), 90.0, id="psic-010-ref001"),
         pytest.param(psic, 1, 1, 1, (0, 0, 1), 120.0, id="psic-111-ref001"),
     ],
 )
@@ -1840,16 +1867,26 @@ def test_compute_natural_psi(factory, h, k, l, ref, expected_psi):  # noqa: E741
 
 
 def test_compute_natural_psi_undefined_when_ref_parallel_to_Q():
-    """_compute_natural_psi returns None when reference is parallel to Q."""
-    g = _setup_psi(fourcv, ref=(1, 0, 0))
-    psi = _natural_psi(g, 1, 0, 0)  # Q along x, ref along x -> parallel
+    """_compute_natural_psi returns None when reference is parallel to Q.
+
+    Under issue #280 ub_identity, Q_phi(0,1,0) = UB @ (0,1,0) is along
+    physical +vertical (for fourcv-BL: +z); choosing ref=(0,1,0) makes
+    n_phi = UB @ (0,1,0) parallel to Q_phi by construction.
+    """
+    g = _setup_psi(fourcv, ref=(0, 1, 0))
+    psi = _natural_psi(g, 0, 1, 0)
     assert psi is None
 
 
 def test_compute_natural_psi_undefined_when_Q_parallel_to_beam():
-    """_compute_natural_psi returns None when Q is parallel to incident beam."""
+    """_compute_natural_psi returns None when Q is parallel to incident beam.
+
+    Under issue #280 ub_identity, the crystal a* axis is physically along
+    the beam (+longitudinal), so Q_phi(1,0,0) is parallel to the beam and
+    psi is undefined.
+    """
     g = _setup_psi(fourcv, ref=(0, 0, 1))
-    psi = _natural_psi(g, 0, 1, 0)  # Q along y (longitudinal = beam direction)
+    psi = _natural_psi(g, 1, 0, 0)
     assert psi is None
 
 
@@ -1859,10 +1896,13 @@ def test_compute_natural_psi_undefined_when_Q_parallel_to_beam():
 @pytest.mark.parametrize(
     "factory, h, k, l, ref",
     [
-        pytest.param(fourcv, 1, 0, 0, (0, 0, 1), id="fourcv-100-ref001"),
+        # Under issue #280 ub_identity, the crystal a* axis is physically
+        # along the beam (+longitudinal), so Q_phi(1,0,0) is beam-parallel
+        # and natural psi is undefined.  Use off-axis hkls instead.
+        pytest.param(fourcv, 0, 1, 0, (0, 0, 1), id="fourcv-010-ref001"),
         pytest.param(fourcv, 1, 0, 1, (0, 0, 1), id="fourcv-101-ref001"),
         pytest.param(fourcv, 1, 1, 1, (0, 0, 1), id="fourcv-111-ref001"),
-        pytest.param(fourch, 1, 0, 0, (0, 0, 1), id="fourch-100-ref001"),
+        pytest.param(fourch, 0, 1, 0, (0, 0, 1), id="fourch-010-ref001"),
         pytest.param(fourch, 1, 1, 1, (0, 0, 1), id="fourch-111-ref001"),
     ],
 )
@@ -1893,9 +1933,13 @@ def test_four_circle_fixed_psi_round_trip(factory, h, k, l, ref):  # noqa: E741
     ],
 )
 def test_four_circle_fixed_psi_wrong_target_returns_empty(factory):
-    """fixed_psi returns [] when natural psi does not match psi_target."""
+    """fixed_psi returns [] when natural psi does not match psi_target.
+
+    Under issue #280 ub_identity, the crystal a* axis is along the beam;
+    use (0, 1, 0) instead of (1, 0, 0) so natural psi is defined.
+    """
     g = _setup_psi(factory, ref=(0, 0, 1))
-    natural = _natural_psi(g, 1, 0, 0)
+    natural = _natural_psi(g, 0, 1, 0)
     assert natural is not None
 
     from ad_hoc_diffractometer import REQUIRED
@@ -1909,7 +1953,7 @@ def test_four_circle_fixed_psi_wrong_target_returns_empty(factory):
         extras={"n_hat": REQUIRED, "psi": None},
     )
     g.mode_name = "fixed_psi"
-    solutions = g.forward(1, 0, 0)
+    solutions = g.forward(0, 1, 0)
     assert solutions == []
 
 
@@ -1919,11 +1963,14 @@ def test_four_circle_fixed_psi_wrong_target_returns_empty(factory):
 @pytest.mark.parametrize(
     "mode_name, h, k, l, ref",
     [
-        pytest.param("fixed_psi_vertical", 1, 0, 0, (0, 0, 1), id="psic-psi_vert-100"),
+        # Under issue #280 ub_identity, psic's crystal a* is along beam
+        # (+longitudinal), so (1, 0, 0) is beam-parallel and psi-undefined.
+        # Use (0, 1, 0) which produces Q_phi along +vertical (in psic-YOU).
+        pytest.param("fixed_psi_vertical", 0, 1, 0, (0, 0, 1), id="psic-psi_vert-010"),
         pytest.param("fixed_psi_vertical", 1, 0, 1, (0, 0, 1), id="psic-psi_vert-101"),
         pytest.param("fixed_psi_vertical", 1, 1, 1, (0, 0, 1), id="psic-psi_vert-111"),
         pytest.param(
-            "fixed_psi_horizontal", 1, 0, 0, (0, 0, 1), id="psic-psi_horiz-100"
+            "fixed_psi_horizontal", 0, 1, 0, (0, 0, 1), id="psic-psi_horiz-010"
         ),
     ],
 )
@@ -1962,7 +2009,9 @@ def test_psic_fixed_psi_wrong_target_returns_empty():
     requests whose natural psi differs from the stored target.
     """
     g = _setup_psi(psic, ref=(0, 0, 1))
-    natural = _natural_psi(g, 1, 0, 0)
+    # Under issue #280 ub_identity, psic (1,0,0) → Q_phi along beam,
+    # so natural psi is undefined.  Use (0,1,0).
+    natural = _natural_psi(g, 0, 1, 0)
     assert natural is not None
 
     from ad_hoc_diffractometer import REQUIRED
@@ -1981,7 +2030,7 @@ def test_psic_fixed_psi_wrong_target_returns_empty():
         extras={"n_hat": REQUIRED, "psi": None},
     )
     g.mode_name = "fixed_psi_vertical"
-    solutions = g.forward(1, 0, 0)
+    solutions = g.forward(0, 1, 0)
     assert solutions == []
 
 
@@ -1991,16 +2040,18 @@ def test_psic_fixed_psi_wrong_target_returns_empty():
 @pytest.mark.parametrize(
     "factory, mode_name, h, k, l, ref",
     [
-        pytest.param(fourcv, "fixed_psi", 1, 0, 0, (0, 0, 1), id="fourcv-100"),
+        # Under issue #280 ub_identity, (1, 0, 0) → Q_phi along the beam
+        # and natural psi is undefined.  Use (0, 1, 0) instead.
+        pytest.param(fourcv, "fixed_psi", 0, 1, 0, (0, 0, 1), id="fourcv-010"),
         pytest.param(fourcv, "fixed_psi", 1, 1, 1, (0, 0, 1), id="fourcv-111"),
         pytest.param(
-            psic, "fixed_psi_vertical", 1, 0, 0, (0, 0, 1), id="psic-vert-100"
+            psic, "fixed_psi_vertical", 0, 1, 0, (0, 0, 1), id="psic-vert-010"
         ),
         pytest.param(
             psic, "fixed_psi_vertical", 1, 1, 1, (0, 0, 1), id="psic-vert-111"
         ),
         pytest.param(
-            psic, "fixed_psi_horizontal", 1, 0, 0, (0, 0, 1), id="psic-horiz-100"
+            psic, "fixed_psi_horizontal", 0, 1, 0, (0, 0, 1), id="psic-horiz-010"
         ),
     ],
 )
@@ -2049,8 +2100,12 @@ def test_fixed_psi_psi_verified_in_solutions(
 @pytest.mark.parametrize(
     "mode_name, h, k, l, ref",
     [
+        # Under issue #280 ub_identity, the crystal a* axis is physically
+        # along the beam (+longitudinal), so ``(1, 0, 0)`` produces a
+        # Q_phi parallel to the beam and natural psi is undefined.  Use
+        # ``(0, 1, 0)`` instead.
         pytest.param(
-            "fixed_psi_vertical", 1, 0, 0, (0, 0, 1), id="kappa6c-psi_vert-100"
+            "fixed_psi_vertical", 0, 1, 0, (0, 0, 1), id="kappa6c-psi_vert-010"
         ),
         # ``(-2, 1, 1)`` was originally here.  Issue #252 substituted
         # ``(2, 1, -1)`` after the kappa-axis re-derivation; issue
@@ -2609,11 +2664,11 @@ def test_is_cardinal_axis(n, expected):
 def test_one_free_angle_analytic_invokes_fast_path():
     """The analytic helper is invoked when the free-stage axis is cardinal.
 
-    Uses ``(0, 1, 0)`` with ``chi = 0`` (the new ``_bisect_fchi_fourcv``
-    default).  Under issue #280 the older choice ``(1, 0, 0)`` at
-    ``chi = 90`` produced a Q_phi parallel to the phi axis, making
-    phi indeterminate and the analytic helper correctly return
-    ``None``.
+    Uses ``(1, 0, 0)`` with ``chi = 0`` (the new ``_bisect_fchi_fourcv``
+    default).  Under the issue #280 ``ub_identity``, the crystal a-axis
+    is physically along the beam (+longitudinal), so ``(1, 0, 0)``
+    produces a non-phi-degenerate ``Q_phi`` and a unique phi solution
+    via the analytic helper.
     """
     from ad_hoc_diffractometer import forward as fmod
 
@@ -2628,7 +2683,7 @@ def test_one_free_angle_analytic_invokes_fast_path():
 
     fmod._solve_one_free_angle_analytic = spy
     try:
-        g.forward(0, 1, 0)
+        g.forward(1, 0, 0)
     finally:
         fmod._solve_one_free_angle_analytic = orig
 
@@ -2636,17 +2691,17 @@ def test_one_free_angle_analytic_invokes_fast_path():
     assert len(calls) == 1
     name, theta = calls[0]
     assert name == "phi"
-    assert theta is not None  # solution exists for (0,1,0) with chi=0
+    assert theta is not None  # solution exists for (1,0,0) with chi=0
 
 
 def test_one_free_angle_analytic_round_trip():
     """Analytic solution round-trips exactly through forward/inverse."""
     g = _bisect_fchi_fourcv()
-    sols = g.forward(0, 1, 0)
+    sols = g.forward(1, 0, 0)
     assert len(sols) >= 1
     for sol in sols:
         hkl_back = g.inverse(sol)
-        assert np.allclose(hkl_back, [0.0, 1.0, 0.0], atol=1e-9)
+        assert np.allclose(hkl_back, [1.0, 0.0, 0.0], atol=1e-9)
 
 
 def test_one_free_angle_analytic_matches_newton():
@@ -2654,7 +2709,7 @@ def test_one_free_angle_analytic_matches_newton():
     from ad_hoc_diffractometer import forward as fmod
 
     g = _bisect_fchi_fourcv()
-    sols_analytic = g.forward(0, 1, 0)
+    sols_analytic = g.forward(1, 0, 0)
     assert len(sols_analytic) == 1
     phi_analytic = sols_analytic[0]["phi"]
 
@@ -2662,7 +2717,7 @@ def test_one_free_angle_analytic_matches_newton():
     orig_check = fmod._is_cardinal_axis
     fmod._is_cardinal_axis = lambda n, atol=1e-12: False
     try:
-        sols_newton = g.forward(0, 1, 0)
+        sols_newton = g.forward(1, 0, 0)
     finally:
         fmod._is_cardinal_axis = orig_check
     assert len(sols_newton) == 1

--- a/tests/test_kappa.py
+++ b/tests/test_kappa.py
@@ -470,17 +470,17 @@ def test_sample_constraint_is_implemented_virtual_on_non_kappa():
             id="fixed_phi-010",
         ),
         pytest.param(
-            # (0,1,0) is along the beam axis and unreachable with omega=0
-            # on kappa4cv; use (0,0,1) which is the canonical fixed_omega
-            # reflection (vertical-axis scattering).
+            # Under issue #280 ub_identity (crystal a* along the beam),
+            # (0,0,1) is unreachable in fixed_omega on kappa4cv (Q_phi
+            # along the kphi axis).  (1,0,0) is reachable.
             "fixed_omega",
             "omega",
             0.0,
-            0,
-            0,
             1,
+            0,
+            0,
             does_not_raise(),
-            id="fixed_omega-001",
+            id="fixed_omega-100",
         ),
         pytest.param(
             "fixed_chi",

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -438,11 +438,22 @@ def test_lattice_lazy_not_computed_at_construction():
 
 
 def test_lattice_lazy_computed_after_access():
+    """Each lazy property populates its own cache when accessed.
+
+    Under issue #280, the three properties (``cartesian_lattice_vectors``,
+    ``reciprocal_lattice_vectors``, ``B``) are computed independently
+    from the lattice parameters via :func:`b_matrix_bl1967` and the
+    BL1967 reciprocal-of-reciprocal identity, rather than chained
+    through one another.  Accessing ``B`` therefore only populates
+    ``_B``; the other caches populate on their own first access.
+    """
     lat = Lattice(a=5.0)
     _ = lat.B
-    assert lat._cartesian_lattice_vectors is not None
-    assert lat._reciprocal_lattice_vectors is not None
     assert lat._B is not None
+    _ = lat.cartesian_lattice_vectors
+    assert lat._cartesian_lattice_vectors is not None
+    _ = lat.reciprocal_lattice_vectors
+    assert lat._reciprocal_lattice_vectors is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -72,15 +72,44 @@ def sapphire_geom():
 # ---------------------------------------------------------------------------
 
 
-def test_ub_identity_sets_U_to_eye(psic_geom):
-    ub_identity(psic_geom.sample)
-    np.testing.assert_array_equal(psic_geom.sample.U, np.eye(3))
+def test_ub_identity_sets_U_to_physical_direction_triple(psic_geom):
+    """Under issue #280, ``ub_identity`` sets U to the basis-independent
+    physical-direction triple (columns: longitudinal, vertical, transverse).
 
-
-def test_ub_identity_sets_UB_to_B(psic_geom):
+    The pre-#280 contract ``U = numpy.eye(3)`` was basis-relative and
+    has been replaced.  See ``ub_identity`` docstring.
+    """
     ub_identity(psic_geom.sample)
+    expected_U = np.column_stack(
+        [
+            np.asarray(psic_geom.basis["longitudinal"], dtype=float),
+            np.asarray(psic_geom.basis["vertical"], dtype=float),
+            np.asarray(psic_geom.basis["transverse"], dtype=float),
+        ]
+    )
+    np.testing.assert_allclose(psic_geom.sample.U, expected_U, atol=1e-12)
+    # U is orthogonal by construction.
     np.testing.assert_allclose(
-        psic_geom.sample.UB, psic_geom.sample.lattice.B, atol=1e-12
+        psic_geom.sample.U @ psic_geom.sample.U.T, np.eye(3), atol=1e-12
+    )
+
+
+def test_ub_identity_sets_UB_to_U_times_B(psic_geom):
+    """``UB = U @ B``, where ``U`` is the physical-direction triple
+    (issue #280; replaces the pre-#280 ``UB = B`` contract).
+    """
+    ub_identity(psic_geom.sample)
+    U_expected = np.column_stack(
+        [
+            np.asarray(psic_geom.basis["longitudinal"], dtype=float),
+            np.asarray(psic_geom.basis["vertical"], dtype=float),
+            np.asarray(psic_geom.basis["transverse"], dtype=float),
+        ]
+    )
+    np.testing.assert_allclose(
+        psic_geom.sample.UB,
+        U_expected @ psic_geom.sample.lattice.B,
+        atol=1e-12,
     )
 
 
@@ -93,6 +122,26 @@ def test_ub_identity_updates_in_place(psic_geom):
     sample = psic_geom.sample
     UB = ub_identity(sample)
     assert sample.UB is UB
+
+
+def test_ub_identity_raises_without_parent(psic_geom):
+    """ub_identity raises ValueError when sample.parent is None.
+
+    Under issue #280 ub_identity needs the geometry's basis vectors
+    to construct the basis-independent U; a sample with no parent
+    cannot supply them.
+    """
+    orphan = Sample(
+        name="orphan",
+        lattice=psic_geom.sample.lattice,
+        reflections=ReflectionList(
+            geometry_name="psic",
+            valid_stages=["mu", "eta", "chi", "phi", "nu", "delta"],
+        ),
+        parent=None,
+    )
+    with pytest.raises(ValueError, match=re.escape("sample.parent")):
+        ub_identity(orphan)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -405,17 +405,44 @@ def test_angles_to_phi_vector_magnitude_bragg(psic_geom):
 
 
 def test_angles_to_phi_vector_explicit_components_psic_sapphire(psic_geom):
-    """
+    r"""
     Explicit component check for psic sapphire (006) at Cu Kα.
 
-    The expected values were computed from the implementation under review
-    and locked here as a regression guard.  Any future change to the
-    rotation convention must also update these numbers.
+    Hand-derivation under the BL1967 standard composition (Busing &
+    Levy 1967, issue #280, outermost-leftmost): with the psic YOU
+    basis (vertical=+x, longitudinal=+y, transverse=+z) and the
+    motor angles ``mu=0, eta=20.97, chi=90, phi=0, nu=0, delta=41.94``:
+
+      D = R(+x, 0) · R(-z, 41.94) = R(-z, 41.94)
+      Z = R(+x, 0) · R(-z, 20.97) · R(+y, 90) · R(-z, 0)
+        = R(-z, 20.97) · R(+y, 90)
+
+    The lab beam ``y_hat = (0, 1, 0)``.  Q_lab = (2π/λ)(D·ŷ − ŷ)
+    has zero x-component (R(-z, ·) preserves the x-z plane only when
+    applied to vectors in it; here ŷ rotates within the x-y plane).
+
+    Working through:
+
+      D·ŷ = R(-z, 41.94) (0,1,0) = (sin 41.94°, cos 41.94°, 0)
+      Q_lab = (2π/λ) (sin 41.94°, cos 41.94° − 1, 0)
+
+    Applying Z^T = R(-y, 90) · R(+z, 20.97) (operator inverse with
+    sign-flipped angles) yields Q_phi with all of its magnitude
+    concentrated along the +z axis::
+
+        Q_phi = (0, 0, (4π/λ)·sin(20.97°))
+              = (0, 0, 2.9191491238932494)  Å⁻¹
+
+    matching |Q_phi| = (4π/λ)·sin(2θ/2) for 2θ = 41.94°.
+
+    The vector lies exactly along +z because the chi=90 rotation
+    swings the original Q_phi (which would be along +y after omega
+    rotation only) onto +z, and phi=0 does not change it.
     """
     psic_geom.wavelength = _LAMBDA_CU_KA
     Q = angles_to_phi_vector(psic_geom, **_SAPPHIRE_ANGLES)
-    expected = np.array([0.37387713, -0.97550961, 2.72580786])
-    np.testing.assert_allclose(Q, expected, atol=1e-6)
+    expected = np.array([0.0, 0.0, _Q_MAG_SAPPHIRE_006])
+    np.testing.assert_allclose(Q, expected, atol=1e-9)
 
 
 # --- invariance / dependence properties -------------------------------------
@@ -1335,6 +1362,19 @@ def test_inverse_real_wavelength_psic_silicon():
     Silicon: a = 5.4310 Å, λ = 1.5406 Å (Cu Kα).
     With the BL1967 B-matrix convention (|B @ hkl| = 2π/d), the round-trip
     inverse(angles_at_Bragg) must return true Miller indices.
+
+    Under the BL1967 standard composition (Busing & Levy 1967, issue
+    #280, outermost-leftmost):
+
+    * ``r1`` at (chi=90, phi=0) places Q_phi along +z.
+    * ``r2`` at (chi=0,  phi=0) places Q_phi along +x.
+
+    These two phi-frame vectors are orthogonal, so the Gram-Schmidt
+    fit in :func:`ub_from_two_reflections_bl1967` is
+    well-conditioned.  (Under the pre-#280 buggy convention the
+    earlier choice ``r2 = (chi=90, phi=90)`` was non-parallel; under
+    the corrected convention that setup produces ``Q_phi`` along
+    +z, collinear with ``r1``, and the fit becomes degenerate.)
     """
     import math
 
@@ -1352,10 +1392,11 @@ def test_inverse_real_wavelength_psic_silicon():
         d = 2.0 * math.pi / float(np.linalg.norm(B @ np.array(hkl, dtype=float)))
         return 2.0 * math.degrees(math.asin(g.wavelength / (2.0 * d)))
 
-    # (006) equivalent: use (0,0,4) — c-axis along phi-axis (chi=90 brings it in)
-    # Use two non-parallel reflections at their true Bragg positions.
-    tth1 = _tth([0, 0, 2])  # c-axis reflection, chi=90 to enter scattering plane
-    tth2 = _tth([2, 0, 0])  # a-axis reflection, chi=90 phi=90
+    # Two non-parallel reflections at their true Bragg positions:
+    #   r1 = (0, 0, 2):  Q_phi along +z under (chi=90, phi=0)
+    #   r2 = (2, 0, 0):  Q_phi along +x under (chi=0,  phi=0)
+    tth1 = _tth([0, 0, 2])
+    tth2 = _tth([2, 0, 0])
 
     r1_angles = {
         "mu": 0.0,
@@ -1368,8 +1409,8 @@ def test_inverse_real_wavelength_psic_silicon():
     r2_angles = {
         "mu": 0.0,
         "eta": tth2 / 2,
-        "chi": 90.0,
-        "phi": 90.0,
+        "chi": 0.0,
+        "phi": 0.0,
         "nu": 0.0,
         "delta": tth2,
     }

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -128,11 +128,17 @@ def test_psi_angle_raises_without_azimuthal_reference():
 
 
 def test_psi_angle_with_azimuthal_reference():
-    """psi_angle returns a float in (-180, 180] when azimuthal_reference is set."""
+    """psi_angle returns a float in (-180, 180] when azimuthal_reference is set.
+
+    Uses ``(0, 1, 0)`` instead of ``(1, 0, 0)``: under issue #280
+    ub_identity the crystal a* axis is along the beam, so Q_phi(1,0,0)
+    is parallel to the beam and psi is undefined.  ``(0, 1, 0)``
+    produces a Q_phi off the beam axis.
+    """
     g = _setup_psic()
     g.azimuthal_reference = (0, 0, 1)
     g.mode_name = "bisecting_vertical"
-    sols = g.forward(1, 0, 0)
+    sols = g.forward(0, 1, 0)
     for s in sols:
         psi = psi_angle(g, angles=s)
         assert isinstance(psi, float)
@@ -140,12 +146,15 @@ def test_psi_angle_with_azimuthal_reference():
 
 
 def test_psi_angle_uses_current_angles_when_none():
-    """psi_angle uses current stage angles when angles=None."""
+    """psi_angle uses current stage angles when angles=None.
+
+    Uses ``(0, 1, 0)`` for the same reason as
+    :func:`test_psi_angle_with_azimuthal_reference`.
+    """
     g = _setup_psic()
     g.azimuthal_reference = (0, 0, 1)
-    # Forward first to get valid motor angles, then set stages
     g.mode_name = "bisecting_vertical"
-    sols = g.forward(1, 0, 0)
+    sols = g.forward(0, 1, 0)
     s = sols[0]
     for name, value in s.items():
         g.set_angle(name, value)
@@ -192,16 +201,19 @@ def test_naz_angle_uses_current_angles_when_none():
 
 
 def test_naz_angle_vertical_normal_returns_zero():
-    """naz_angle returns 0 when surface normal is vertical (undefined by convention)."""
+    """naz_angle returns 0 when surface normal is vertical (undefined by convention).
+
+    Under issue #280 ub_identity, ``UB @ (0, 1, 0) = U[:, 1] · |b2*|`` is
+    physically along ``+vertical`` (column 1 of U is the vertical basis
+    vector).  Pre-#280 the same physical configuration was selected by
+    ``surface_normal = (1, 0, 0)`` because the basis-relative ``U = I``
+    placed the crystal a-axis along the basis-x direction (= vertical
+    in psic-YOU).
+    """
     g = _setup_psic()
-    # Vertical = +x in BASIS_YOU; a surface normal along (1,0,0) Miller indices
-    # maps to a reciprocal direction. Use a normal that is vertical in the lab.
-    # For naz to be zero by convention, the horizontal projection must be negligible.
-    # The vertical axis is XHAT. Any n_hkl mapping to purely XHAT direction gives naz=0.
-    # This is tricky to arrange exactly — just verify naz is a float.
-    g.surface_normal = (1, 0, 0)
+    g.surface_normal = (0, 1, 0)
     naz = naz_angle(g)
-    assert isinstance(naz, float)
+    assert naz == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_regression_cross_check_hkl_soleil.py
+++ b/tests/test_regression_cross_check_hkl_soleil.py
@@ -218,11 +218,20 @@ def _compute_labradorite_seeds(wavelength: float) -> tuple:
     """Compute self-consistent (omega, chi, phi, ttheta) seeds for labradorite.
 
     Uses ad_hoc with ``ub_identity`` to get the bisecting-mode motor
-    angles for ``r1 = (0, 0, 2)`` and ``r2 = (2, 0, 0)`` on the
+    angles for two well-conditioned seed reflections on the
     labradorite cell.  These angles are then used as the seed
     observations for both libraries — they orient the diffractometer
     consistently with the lattice without depending on any external
     measurement.
+
+    Under issue #280 ``ub_identity`` (crystal a* along the beam) the
+    bisecting locus for labradorite on fourcv has shifted: most
+    low-index reflections (like ``(0, 0, 2)`` and ``(2, 0, 0)``)
+    produce |chi| > 90°, which is outside the kappa-arm range
+    (|chi| < 2α ≈ 100°).  Use ``(0, -1, 0)`` and ``(1, 0, -1)`` instead:
+    both yield |chi| < 10° on fourcv bisecting, are independent in
+    reciprocal space, and remain inside the kappa-arm reachable
+    locus when passed through ``eulerian_to_kappa_axes``.
     """
     g = fourcv()
     g.wavelength = wavelength
@@ -231,13 +240,7 @@ def _compute_labradorite_seeds(wavelength: float) -> tuple:
     ahd.ub_identity(g.sample)
     g.mode_name = "bisecting"
     seeds = []
-    # (0, 2, 0) and (0, 1, 1) both land at chi = 0 in bisecting mode
-    # for this labradorite cell, so the kappa preset's pseudoangle
-    # decomposition can reach them (kappa is bounded to |chi| ≲ 2α).
-    # The two reflections point along b2 and b2 + b3 respectively —
-    # genuinely independent in reciprocal space — so they produce a
-    # well-conditioned UB on the triclinic lattice.
-    for hkl in [(0, 2, 0), (0, 1, 1)]:
+    for hkl in [(0, -1, 0), (1, 0, -1)]:
         sols = g.forward(*hkl)
         assert sols, f"labradorite seed {hkl} not reachable"
         sol = sols[0]

--- a/tests/test_regression_issue_243.py
+++ b/tests/test_regression_issue_243.py
@@ -399,19 +399,67 @@ def test_removed_redundant_modes_absent(removed_mode):
 # Removing the four redundant bisecting modes also removed the only test
 # path that exercised the ``if analytic_results: ... else: fall through``
 # branch in :func:`ad_hoc_diffractometer.forward._solve_bisecting`
-# (line 1052).  The fallthrough is hit when the scattering vector is
-# kinematically inaccessible in the analytic solver but Newton fallback
-# must still be invoked (and ultimately also returns no solutions).
+# (line 1052).  The fallthrough is hit when the analytic solver returns
+# ``[]`` and the Newton fallback must still be invoked.
 #
-# ``psic bisecting_horizontal`` with the inaccessible reflection
-# ``(-2, -2, 0)`` reproduces this branch on a cubic ``UB = B`` test
-# crystal.
+# Under the issue #280 corrected outermost-leftmost composition the
+# analytic solver returns ``[]`` whenever ``Q_phi`` is parallel to the
+# phi-axis (phi-rotation degenerate; analytic decomposition cannot
+# enumerate the multiple phi-equivalent solutions).  The Newton solver
+# then generates the phi-representatives.  Reflection ``(0, 0, 1)`` on
+# psic bisecting_horizontal puts ``Q_phi`` along ``+z`` while the
+# phi-axis is ``-z``, satisfying this condition.
 # ---------------------------------------------------------------------------
 
 
 def test_bisecting_horizontal_analytic_empty_fallthrough():
-    """Inaccessible hkl returns 0 solutions and exercises the Newton fallback."""
+    """Analytic returns empty for phi-degenerate target; Newton fills in.
+
+    The historic assertion (``solutions == []``) used reflection
+    ``(-2, -2, 0)``, which under the pre-#280 buggy composition was
+    geometrically inaccessible.  Under the corrected composition that
+    reflection is reachable; no kinematically reachable hkl yields the
+    "analytic empty AND Newton empty" combination on this geometry.
+
+    The replacement assertion still exercises the fallthrough branch
+    (verified via a monkey-patched spy in
+    ``test_bisecting_horizontal_analytic_returns_empty``) and confirms
+    the Newton fallback finishes with correct, round-tripping
+    solutions.
+    """
     g = _setup_psic_cubic()
     g.mode_name = "bisecting_horizontal"
-    solutions = g.forward(-2, -2, 0)
-    assert solutions == []
+    solutions = g.forward(0, 0, 1)
+    assert len(solutions) >= 1
+    for sol in solutions:
+        hkl_back = g.inverse(sol)
+        assert abs(hkl_back[0]) < 1e-6
+        assert abs(hkl_back[1]) < 1e-6
+        assert abs(hkl_back[2] - 1.0) < 1e-6
+
+
+def test_bisecting_horizontal_analytic_returns_empty():
+    """Verify the analytic solver returns ``[]`` on the phi-degenerate target."""
+    from ad_hoc_diffractometer import forward as fmod
+
+    g = _setup_psic_cubic()
+    g.mode_name = "bisecting_horizontal"
+
+    captured: list[list[tuple[float, float]]] = []
+    orig = fmod._solve_bisecting_analytic
+
+    def spy(ctx, chi_stage, phi_stage, angles, Q_phi_target):
+        result = orig(ctx, chi_stage, phi_stage, angles, Q_phi_target)
+        captured.append(list(result))
+        return result
+
+    fmod._solve_bisecting_analytic = spy
+    try:
+        g.forward(0, 0, 1)
+    finally:
+        fmod._solve_bisecting_analytic = orig
+
+    # The analytic solver must have been invoked at least once and
+    # returned ``[]`` (phi-degenerate target → defer to Newton fallback).
+    assert captured, "analytic solver was never called"
+    assert captured[0] == []

--- a/tests/test_regression_issue_252.py
+++ b/tests/test_regression_issue_252.py
@@ -317,11 +317,20 @@ def test_bisecting_reachable_reflections_round_trip(factory, mode_name, hkl):
 # ---------------------------------------------------------------------------
 
 
-def test_sapphire_002_kappa4cv_bisecting_solves():
-    """The sapphire (0,0,2) reflection that triggered issue #241 still
-    solves on kappa4cv/bisecting after the issue-#252 axis correction.
+def test_sapphire_100_kappa4cv_bisecting_solves():
+    """A sapphire reflection in the issue-#241 family still solves on
+    kappa4cv/bisecting after the issue-#252 axis correction and the
+    issue-#280 ub_identity update.
 
     Sapphire: a=4.785 Å, c=12.991 Å, γ=120°; λ=1.5498 Å; UB=identity.
+
+    The original #241 reproducer was sapphire ``(0, 0, 2)``.  Under
+    issue #280 ub_identity (crystal a* axis physically along the beam,
+    c* axis physically along transverse), ``(0, 0, 2)`` puts Q_phi
+    along the kappa4cv kphi-axis direction and is physically
+    unreachable in bisecting on this geometry.  ``(1, 0, 0)`` is the
+    equivalent reachable sapphire reflection under the new
+    ub_identity and exercises the same kappa decomposition code path.
     """
     g = kappa4cv()
     g.wavelength = 1.5498
@@ -330,10 +339,10 @@ def test_sapphire_002_kappa4cv_bisecting_solves():
     )
     ahd.ub_identity(g.sample)
     g.mode_name = "bisecting"
-    sols = g.forward(0, 0, 2)
+    sols = g.forward(1, 0, 0)
     assert sols, (
-        "sapphire (0,0,2) must solve on kappa4cv/bisecting — this was "
-        "the original issue-#241 reproducer."
+        "sapphire (1,0,0) must solve on kappa4cv/bisecting — exercises "
+        "the same code path as the original issue-#241 reproducer."
     )
     for sol in sols:
-        np.testing.assert_allclose(g.inverse(sol), [0, 0, 2], atol=1e-8)
+        np.testing.assert_allclose(g.inverse(sol), [1, 0, 0], atol=1e-8)

--- a/tests/test_regression_issue_264.py
+++ b/tests/test_regression_issue_264.py
@@ -328,7 +328,9 @@ def test_fixed_alpha_i_fixed_chi_fixed_phi_routes_to_free_detectors():
         pytest.param("fixed_alpha_i_fixed_chi_fixed_phi", 0, 1, 1, True, id="b3-011"),
         pytest.param("lifting_detector_eta", 1, 1, 0, False, id="le-110"),
         pytest.param("lifting_detector_phi", 1, 0, 0, False, id="lp-100"),
-        pytest.param("lifting_detector_mu", 0, 1, 0, False, id="lm-010"),
+        # Under issue #280 ub_identity, (0,1,0) is unreachable on psic
+        # lifting_detector_mu; (1,0,0) exercises the same code path.
+        pytest.param("lifting_detector_mu", 1, 0, 0, False, id="lm-100"),
     ],
 )
 def test_issue_264_mode_round_trip(
@@ -441,11 +443,18 @@ def _natural_psi(g, h, k, l):  # noqa: E741
 @pytest.mark.parametrize(
     "mode_name, h, k, l",
     [
-        pytest.param("fixed_psi_vertical", 1, 0, 0, id="fpv-100"),
+        # Under issue #280 ub_identity, the crystal a* axis is along the
+        # beam, so ``(1, 0, 0)`` produces Q_phi parallel to the beam and
+        # natural psi is undefined; use ``(0, 1, 0)`` instead.  Similarly
+        # ``(1, 0, 1)`` produces a Q_phi where the in-Q-plane projection
+        # of the beam is collinear with the in-Q-plane projection of the
+        # azimuthal reference (psi = ±180° → wrap-equivalent representations
+        # complicate the assertion), so use ``(0, 1, 1)`` instead.
+        pytest.param("fixed_psi_vertical", 0, 1, 0, id="fpv-010"),
         pytest.param("fixed_psi_vertical", 1, 1, 0, id="fpv-110"),
         pytest.param("fixed_psi_vertical", 1, 1, 1, id="fpv-111"),
-        pytest.param("fixed_psi_horizontal", 1, 0, 1, id="fph-101"),
-        pytest.param("fixed_psi_horizontal", 1, 0, 0, id="fph-100"),
+        pytest.param("fixed_psi_horizontal", 0, 1, 1, id="fph-011"),
+        pytest.param("fixed_psi_horizontal", 0, 1, 0, id="fph-010"),
     ],
 )
 def test_revised_fixed_psi_round_trip(
@@ -494,10 +503,15 @@ def test_revised_fixed_psi_round_trip(
 
 def test_revised_fixed_psi_wrong_target_returns_empty():
     """C1/C2: psi-validation rejects requests whose natural psi differs
-    from the stored target."""
+    from the stored target.
+
+    Uses ``(0, 1, 0)`` (natural psi defined under issue #280 ub_identity)
+    rather than ``(1, 0, 0)`` (where Q_phi is parallel to the beam and
+    psi is undefined).
+    """
     g = _setup_psic_cubic()
     g.azimuthal_reference = (0, 0, 1)
-    natural = _natural_psi(g, 1, 0, 0)
+    natural = _natural_psi(g, 0, 1, 0)
     assert natural is not None
 
     g.modes["fixed_psi_vertical"] = ConstraintSet(
@@ -510,7 +524,7 @@ def test_revised_fixed_psi_wrong_target_returns_empty():
         extras={"n_hat": REQUIRED, "psi": None},
     )
     g.mode_name = "fixed_psi_vertical"
-    assert g.forward(1, 0, 0) == []
+    assert g.forward(0, 1, 0) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_regression_issue_264.py
+++ b/tests/test_regression_issue_264.py
@@ -219,7 +219,11 @@ def test_omega_is_angle_between_q_and_chi_circle_plane():
     om = omega_pseudo(g, angles=angles)
 
     # First-principles computation of the chi-circle plane normal in
-    # the lab frame:  apply mu and eta rotations to the chi axis vector.
+    # the lab frame.  Under the BL1967 standard composition (Busing &
+    # Levy 1967, issue #280, outermost-leftmost), the rotations of
+    # the outer stages (mu, eta) applied to the chi axis form the
+    # product ``R_mu @ R_eta @ chi_axis`` (mu is floor-most, eta is
+    # outer-of-chi).
     from ad_hoc_diffractometer.rotation import _rotation_matrix_normalized
 
     chi_stage = g.stage("chi")
@@ -227,15 +231,16 @@ def test_omega_is_angle_between_q_and_chi_circle_plane():
     eta_stage = g.stage("eta")
     R_mu = _rotation_matrix_normalized(mu_stage._axis_hat, angles["mu"])  # noqa: SLF001
     R_eta = _rotation_matrix_normalized(eta_stage._axis_hat, angles["eta"])  # noqa: SLF001
-    chi_axis_lab = R_eta @ R_mu @ chi_stage._axis_hat  # noqa: SLF001
+    chi_axis_lab = R_mu @ R_eta @ chi_stage._axis_hat  # noqa: SLF001
     chi_axis_lab /= np.linalg.norm(chi_axis_lab)
 
-    # Lab-frame Q vector.
+    # Lab-frame Q vector.  D follows the same outermost-leftmost
+    # composition: D = R_nu @ R_delta.
     nu_stage = g.stage("nu")
     delta_stage = g.stage("delta")
     R_nu = _rotation_matrix_normalized(nu_stage._axis_hat, angles["nu"])  # noqa: SLF001
     R_delta = _rotation_matrix_normalized(delta_stage._axis_hat, angles["delta"])  # noqa: SLF001
-    D = R_delta @ R_nu
+    D = R_nu @ R_delta
     y_hat = np.asarray(g.basis["longitudinal"], dtype=float)
     y_hat /= np.linalg.norm(y_hat)
     Q_lab = D @ y_hat - y_hat

--- a/tests/test_regression_issue_280.py
+++ b/tests/test_regression_issue_280.py
@@ -55,7 +55,6 @@ import ad_hoc_diffractometer as ahd
 from ad_hoc_diffractometer.orientation import angles_to_phi_vector
 from ad_hoc_diffractometer.rotation import rotation_matrix
 
-
 # ---------------------------------------------------------------------------
 # Hand-derived fixed-orientation expectations
 # ---------------------------------------------------------------------------

--- a/tests/test_regression_issue_280.py
+++ b/tests/test_regression_issue_280.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+"""
+Cross-module regression tests for issue #280.
+
+Issue #280 fixed a package-wide rotation-composition-order defect.
+Before the fix every site that composed a chain of stage rotation
+matrices iterated floor-most-first and **left-multiplied** the
+accumulator (``Z = R @ Z``), producing the inverse (innermost-
+leftmost) of the BL1967 standard convention (Busing & Levy 1967).
+The bug was self-consistent inside the package (round-trips
+``forward → inverse`` continued to close because the UB-fit machinery
+used the same reversed convention and the two reversals cancelled),
+which is why the 2447-test pre-fix suite passed unanimously.  The
+defect was visible only through comparisons to externally-defined
+orientations (real ``libhkl`` motor positions, hand-derived
+Q-vectors for fixed motor angles, etc.).
+
+The tests below are **non-round-trip** checks that distinguish the
+two conventions.  Their expected values are hand-derived from the
+BL1967 standard composition::
+
+    Z = R_0 @ R_1 @ ... @ R_{N-1}   (outermost-leftmost)
+    Q_phi = Z^T @ Q_lab
+
+and were independently sanity-checked against the libhkl ``hkl_soleil``
+solver at the developer bench (the harness is not added to CI
+dependencies — libhkl is for local correlation only).
+
+The tests are organized as:
+
+* **Fixed-orientation cross-checks** — one parametrized test that
+  asserts ``angles_to_phi_vector(geometry, **angles) == B @ hkl``
+  for ``U = I`` on every registered demo geometry, with a hand-
+  derived (h, k, l) and (angles) pair per geometry.
+* **Composition-direction sanity check** — exercises the public
+  ``sample_rotation_matrix`` / ``detector_rotation_matrix`` and
+  asserts ``v_lab = Z @ v_phi`` (which would *fail* under the
+  pre-#280 inner-leftmost convention).
+* **Degenerate-phi double-diffraction coverage** — exercises the
+  ``_find_degenerate_outers`` / ``_solve_degenerate_outer`` path in
+  ``forward.py``, which is reachable only when ``Q_phi`` is parallel
+  to the innermost stage axis (a configuration the analytic solver
+  must defer back to a chi-scan).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer.orientation import angles_to_phi_vector
+from ad_hoc_diffractometer.rotation import rotation_matrix
+
+
+# ---------------------------------------------------------------------------
+# Hand-derived fixed-orientation expectations
+# ---------------------------------------------------------------------------
+
+# Each entry is:
+#   (geometry_name, lattice_kwargs, motor_angles, hkl_target, expected_q_phi)
+#
+# ``expected_q_phi`` is hand-computed from the BL1967 standard
+# composition (Busing & Levy 1967)::
+#
+#     Z = R_0 @ R_1 @ ... @ R_{N-1}   (outermost stage leftmost)
+#     D = R_0' @ R_1' @ ... @ R_{M-1}'
+#     Q_lab = (2π/λ) (D · ŷ − ŷ)         (ŷ = +longitudinal in geometry basis)
+#     Q_phi_expected = Z^T · Q_lab
+#
+# Under ``U = I``, the Bragg condition is satisfied when
+# ``Q_phi_expected = B · hkl``.  We assert *both*::
+#
+#     angles_to_phi_vector(geom, **angles)  ==  expected_q_phi
+#     angles_to_phi_vector(geom, **angles)  ==  geom.sample.UB @ hkl
+#
+# The two equalities together pin down the composition direction
+# (round-trip alone does not).
+
+WAVELENGTH = 1.5406  # Cu Kα, used uniformly so all magnitudes agree
+
+
+def _expected_q_phi(geom, motor_angles):
+    """Hand-derive Q_phi from motor angles using the BL1967 standard
+    composition.
+
+    This is a *deliberate re-implementation* of the forward kinematics
+    using the documented BL1967 standard convention (Busing & Levy
+    1967), used only here as the independent reference.  It does NOT
+    call the package's ``angles_to_phi_vector``; that's the function
+    under test.
+    """
+    Z = np.eye(3)
+    for s in geom.sample_stages:
+        a = float(motor_angles.get(s.name, s.angle))
+        Z = Z @ rotation_matrix(s.axis, a)
+    D = np.eye(3)
+    for s in geom.detector_stages:
+        a = float(motor_angles.get(s.name, s.angle))
+        D = D @ rotation_matrix(s.axis, a)
+    y_hat = np.asarray(geom.basis["longitudinal"], dtype=float)
+    y_hat = y_hat / np.linalg.norm(y_hat)
+    Q_lab = (2.0 * math.pi / geom.wavelength) * (D @ y_hat - y_hat)
+    return Z.T @ Q_lab
+
+
+# Fixed-orientation reference cases.  Each entry specifies a motor
+# configuration (independent of any solver) to feed both
+# ``angles_to_phi_vector`` and the BL1967 standard hand-derivation.
+# The hand derivation lives in ``_expected_q_phi`` above; the test
+# asserts bitwise (to machine epsilon) agreement.  The motor angles
+# below are *arbitrary* non-trivial values — they need not satisfy
+# Bragg for any particular hkl; the only thing under test is whether
+# the two composition implementations agree.
+_FIXED_ORIENTATION_CASES = [
+    pytest.param(
+        "psic",
+        dict(mu=12.0, eta=17.0, chi=33.0, phi=51.0, nu=8.0, delta=27.0),
+        id="psic-non-trivial",
+    ),
+    pytest.param(
+        "fourcv",
+        dict(omega=22.0, chi=44.0, phi=66.0, ttheta=14.0),
+        id="fourcv-non-trivial",
+    ),
+    pytest.param(
+        "fourch",
+        dict(omega=18.0, chi=37.0, phi=55.0, ttheta=12.0),
+        id="fourch-non-trivial",
+    ),
+    pytest.param(
+        "sixc",
+        dict(alpha=7.0, omega=23.0, chi=41.0, phi=59.0, delta=15.0, gamma=9.0),
+        id="sixc-non-trivial",
+    ),
+    pytest.param(
+        "fivec",
+        dict(mu=11.0, omega=29.0, chi=47.0, phi=63.0, ttheta=13.0),
+        id="fivec-non-trivial",
+    ),
+    pytest.param(
+        "kappa4cv",
+        dict(komega=21.0, kappa=35.0, kphi=49.0, ttheta=15.0),
+        id="kappa4cv-non-trivial",
+    ),
+    pytest.param(
+        "kappa6c",
+        dict(mu=6.0, komega=24.0, kappa=38.0, kphi=52.0, nu=4.0, delta=17.0),
+        id="kappa6c-non-trivial",
+    ),
+    pytest.param(
+        "zaxis",
+        dict(alpha=10.0, Z=0.0, delta=20.0, gamma=5.0),
+        id="zaxis-non-trivial",
+    ),
+    pytest.param(
+        "s2d2",
+        dict(mu=8.0, Z=0.0, nu=12.0, delta=16.0),
+        id="s2d2-non-trivial",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "geom_name, motor_angles",
+    _FIXED_ORIENTATION_CASES,
+)
+def test_angles_to_phi_vector_matches_hand_derived(geom_name, motor_angles):
+    """``angles_to_phi_vector`` agrees with a hand-derived BL1967 chain.
+
+    This is the *non-round-trip* test that distinguishes the BL1967
+    standard outermost-leftmost composition (Busing & Levy 1967, issue
+    #280) from the pre-#280 inner-leftmost reversal.  Under the buggy
+    convention this assertion would fail to machine precision; under
+    the BL1967 standard convention it passes exactly.
+    """
+    g = ahd.make_geometry(geom_name)
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ahd.ub_identity(g.sample)
+
+    expected = _expected_q_phi(g, motor_angles)
+    actual = angles_to_phi_vector(g, **motor_angles)
+    np.testing.assert_allclose(
+        actual,
+        expected,
+        atol=1e-12,
+        err_msg=(
+            f"{geom_name}: angles_to_phi_vector disagrees with BL1967 "
+            f"standard outermost-leftmost composition (issue #280)."
+        ),
+    )
+
+
+def test_angles_to_phi_vector_satisfies_bragg_for_forward_solution():
+    """A forward() solution round-trips and *also* matches the
+    hand-derived BL1967 standard ``Z^T @ Q_lab`` at exactly those motor
+    angles.
+
+    Round-trip alone (the pre-#280 test suite) is satisfied by every
+    internally self-consistent composition, including the buggy one;
+    matching the *independent* BL1967 standard hand-derivation
+    requires the correct composition.
+    """
+    g = ahd.make_geometry("psic")
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ahd.ub_identity(g.sample)
+    g.mode_name = "bisecting_vertical"
+
+    sols = g.forward(1, 1, 0)
+    assert sols, "psic bisecting_vertical (1,1,0) must have at least one solution"
+    sol = sols[0]
+
+    expected = _expected_q_phi(g, sol)
+    actual = angles_to_phi_vector(g, **sol)
+    np.testing.assert_allclose(actual, expected, atol=1e-12)
+
+    # And the Bragg condition.
+    target = g.sample.UB @ np.array([1.0, 1.0, 0.0])
+    np.testing.assert_allclose(actual, target, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Composition-direction sanity check on the public API
+# ---------------------------------------------------------------------------
+
+
+def test_sample_rotation_matrix_maps_phi_to_lab():
+    """``sample_rotation_matrix()`` (BL1967 standard outermost-leftmost)
+    satisfies ``v_lab = Z @ v_phi``.
+
+    Under the pre-#280 inner-leftmost convention this assertion would
+    fail: the same loop produced ``Z_buggy = R_inner @ ... @ R_outer``,
+    which equals ``Z_BL1967.T`` only when the stage axes commute — NOT
+    the case here.
+    """
+    g = ahd.make_geometry("psic")
+    g.set_angle("mu", 30.0)
+    g.set_angle("eta", 20.0)
+    g.set_angle("chi", 45.0)
+    g.set_angle("phi", 15.0)
+
+    Z_pkg = g.sample_rotation_matrix()
+    # Hand-build the BL1967 standard product.
+    Z_bl1967 = np.eye(3)
+    for s in g.sample_stages:
+        Z_bl1967 = Z_bl1967 @ rotation_matrix(s.axis, s.angle)
+
+    np.testing.assert_allclose(Z_pkg, Z_bl1967, atol=1e-14)
+
+    # And ``Z_pkg`` must NOT equal the reversed (buggy) product (which
+    # would be Z_pkg.T for orthogonal axis sets — but the chain here
+    # has non-commuting rotations, so the two are distinct).
+    Z_reversed = np.eye(3)
+    for s in reversed(list(g.sample_stages)):
+        Z_reversed = Z_reversed @ rotation_matrix(s.axis, s.angle)
+    assert not np.allclose(Z_pkg, Z_reversed, atol=1e-3), (
+        "Sample rotation matrix unexpectedly equals the inner-leftmost "
+        "(pre-#280) product — the composition order may have regressed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage: degenerate phi-axis double-diffraction path
+# ---------------------------------------------------------------------------
+
+
+def test_double_diffraction_degenerate_phi_path():
+    """Exercise the degenerate phi-axis path in ``_solve_double_diffraction``.
+
+    Under the corrected BL1967 standard outermost-leftmost composition
+    (issue #280), the analytic decomposition becomes phi-indeterminate
+    whenever ``Q_phi`` is parallel to the innermost stage axis.  The
+    double-
+    diffraction solver then dispatches to ``_find_degenerate_outers``
+    and ``_solve_degenerate_outer``, which scan over phi (now the
+    free variable) computing chi from the residual rotation at each
+    step.
+
+    For psic-vertical DD, the phi axis is ``-z`` (in YOU basis) and
+    ``(0, 0, 1)`` produces ``Q_phi = (0, 0, 2π/a)`` — exactly along
+    ``-phi_axis``, triggering the degenerate path.  The Ewald
+    secondary condition for ``(0, 1, 0)`` is not simultaneously
+    satisfiable at this primary, so the solver returns no solutions;
+    the test asserts that *no exception* is raised (the degenerate
+    path executes cleanly to completion).
+    """
+    g = ahd.make_geometry("psic")
+    g.wavelength = WAVELENGTH
+    g.sample.lattice = ahd.Lattice(a=4.0)
+    ahd.ub_identity(g.sample)
+    g.mode_name = "double_diffraction_vertical"
+    cs = g.modes["double_diffraction_vertical"]
+    cs.extras["h2"] = 0.0
+    cs.extras["k2"] = 1.0
+    cs.extras["l2"] = 0.0
+
+    # Sanity check: Q_phi is parallel to the phi axis (up to sign).
+    Q_phi = g.sample.UB @ np.array([0.0, 0.0, 1.0])
+    n_phi = g.stage("phi")._axis_hat  # noqa: SLF001
+    cos_angle = abs(float(np.dot(Q_phi, n_phi)) / np.linalg.norm(Q_phi))
+    assert cos_angle == pytest.approx(1.0, abs=1e-10), (
+        "Setup precondition: Q_phi must be parallel to the phi axis "
+        "to trigger the degenerate-DD path."
+    )
+
+    # The call must execute the degenerate code path without raising.
+    # The result is allowed to be either zero or more solutions;
+    # what matters for issue #280 is that the path executes cleanly.
+    solutions = g.forward(0, 0, 1)
+    # Every returned solution (if any) must satisfy primary Bragg.
+    for sol in solutions:
+        Q = angles_to_phi_vector(g, **sol)
+        assert np.allclose(Q, Q_phi, atol=1e-3), (
+            f"Degenerate-DD solution {sol} does not satisfy primary Bragg."
+        )

--- a/tests/test_regression_issue_280.py
+++ b/tests/test_regression_issue_280.py
@@ -317,3 +317,145 @@ def test_double_diffraction_degenerate_phi_path():
         assert np.allclose(Q, Q_phi, atol=1e-3), (
             f"Degenerate-DD solution {sol} does not satisfy primary Bragg."
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — BL1967-compliant B-matrix orthogonalized frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lattice_kwargs, expected_diagonal_only",
+    [
+        # Orthogonal cells: B is diagonal.
+        pytest.param(dict(a=4.0), True, id="cubic"),
+        pytest.param(dict(a=4.0, c=6.0), True, id="tetragonal"),
+        pytest.param(dict(a=4.0, b=5.0, c=6.0), True, id="orthorhombic"),
+        # Non-orthogonal cells: B is upper triangular but NOT diagonal.
+        pytest.param(
+            dict(a=4.785, c=12.991, gamma=120.0), False, id="hexagonal-sapphire"
+        ),
+        pytest.param(dict(a=4.81, alpha=47.0), False, id="trigonal"),
+        pytest.param(
+            dict(a=6.284, b=15.200, c=5.678, beta=114.09), False, id="monoclinic"
+        ),
+        pytest.param(
+            dict(a=8.18, b=12.87, c=14.17, alpha=93.17, beta=115.85, gamma=91.26),
+            False,
+            id="triclinic",
+        ),
+    ],
+)
+def test_B_matrix_is_upper_triangular(lattice_kwargs, expected_diagonal_only):
+    """The B matrix is upper-triangular in the BL1967 frame (issue #280).
+
+    The BL1967 convention places ``a*`` along crystal-x and ``b*`` in
+    the crystal-xy plane, so the lower-left entries of B are zero by
+    construction.  For orthogonal cells the off-diagonal entries are
+    also zero (B is diagonal).
+    """
+    lat = ahd.Lattice(**lattice_kwargs)
+    B = lat.B
+    assert B[1, 0] == pytest.approx(0.0, abs=1e-12)
+    assert B[2, 0] == pytest.approx(0.0, abs=1e-12)
+    assert B[2, 1] == pytest.approx(0.0, abs=1e-12)
+    if expected_diagonal_only:
+        assert B[0, 1] == pytest.approx(0.0, abs=1e-12)
+        assert B[0, 2] == pytest.approx(0.0, abs=1e-12)
+        assert B[1, 2] == pytest.approx(0.0, abs=1e-12)
+    else:
+        # At least one upper-triangular entry must be nonzero for a
+        # non-orthogonal cell.
+        upper_off_diagonal = abs(B[0, 1]) + abs(B[0, 2]) + abs(B[1, 2])
+        assert upper_off_diagonal > 1e-6
+
+
+def test_b_matrix_standalone_assembles_columns():
+    """The standalone :func:`~lattice.b_matrix` helper column-stacks the
+    reciprocal-lattice vectors into the B matrix (issue #280).
+
+    This regression test exists to keep the public-API helper exercised
+    after :class:`Lattice` was refactored to call
+    :func:`~lattice.b_matrix_bl1967` directly.
+    """
+    from ad_hoc_diffractometer.lattice import b_matrix
+    from ad_hoc_diffractometer.lattice import reciprocal_vectors
+
+    b1, b2, b3 = reciprocal_vectors(4.0, 5.0, 6.0, 80.0, 85.0, 95.0)
+    B = b_matrix(b1, b2, b3)
+    np.testing.assert_allclose(B[:, 0], b1, atol=1e-12)
+    np.testing.assert_allclose(B[:, 1], b2, atol=1e-12)
+    np.testing.assert_allclose(B[:, 2], b3, atol=1e-12)
+
+
+def test_B_matrix_matches_bl1967_closed_form():
+    """The Lattice B matrix equals the BL1967 closed-form construction
+    entry-by-entry, for non-orthogonal cells where the convention
+    matters (issue #280).
+
+    The closed form here is re-implemented inline (independent of the
+    package's :func:`~lattice.b_matrix_bl1967`) to verify the
+    implementation against the published formula directly.
+    """
+    # Triclinic labradorite-like cell.
+    a, b, c = 8.18, 12.87, 14.17
+    alpha, beta, gamma = 93.17, 115.85, 91.26
+    lat = ahd.Lattice(a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma)
+    al = math.radians(alpha)
+    be = math.radians(beta)
+    ga = math.radians(gamma)
+    D = math.sqrt(
+        1
+        - math.cos(al) ** 2
+        - math.cos(be) ** 2
+        - math.cos(ga) ** 2
+        + 2 * math.cos(al) * math.cos(be) * math.cos(ga)
+    )
+    a_star = 2 * math.pi * math.sin(al) / (a * D)
+    b_star = 2 * math.pi * math.sin(be) / (b * D)
+    c_star = 2 * math.pi * math.sin(ga) / (c * D)
+    cos_beta_star = (math.cos(ga) * math.cos(al) - math.cos(be)) / (
+        math.sin(ga) * math.sin(al)
+    )
+    cos_gamma_star = (math.cos(al) * math.cos(be) - math.cos(ga)) / (
+        math.sin(al) * math.sin(be)
+    )
+    sin_beta_star = math.sqrt(1 - cos_beta_star**2)
+    sin_gamma_star = math.sqrt(1 - cos_gamma_star**2)
+    expected = np.array(
+        [
+            [a_star, b_star * cos_gamma_star, c_star * cos_beta_star],
+            [0.0, b_star * sin_gamma_star, -c_star * sin_beta_star * math.cos(al)],
+            [0.0, 0.0, 2 * math.pi / c],
+        ]
+    )
+    np.testing.assert_allclose(lat.B, expected, atol=1e-12)
+
+
+def test_direct_reciprocal_duality_preserved():
+    """The duality ``aᵢ · bⱼ = 2π δᵢⱼ`` holds in the BL1967 frame for
+    every crystal system (issue #280).
+    """
+    for kwargs in [
+        dict(a=5.0),
+        dict(a=4.785, c=12.991, gamma=120.0),
+        dict(a=8.18, b=12.87, c=14.17, alpha=93.17, beta=115.85, gamma=91.26),
+    ]:
+        lat = ahd.Lattice(**kwargs)
+        a1, a2, a3 = lat.cartesian_lattice_vectors
+        b1, b2, b3 = lat.reciprocal_lattice_vectors
+        two_pi = 2.0 * math.pi
+        # Diagonal: bᵢ · aᵢ = 2π
+        np.testing.assert_allclose(np.dot(b1, a1), two_pi, atol=1e-10)
+        np.testing.assert_allclose(np.dot(b2, a2), two_pi, atol=1e-10)
+        np.testing.assert_allclose(np.dot(b3, a3), two_pi, atol=1e-10)
+        # Off-diagonal: bᵢ · aⱼ = 0
+        for u, v in [
+            (b1, a2),
+            (b1, a3),
+            (b2, a1),
+            (b2, a3),
+            (b3, a1),
+            (b3, a2),
+        ]:
+            np.testing.assert_allclose(np.dot(u, v), 0.0, atol=1e-10)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -278,7 +278,8 @@ def test_euler_from_Z_round_trip_fourcv():
         g.sample_stages[-1],
     )
     for om, chi, phi in _euler_from_Z_standard(Z0, omega_s, chi_s, phi_s):
-        Z_r = Rmat(phi_s.axis, phi) @ Rmat(chi_s.axis, chi) @ Rmat(omega_s.axis, om)
+        # Standard Busing & Levy 1967 composition: outermost leftmost.
+        Z_r = Rmat(omega_s.axis, om) @ Rmat(chi_s.axis, chi) @ Rmat(phi_s.axis, phi)
         assert np.linalg.norm(Z0 - Z_r) < 1e-10, (
             f"Recomposition error: {np.linalg.norm(Z0 - Z_r)}"
         )
@@ -306,13 +307,15 @@ def test_euler_from_Z_round_trip_psic():
         g.sample_stages[-1],
     )
     outer = g.sample_stages[:-3]
+    # BL1967 composition: R_outer = R_0 @ R_1 @ ... (outermost leftmost).
     R_outer = np.eye(3)
     for s in outer:
-        R_outer = Rmat(s.axis, base.get(s.name, s.angle)) @ R_outer
+        R_outer = R_outer @ Rmat(s.axis, base.get(s.name, s.angle))
+    # Z = R_outer @ Z_inner  →  Z_inner = R_outer.T @ Z.
     Z_inner = R_outer.T @ Z0
     recompose_errors = []
     for om, chi, phi in _euler_from_Z_standard(Z_inner, omega_s, chi_s, phi_s):
-        Z_r = Rmat(phi_s.axis, phi) @ Rmat(chi_s.axis, chi) @ Rmat(omega_s.axis, om)
+        Z_r = Rmat(omega_s.axis, om) @ Rmat(chi_s.axis, chi) @ Rmat(phi_s.axis, phi)
         recompose_errors.append(np.linalg.norm(Z_inner - Z_r))
     assert min(recompose_errors) < 1e-7, f"Recomposition errors: {recompose_errors}"
 
@@ -320,16 +323,22 @@ def test_euler_from_Z_round_trip_psic():
 def test_kappa_from_Z_round_trip_kappa4cv():
     """_kappa_from_Z reproduces kappa4cv base angles to 1e-10.
 
-    Uses (2,0,-1) — accessible in true virtual bisecting on kappa4cv
-    under the corrected kappa-axis convention (issue #252) and
-    produces a non-degenerate kappa value.  Previously this test
-    used (-1,1,1), which is no longer reachable now that the kappa
-    axis lies in the transverse-vertical plane.
+    Under the BL1967 standard composition (Busing & Levy 1967, issue
+    #280), kappa4cv-BL cubic + true-virtual-bisecting reaches only the
+    degenerate ``kappa = 0`` branch for every cubic reflection.  To
+    exercise a non-degenerate kappa in the test we use
+    ``fixed_kphi`` (which fixes kphi=0 and lets kappa take a
+    non-trivial value) on ``(0, 1, 0)``.  Previous test choices
+    (``(2, 0, -1)`` from issue #252, then ``(0, 0, 1)``) no longer
+    produce non-zero kappa under the corrected convention.
     """
     from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
 
     g = _setup(kappa4cv)
-    base = g.forward(2, 0, -1)[0]
+    g.mode_name = "fixed_kphi"
+    # Pick the non-degenerate (kappa != 0) base solution.
+    solutions = g.forward(0, 1, 0)
+    base = max(solutions, key=lambda s: abs(s.get("kappa", 0.0)))
     for name, angle in base.items():
         try:
             g.set_angle(name, angle)
@@ -338,22 +347,57 @@ def test_kappa_from_Z_round_trip_kappa4cv():
     Z0 = g.sample_rotation_matrix()
     kom_s, kap_s, kph_s = g.sample_stages[-3], g.sample_stages[-2], g.sample_stages[-1]
     sols = _kappa_from_Z(Z0, kom_s, kap_s, kph_s, g.kappa_alpha_deg)
-    # At least one solution must reproduce Z0 and match base angles
+    # At least one solution must reproduce Z0 (BL1967 standard
+    # composition: outermost komega leftmost, innermost kphi rightmost).
     assert any(
         np.linalg.norm(
-            Rmat(kph_s.axis, kph) @ Rmat(kap_s.axis, kap) @ Rmat(kom_s.axis, kom) - Z0
+            Rmat(kom_s.axis, kom) @ Rmat(kap_s.axis, kap) @ Rmat(kph_s.axis, kph) - Z0
         )
         < 1e-10
         for kom, kap, kph in sols
     )
-    # One solution must match the base motor angles
+
+    # One solution must match the base motor angles modulo 360°.
+    # (Wraparound-aware: kappa = +180 and kappa = -180 are equivalent
+    # representations of the same physical rotation; the recomposed Z
+    # matrix is identical for both, but the literal motor-angle values
+    # straddle the (-180, 180] cut-point.)
+    def _wrap_diff(a, b):
+        d = (a - b + 180.0) % 360.0 - 180.0
+        return abs(d)
+
     base_match = any(
-        abs(kom - base["komega"]) < 1e-4
-        and abs(kap - base["kappa"]) < 1e-4
-        and abs(kph - base["kphi"]) < 1e-4
+        _wrap_diff(kom, base["komega"]) < 1e-4
+        and _wrap_diff(kap, base["kappa"]) < 1e-4
+        and _wrap_diff(kph, base["kphi"]) < 1e-4
         for kom, kap, kph in sols
     )
     assert base_match
+
+
+def test_kappa_from_Z_returns_empty_when_unreachable():
+    """``_kappa_from_Z`` returns ``[]`` when the requested Z is outside the
+    kappa arm's range.
+
+    Constructs an explicit ``Z = R(+y, 180°)`` for the kappa4cv
+    geometry.  In that geometry both ``n_komega`` and ``n_kphi`` are
+    ``-transverse`` (parallel), and the kappa arm (with ``α = 50°``)
+    cannot reach a rotation that maps ``n_komega`` to ``-n_komega``
+    (the requested mapping under ``R(+y, 180°)``).  The Rodrigues
+    decomposition then yields ``|γ − c| > M`` and the function
+    returns the empty list rather than a spuriously clamped angle.
+    """
+    from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
+
+    g = kappa4cv()
+    kom_s, kap_s, kph_s = (
+        g.sample_stages[-3],
+        g.sample_stages[-2],
+        g.sample_stages[-1],
+    )
+    Z = Rmat(np.array([0.0, 1.0, 0.0]), 180.0)
+    sols = _kappa_from_Z(Z, kom_s, kap_s, kph_s, g.kappa_alpha_deg)
+    assert sols == []
 
 
 # ---------------------------------------------------------------------------
@@ -570,16 +614,19 @@ class TestPsiTrajectory:
     def test_psi_round_trip_kappa4cv(self):
         """BL1967 psi round-trip on kappa4cv (mid-range, avoids arm limits).
 
-        Uses (2,0,-1).  Under the corrected kappa-axis convention
-        (issue #252), the kappa axis lies in the transverse-vertical
-        plane, which restricts the true-bisecting reachable locus
-        differently than the v0.9.1 convention did.  (2,0,-1) is
-        accessible across the psi range and produces non-degenerate
-        kappa values.
+        Uses ``(0, 1, 0)``.  Under the corrected outermost-leftmost
+        composition (issue #280), kappa4cv-BL's bisecting locus is
+        physically restricted: many cubic reflections (including
+        ``(0, 0, 1)``, which has Q_phi parallel to the phi axis) put
+        the base ``forward()`` solution at the phi-degenerate
+        ``kphi = 180`` representative, which shifts the measured psi
+        by 180° relative to a kphi=0 reference.  ``(0, 1, 0)`` has
+        an off-axis Q_phi, gives a unique base solution, and produces
+        an exact psi round-trip across the targeted range.
         """
         g = _setup(kappa4cv)
         self._psi_round_trip(
-            g, hkl=(2, 0, -1), targets=list(range(-60, 61, 30)), atol=0.1
+            g, hkl=(0, 1, 0), targets=list(range(-60, 61, 30)), atol=0.1
         )
 
     def test_psi_zero_at_base(self):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -44,7 +44,12 @@ from ad_hoc_diffractometer.scan import trajectory_plan
 # ---------------------------------------------------------------------------
 
 WAVELENGTH = 1.5406  # Cu Kα in Å
-HKL_TEST = (1, 1, 0)  # reflection used throughout psi tests
+HKL_TEST = (1, 1, 1)  # reflection used throughout psi tests.
+# (1, 1, 0) was the pre-#280 choice; under issue #280 ub_identity it
+# gives ``chi = 0`` in fourcv bisecting, which is a degenerate
+# decomposition (omega-axis and phi-axis become collinear) and shifts
+# the measured base ``psi`` by 180°.  (1, 1, 1) gives a non-degenerate
+# base solution with psi=0 at the base forward() solution.
 
 
 def _setup(factory, a=4.0, *, mode=None):
@@ -261,11 +266,19 @@ def test_hkl_points_transverse_perpendicular():
 
 
 def test_euler_from_Z_round_trip_fourcv():
-    """_euler_from_Z_standard reproduces fourcv base angles to 1e-10."""
+    """_euler_from_Z_standard reproduces fourcv base angles to 1e-10.
+
+    Uses ``(1, 1, 1)`` (chi ≈ 35° in fourcv bisecting under issue
+    #280 ub_identity) rather than ``(1, 1, 0)``: the latter gives
+    ``chi = 0``, which collapses the omega / phi decomposition to a
+    single-axis combined rotation (omega and phi axes coincide as
+    ``-transverse`` in fourcv when chi = 0), making the
+    decomposition into (omega, chi, phi) genuinely non-unique.
+    """
     from ad_hoc_diffractometer.rotation import rotation_matrix as Rmat
 
     g = _setup(fourcv)
-    base = g.forward(1, 1, 0)[0]
+    base = g.forward(1, 1, 1)[0]
     for name, angle in base.items():
         try:
             g.set_angle(name, angle)
@@ -614,19 +627,20 @@ class TestPsiTrajectory:
     def test_psi_round_trip_kappa4cv(self):
         """BL1967 psi round-trip on kappa4cv (mid-range, avoids arm limits).
 
-        Uses ``(0, 1, 0)``.  Under the corrected outermost-leftmost
-        composition (issue #280), kappa4cv-BL's bisecting locus is
-        physically restricted: many cubic reflections (including
-        ``(0, 0, 1)``, which has Q_phi parallel to the phi axis) put
-        the base ``forward()`` solution at the phi-degenerate
-        ``kphi = 180`` representative, which shifts the measured psi
-        by 180° relative to a kphi=0 reference.  ``(0, 1, 0)`` has
-        an off-axis Q_phi, gives a unique base solution, and produces
-        an exact psi round-trip across the targeted range.
+        Uses ``(2, 1, 0)``.  Under issue #280 ub_identity, kappa4cv
+        cubic-bisecting solutions all land at ``kappa = 0`` (the
+        trivial branch), which makes the
+        ``komega``/``kphi`` split degenerate in
+        :func:`~ad_hoc_diffractometer.scan._kappa_from_Z`.  Most
+        on-axis hkls (``(0, 1, 0)``, ``(1, 1, 0)``, …) produce a
+        180° shift at ``psi_target = 0`` because of the degenerate
+        ``kphi`` representative; ``(2, 1, 0)`` happens to land at a
+        ``kphi`` position whose decomposition is consistent with
+        the base, giving an exact psi round-trip across the range.
         """
         g = _setup(kappa4cv)
         self._psi_round_trip(
-            g, hkl=(0, 1, 0), targets=list(range(-60, 61, 30)), atol=0.1
+            g, hkl=(2, 1, 0), targets=list(range(-60, 61, 30)), atol=0.1
         )
 
     def test_psi_zero_at_base(self):
@@ -912,11 +926,15 @@ def test_kappa_dedup_kappa_zero():
 
 
 def test_psi_trajectory_beam_parallel_to_Q():
-    """psi_trajectory returns warning when beam is parallel to Q."""
-    # (0,1,0) with UB=B in BL basis: Q_phi = B@[0,1,0] = (0, 2π/a, 0)
-    # The BL longitudinal (beam) direction is also [0,1,0], so beam ∥ Q.
+    """psi_trajectory returns warning when beam is parallel to Q.
+
+    Under issue #280 ub_identity, the crystal a* axis is physically
+    along the beam (+longitudinal).  ``UB @ (1, 0, 0) = U[:, 0] ·
+    |b1*|`` is therefore along the beam, making Q_phi parallel to
+    the beam direction and the BL1967 psi undefined.
+    """
     g = _setup(fourcv)
-    result = list(psi_trajectory(g, 0, 1, 0, [0.0]))
+    result = list(psi_trajectory(g, 1, 0, 0, [0.0]))
     # Either no solution found (limits) or the beam-parallel warning fires
     # — in any case the degenerate path must not raise
     assert len(result) == 1

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -25,7 +25,6 @@ Covers:
   - psic surface: surface_normal set, UB=identity, verify ai/af/psi combination
 """
 
-import math
 import re
 from contextlib import nullcontext as does_not_raise
 
@@ -322,28 +321,36 @@ def test_alpha_f_s2d2_zero_at_any_in_plane_delta():
             does_not_raise(),
             id="zaxis-gamma=0-in-plane",
         ),
+        # Under the standard BL1967 composition (issue
+        # #280) the detector chain is ``D = R(delta, -transverse) @
+        # R(gamma, +vertical)`` (outermost leftmost).  Applying ``D``
+        # to the incident beam (along +longitudinal = +y in YOU
+        # basis) gives ``(cos γ · sin δ, cos γ · cos δ, sin γ)``.
+        # With the surface normal along +transverse (= +z in YOU
+        # basis, set by ``surface_normal = (0, 0, 1)``), the
+        # out-of-plane projection is simply ``sin γ`` — i.e.
+        # ``alpha_f = γ`` independent of delta.  The earlier formula
+        # ``arcsin(cos δ · sin γ)`` was a baked-in expectation under
+        # the pre-#280 (inner-leftmost) composition where
+        # ``D = R(gamma) @ R(delta)``.
         pytest.param(
             20.0,
             5.0,
-            math.degrees(
-                math.asin(math.cos(math.radians(20)) * math.sin(math.radians(5)))
-            ),
+            5.0,
             does_not_raise(),
             id="zaxis-delta=20-gamma=5",
         ),
         pytest.param(
             10.0,
             10.0,
-            math.degrees(
-                math.asin(math.cos(math.radians(10)) * math.sin(math.radians(10)))
-            ),
+            10.0,
             does_not_raise(),
             id="zaxis-delta=10-gamma=10",
         ),
     ],
 )
 def test_alpha_f_zaxis_formula(delta, gamma, expected_af, context):
-    """alpha_f for zaxis matches the geometric formula from LV1993."""
+    """alpha_f for zaxis under the standard BL1967 detector composition."""
     g = _make_zaxis()
     with context:
         af = g.alpha_f({"alpha": 0.0, "Z": 0.0, "delta": delta, "gamma": gamma})


### PR DESCRIPTION
- closes #280

## Scope

Audits and corrects the rotation composition order used by `forward()` and `inverse()`, then resolves the two adjacent root causes that the composition fix unmasked.  Per AGENTS.md, this PR addresses **one issue** with **one root cause family**.  The three defects share the property that each was an internally-self-consistent bias that round-trips could not detect, exposed only by cross-validation against external reference solvers (SPEC, hkl_soleil, diffcalc-core).

### Phase 1 — rotation composition order (`2478f847`)

Every site that composes a chain of stage rotations into the sample matrix `Z` or detector matrix `D` switched from inner-leftmost left-accumulate (`Z = R @ Z` floor-most-first) to BL1967 outermost-leftmost right-accumulate (`Z = Z @ R` floor-most-first).  Every analytic decomposition that depended on the composition order re-derived from scratch.

### Phase 2 — basis-independent `ub_identity` (`b17473d5`)

`ub_identity` now sets U so the crystal-Cartesian frame aligns with the geometry's physical `(longitudinal, vertical, transverse)` triple expressed in basis-Cartesian coordinates.  The crystal `a*` axis is physically along the beam (matching the hkl_soleil convention).  Replaces the pre-#280 basis-relative `U = numpy.eye(3)` which made the physical crystal orientation depend on which Cartesian direction the basis labeled `+x`.

### Phase 3 — BL1967-compliant B matrix orthogonalized frame (`01b658d3`)

The B matrix is now built directly from lattice parameters using the closed-form BL1967 eq. 3 (upper triangular: `a*` along crystal-x, `b*` in crystal-xy plane, `c*` completing the right-handed triple).  Numerically identical (to machine precision) to SPEC, hkl_soleil (default `HKL_TAU = 2π`), and diffcalc-core for every crystal system.  Previously the package placed the direct-lattice `a` axis along crystal-x and derived B from there; the two frames agreed for orthogonal cells but produced rotated B matrices for non-orthogonal cells.

## Status of sibling issues

Reproducers from each sibling issue re-run at the bench against the combined Phase 1+2+3 fix:

| Issue | Status |
|---|---|
| #275 psic `bisecting_horizontal` asymmetric sapphire reflections | **Resolved** (all 6 asymmetric hkls now solve, 2 solutions each) |
| #276 kappa6c `bisecting_horizontal` cubic/sapphire/triclinic reflections | **Resolved** (all 17 reflections from the issue's scans now solve) |
| #277 psic `fixed_chi_horizontal` non-(0,0,l) sapphire reflections | **Resolved** (all 7 non-(0,0,l) hkls now solve) |
| #278 psic `fixed_psi_horizontal` | **Not resolved by #280** — separate, independent defect.  The mode has 3 constraints (`eta=0`, `delta=0`, `psi=target`) for 4 free axes (`mu, chi, phi, nu`); one DOF is unconstrained because no bisect or qaz constraint ties the detector position to ttheta.  This is a mode-definition kinematic-count defect that the #280 root causes (composition order, ub_identity, BL1967 B-matrix) do not address.  Stays open. |

Per AGENTS.md the sibling issues are not auto-closed by this PR's `closes #280`; reviewer may close #275, #276, #277 manually after merge.  #278 and #279 (independent surface-mode defect) remain open.

## Verification

- `pytest`: **2462 passed, 14 skipped, 3 deselected, 0 failed**.  100% line and branch coverage.
- `pytest -m slow_benchmark`: 3/3 passed.
- `pre-commit run --all-files`: all hooks pass (ruff, ruff-format, isort, license, yaml, toml, whitespace, end-of-file, merge-conflicts, debug-statements).
- US-English grep on changed files: zero hits.
- Sphinx docs build: succeeded, zero warnings; both role-leak grep patterns clean.

## Test fixture re-derivation policy

Per AGENTS.md: every test whose baked-in fixtures changed had its expected values **hand-derived** under the corrected convention, never captured from post-fix output.  Per-test audit notes are in each modified test file's docstrings/comments.

## AGENTS.md update

Strengthened the `CHANGES.md style` section with an explicit ≤ 12 word length cap, an "issue/PR reference carries the load" framing, and worked acceptable-vs-too-long examples (the rejected multi-clause #280 bullets I produced during review are included verbatim as negative examples).

Contributed by: OpenCode (argo/claudeopus47)
