### PR TITLE
maint #290 unify copyright automation

### DIFF
--- a/.copyright.txt
+++ b/.copyright.txt
@@ -1,2 +1,2 @@
-Copyright (c) 2026 UChicago Argonne, LLC
-SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+Copyright (c) 2026-2026 UChicago Argonne, LLC
+SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,22 @@ repos:
           - --license-filepath=.copyright.txt
           - --comment-style=#
           - --no-extra-eol
+      - id: insert-license
+        name: insert-license (scripts)
+        files: ^scripts/.*\.py$
+        args:
+          - --license-filepath=.copyright.txt
+          - --comment-style=#
+          - --no-extra-eol
+
+  - repo: local
+    hooks:
+      - id: update-copyright-year
+        name: Update copyright end year
+        language: python
+        entry: python scripts/update_copyright_year.py
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,73 @@ python3 -m pre_commit run --all-files
 
 ---
 
+## Copyright handling
+
+The repo uses three coordinated mechanisms to keep copyright text
+consistent.  All three are wired into pre-commit and run automatically.
+
+### 1. Per-file headers — `.copyright.txt` + `insert-license`
+
+`.copyright.txt` is the single source of truth for the per-file header
+text:
+
+```text
+Copyright (c) 2026-2026 UChicago Argonne, LLC
+SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+```
+
+The `Lucas-C/insert-license` pre-commit hook propagates that header to
+every covered Python file on each commit.  Three hook instances cover:
+
+* `src/ad_hoc_diffractometer/*.py` (excluding `_version.py`)
+* `tests/test_*.py`
+* `scripts/*.py`
+
+To change the per-file header text project-wide, edit only
+`.copyright.txt` and run `pre-commit run --all-files`.
+
+### 2. Year-range bump — `scripts/update_copyright_year.py`
+
+A **local** pre-commit hook (`update-copyright-year`) runs the
+`scripts/update_copyright_year.py` script on every commit.  The script
+rewrites the pattern `<START>-<OLD_END>` → `<START>-<CURRENT_YEAR>` in
+each file listed in its `TARGET_FILES`:
+
+* `.copyright.txt`
+* `LICENSE` (line 1 only — the licence body is verbatim per ANL legal
+  and is never edited)
+* `docs/source/conf.py`
+
+The script exits non-zero when it changes anything, so pre-commit fails
+and the developer stages the rewrite before retrying the commit.  On
+January 1 of any year, the next commit on any branch will bring every
+year span forward.
+
+### 3. Sphinx docs — static year range in `conf.py`
+
+`docs/source/conf.py` declares `copyright` as a static year-range string,
+not a build-time-dynamic `datetime.now().year` expression.  This is
+intentional: the bump script is the single mechanism that keeps
+`LICENSE`, `.copyright.txt`, and the rendered docs aligned, and a
+dynamic expression would hide drift between them.
+
+### What NOT to edit by hand
+
+* The `Copyright (c) YYYY-YYYY ...` line on individual `.py` files —
+  edit `.copyright.txt` and re-run pre-commit instead.
+* The end year in `LICENSE` line 1, `docs/source/conf.py`, or
+  `.copyright.txt` on January 1 — the bump script handles it.
+* The body of `LICENSE` — verbatim per ANL legal.
+
+### What to edit by hand
+
+* The **start** year in any year range (project inception year);
+  the script never touches it.
+* Adding new files to `TARGET_FILES` if a new file legitimately
+  contains a year range.
+
+---
+
 ## Benchmark tests
 
 The benchmark test suite (`tests/test_benchmark.py`) includes slow tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ Note any unreleased items inside the comment here.  Not visible until release.
 
 - Kappa equivalent-Eulerian chi axis now matches fourcv/fourch/psic. (#284)
 
+### Maintenance
+
+- Unify copyright automation: `.copyright.txt` year range, SPDX identifier `LicenseRef-UChicago-Argonne-LLC-License`, bump-script pre-commit hook. (#290)
+
 -->
 
 ## Release v0.11.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Note any unreleased items inside the comment here.  Not visible until release.
 
 ### Maintenance
 
-- Unify copyright automation: `.copyright.txt` year range, SPDX identifier `LicenseRef-UChicago-Argonne-LLC-License`, bump-script pre-commit hook. (#290)
+- Unify copyright automation across hklpy2 family. (#290)
 
 -->
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2026, UChicago Argonne, LLC
+Copyright (c) 2026-2026, UChicago Argonne, LLC
 
 All Rights Reserved
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,9 @@ _metadata = _toml["project"]
 project = "ad_hoc_diffractometer"
 # author = _metadata["authors"][0]["name"]
 author = "UChicago Argonne, LLC"
-copyright = f"2026, {author}"
+# Static year range; kept in sync with .copyright.txt and LICENSE by
+# scripts/update_copyright_year.py (registered as a pre-commit hook).
+copyright = "2026-2026, UChicago Argonne, LLC"
 description = _metadata["description"]
 
 release = _version("ad_hoc_diffractometer")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [{ name = "Pete Jemian", email = "prjemian+ad_hoc@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["diffraction", "geometry", "crystallography", "x-ray", "neutron"]
-license = "LicenseRef-ANL-Open-Source-License"
+license = "LicenseRef-UChicago-Argonne-LLC-License"
 license-files = ["LICEN[CS]E*"]
 # https://pypi.org/classifiers/
 classifiers = [

--- a/scripts/update_copyright_year.py
+++ b/scripts/update_copyright_year.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+"""
+Update the copyright end year in tracked source files to the current year.
+
+Designed to be used as a pre-commit hook (local repo hook).  Exit codes follow
+the pre-commit convention:
+
+* 0 - nothing changed (all files already have the correct year).
+* 1 - one or more files were modified; pre-commit will mark the hook as
+      "failed" so the developer sees the diff and stages the updated files
+      before retrying the commit.
+
+The script rewrites the pattern ``<START_YEAR>-<OLD_YEAR>`` ->
+``<START_YEAR>-<CURRENT_YEAR>`` wherever it appears in each target file,
+leaving everything else untouched.
+
+Files checked (paths relative to the repository root):
+
+* ``.copyright.txt``          - per-file header template
+* ``LICENSE``                 - line-1 copyright statement (only the year
+                                range is rewritten; the licence body is
+                                verbatim per ANL legal and is never touched
+                                by this script)
+* ``docs/source/conf.py``     - Sphinx ``copyright`` value
+
+To add a new target, append to :data:`TARGET_FILES` below.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+# Files that contain the copyright year span, relative to the repo root.
+TARGET_FILES: list[pathlib.Path] = [
+    REPO_ROOT / ".copyright.txt",
+    REPO_ROOT / "LICENSE",
+    REPO_ROOT / "docs" / "source" / "conf.py",
+]
+
+# Matches e.g. "2026-2026" and captures the start year and old end year.
+YEAR_RANGE_PATTERN = re.compile(r"(\d{4})-(\d{4})")
+
+CURRENT_YEAR = str(datetime.now().year)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def update_file(path: pathlib.Path, current_year: str) -> bool:
+    """
+    Replace stale end-years in *path* with *current_year*.
+
+    Returns True if the file was modified.
+    """
+    original = path.read_text(encoding="utf-8")
+
+    def _replace(match: re.Match) -> str:
+        start, end = match.group(1), match.group(2)
+        if end == current_year:
+            return match.group(0)  # already up to date
+        return f"{start}-{current_year}"
+
+    updated = YEAR_RANGE_PATTERN.sub(_replace, original)
+
+    if updated == original:
+        return False
+
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    changed: list[pathlib.Path] = []
+
+    for filepath in TARGET_FILES:
+        if not filepath.exists():
+            print(f"WARNING: {filepath} not found - skipping.", file=sys.stderr)
+            continue
+        if update_file(filepath, CURRENT_YEAR):
+            changed.append(filepath)
+            print(
+                f"Updated copyright end year to {CURRENT_YEAR} in: {filepath.relative_to(REPO_ROOT)}"
+            )
+
+    if changed:
+        print(
+            "\nCopyright year(s) updated. Stage the changed file(s) and re-run the commit.",
+            file=sys.stderr,
+        )
+        return 1  # signal pre-commit that something changed
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ad_hoc_diffractometer/__init__.py
+++ b/src/ad_hoc_diffractometer/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 ad_hoc_diffractometer — Multi-circle diffractometer geometry and related calculations.
 

--- a/src/ad_hoc_diffractometer/axes.py
+++ b/src/ad_hoc_diffractometer/axes.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 axes.py — caller-facing axis notation and physical direction mapping.
 

--- a/src/ad_hoc_diffractometer/benchmark.py
+++ b/src/ad_hoc_diffractometer/benchmark.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 benchmark.py — forward/inverse performance measurement.
 

--- a/src/ad_hoc_diffractometer/constants.py
+++ b/src/ad_hoc_diffractometer/constants.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 constants.py — shared Cartesian basis vectors.
 

--- a/src/ad_hoc_diffractometer/conversions.py
+++ b/src/ad_hoc_diffractometer/conversions.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 r"""
 conversions.py — Alternative calculation engines.
 

--- a/src/ad_hoc_diffractometer/diffractometer.py
+++ b/src/ad_hoc_diffractometer/diffractometer.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 diffractometer.py — AdHocDiffractometer class.
 

--- a/src/ad_hoc_diffractometer/display.py
+++ b/src/ad_hoc_diffractometer/display.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 display.py — display precision settings and numeric comparison helper.
 

--- a/src/ad_hoc_diffractometer/drawing.py
+++ b/src/ad_hoc_diffractometer/drawing.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 drawing.py — geometry visualization helpers.
 

--- a/src/ad_hoc_diffractometer/factories.py
+++ b/src/ad_hoc_diffractometer/factories.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 factories.py — geometry registry and shared definitions.
 

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 r"""
 forward.py — Forward diffraction calculation: (h, k, l) → motor angles.
 

--- a/src/ad_hoc_diffractometer/geometries/__init__.py
+++ b/src/ad_hoc_diffractometer/geometries/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Declarative geometry definitions (issue #267).
 

--- a/src/ad_hoc_diffractometer/geometry_loader.py
+++ b/src/ad_hoc_diffractometer/geometry_loader.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 geometry_loader.py — declarative-YAML geometry loader (issue #267).
 

--- a/src/ad_hoc_diffractometer/kappa.py
+++ b/src/ad_hoc_diffractometer/kappa.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 kappa.py — Kappa-to-Eulerian angle conversion.
 

--- a/src/ad_hoc_diffractometer/lattice.py
+++ b/src/ad_hoc_diffractometer/lattice.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 lattice.py — crystallographic lattice calculations.
 

--- a/src/ad_hoc_diffractometer/mode.py
+++ b/src/ad_hoc_diffractometer/mode.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 mode.py — Diffraction mode / operating constraints.
 

--- a/src/ad_hoc_diffractometer/orientation.py
+++ b/src/ad_hoc_diffractometer/orientation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 r"""
 orientation.py — U and UB matrix computation from orienting reflections.
 

--- a/src/ad_hoc_diffractometer/radiation.py
+++ b/src/ad_hoc_diffractometer/radiation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 radiation.py — Wavelength, energy, and wave-number conversions.
 

--- a/src/ad_hoc_diffractometer/reference.py
+++ b/src/ad_hoc_diffractometer/reference.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 reference.py — Reference pseudo-angle computations for diffraction modes.
 

--- a/src/ad_hoc_diffractometer/refinement.py
+++ b/src/ad_hoc_diffractometer/refinement.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 refinement.py — Lattice and orientation refinement from multiple reflections.
 

--- a/src/ad_hoc_diffractometer/reflection.py
+++ b/src/ad_hoc_diffractometer/reflection.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 reflection.py — Reflection and ReflectionList for orienting reflections.
 

--- a/src/ad_hoc_diffractometer/rotation.py
+++ b/src/ad_hoc_diffractometer/rotation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 rotation.py — rotation matrix calculation.
 

--- a/src/ad_hoc_diffractometer/sample.py
+++ b/src/ad_hoc_diffractometer/sample.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 sample.py — Sample class and SampleDict for crystallographic sample management.
 

--- a/src/ad_hoc_diffractometer/scan.py
+++ b/src/ad_hoc_diffractometer/scan.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 scan.py — Reciprocal-space trajectory computation.
 

--- a/src/ad_hoc_diffractometer/stage.py
+++ b/src/ad_hoc_diffractometer/stage.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 stage.py — rotary stage description.
 

--- a/src/ad_hoc_diffractometer/surface.py
+++ b/src/ad_hoc_diffractometer/surface.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 surface.py — Surface geometry calculations.
 

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.axes.
 

--- a/tests/test_basis_invariance.py
+++ b/tests/test_basis_invariance.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Basis-invariance tests for all preset geometries.
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Tests for the benchmark module.
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.conversions.
 

--- a/tests/test_diffractometer.py
+++ b/tests/test_diffractometer.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.diffractometer.
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.display.
 

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.drawing.
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.factories.
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.forward (compute_forward / geometry.forward).
 

--- a/tests/test_geometry_loader.py
+++ b/tests/test_geometry_loader.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for :mod:`ad_hoc_diffractometer.geometry_loader`.
 

--- a/tests/test_kappa.py
+++ b/tests/test_kappa.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.kappa — kappa-to-Eulerian conversion.
 

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for the Lattice class in lattice.py.
 

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.mode and mode-related geometry features.
 

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.orientation.
 

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.radiation (issues #21 and #8).
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.reference — reference pseudo-angles.
 

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.refinement.
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.reflection.
 

--- a/tests/test_regenerate_switcher.py
+++ b/tests/test_regenerate_switcher.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for tools/regenerate_switcher.py.
 
 The script lives in ``tools/`` (outside the importable package) so it is

--- a/tests/test_regression_cross_check_hkl_soleil.py
+++ b/tests/test_regression_cross_check_hkl_soleil.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests cross-validating against ``hkl_soleil`` (libhkl).
 

--- a/tests/test_regression_issue_237.py
+++ b/tests/test_regression_issue_237.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #237.
 

--- a/tests/test_regression_issue_243.py
+++ b/tests/test_regression_issue_243.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #243.
 

--- a/tests/test_regression_issue_252.py
+++ b/tests/test_regression_issue_252.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #252.
 

--- a/tests/test_regression_issue_262.py
+++ b/tests/test_regression_issue_262.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #262 — psic and kappa6c zone modes.
 

--- a/tests/test_regression_issue_264.py
+++ b/tests/test_regression_issue_264.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #264.
 

--- a/tests/test_regression_issue_267.py
+++ b/tests/test_regression_issue_267.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #267 — declarative geometries.
 

--- a/tests/test_regression_issue_278.py
+++ b/tests/test_regression_issue_278.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #278.
 

--- a/tests/test_regression_issue_279.py
+++ b/tests/test_regression_issue_279.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #279.
 

--- a/tests/test_regression_issue_280.py
+++ b/tests/test_regression_issue_280.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Cross-module regression tests for issue #280.
 

--- a/tests/test_regression_issue_284.py
+++ b/tests/test_regression_issue_284.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #284.
 
@@ -443,9 +443,7 @@ def test_kappa_eulerian_chi_invalid_form_rejected():
     """Non-string non-vector ``kappa_eulerian_chi`` is rejected."""
     doc = yaml.safe_load(_kappa_yaml_doc())
     doc["kappa_eulerian_chi"] = 42  # neither a string nor a vector
-    with pytest.raises(
-        GeometrySchemaError, match="'kappa_eulerian_chi' must be"
-    ):
+    with pytest.raises(GeometrySchemaError, match="'kappa_eulerian_chi' must be"):
         load_geometry_file(yaml.safe_dump(doc))
 
 
@@ -701,6 +699,3 @@ def test_kappa_convention_accepts_any_perpendicular_n_chi_eq(n_chi_eq, context):
             n_kphi=n_kphi,
             n_chi_eq=np.array(n_chi_eq, dtype=float),
         )
-
-
-

--- a/tests/test_regression_issue_285.py
+++ b/tests/test_regression_issue_285.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #285.
 

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.rotation.
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.sample.
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.scan.
 

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.stage.
 

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-ANL-Open-Source-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Unit tests for ad_hoc_diffractometer.surface and geometry surface methods.
 


### PR DESCRIPTION
- closes #290

## Summary

Unify copyright automation in this repo and establish the reference
implementation for the parallel work in bluesky/hklpy2#411 and
prjemian/hklpy2_solvers#112.

## Changes

### Configuration
- `.copyright.txt`: year-range form (`2026-2026`), SPDX identifier
  `LicenseRef-UChicago-Argonne-LLC-License`.
- `pyproject.toml`: `license` field switched to
  `LicenseRef-UChicago-Argonne-LLC-License`.
- `LICENSE` line 1: year-range form `2026-2026`.  Body unchanged
  (verbatim per ANL legal).
- `docs/source/conf.py`: static year-range string
  `"2026-2026, UChicago Argonne, LLC"` (no more `f"2026, {author}"`).
  Bump script keeps the end year fresh.

### New: bump script and hook
- `scripts/update_copyright_year.py`: rewrites
  `<START>-<OLD_END>` → `<START>-<CURRENT_YEAR>` in
  `TARGET_FILES = [.copyright.txt, LICENSE, docs/source/conf.py]`.
  Exits non-zero when it changes anything so pre-commit fails until
  the developer stages the rewrite.
- `.pre-commit-config.yaml`:
  - New local hook `update-copyright-year`
    (`always_run: true`, `pass_filenames: false`).
  - New `insert-license (scripts)` hook instance covering `scripts/*.py`.

### Header propagation
- Every covered `.py` file (61 files) had its header rewritten by
  `insert-license` to match the new `.copyright.txt`.  This is the
  expected bulk diff; no logic changed.

### Documentation
- `AGENTS.md`: new "Copyright handling" section explaining the three
  coordinated mechanisms (`.copyright.txt` + `insert-license`, the
  bump script, static Sphinx `conf.py`), what to edit by hand, and
  what not to.
- `CHANGES.md`: one-line `### Maintenance` entry inside the unreleased
  HTML-comment block, referencing `(#290)`.

## Verification
- `pre-commit run --all-files` — all hooks pass.
- `pytest -q` — 2580 passed, 2 skipped, 100% coverage maintained.
- Bump script sanity run — exits 0 (no-op; all year ranges already
  current).

## SPDX identifier change (PyPI metadata impact)
The `License-Expression` field on PyPI will visibly change from
`LicenseRef-ANL-Open-Source-License` to
`LicenseRef-UChicago-Argonne-LLC-License` on the next release.
Acceptable per the issue discussion: this is a `LicenseRef-*` custom
identifier authored by the project owner, the licence text in `LICENSE`
is unchanged, and the new identifier aligns with `bluesky/hklpy2` and
`prjemian/hklpy2_solvers`.

## Cross-repo follow-up
This branch finalises the reference implementation.  Parallel issues
will port the (now finalised) `scripts/update_copyright_year.py`,
`.copyright.txt` + `insert-license` config, and Sphinx `conf.py`
pattern to:
- bluesky/hklpy2#411
- prjemian/hklpy2_solvers#112

Agent: OpenCode (claudeopus47)

