### PR TITLE
fix(#306, #307): solve three free sample angles for psic reference modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,14 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
 
 ## Issue and PR workflow
 
-1. **Before writing any code**, set the issue status to "In progress" on the
-   GitHub project board:
+1. **Before writing any code**, *if the issue is on one or more project
+   boards*, set the issue status to "In progress" on each of those boards:
    ```bash
    # Find the project item ID for the issue, then update its status field
    gh api graphql -f query='...'   # see project board queries below
    ```
+   If the issue is on no project board, skip this step — there is no board
+   status to set.
 
 2. **Open a PR** with a body that includes a closing reference as a bullet,
    followed by any remarks and the agent/model signature:
@@ -82,10 +84,18 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
    The `closes #N` keyword triggers GitHub automation: when the PR is merged
    the issue is closed and the project card moves to "Done" automatically.
 
-   Every PR must also have its **milestone** and **project board** set,
-   and its project board status must be set to **"In Progress"**.
-   Issues and PRs may belong to **more than one project board** — add the
-   card to every board that tracks the work.
+   **Mirror the issue's milestone and boards onto the PR.**  The PR
+   inherits whatever the issue has — no more, no less:
+
+   - If the issue is assigned to a **milestone**, set the PR to the same
+     milestone.  If the issue has no milestone, the PR gets none.
+   - If the issue is on one or more **project boards**, add the PR to the
+     same board(s) and set its status to **"In Progress"**.  If the issue
+     is on no board, the PR gets no board.
+
+   A PR is always created (the no-board / no-milestone case simply means
+   the PR has no board or milestone either) — the absence of a board or
+   milestone is never a reason to skip the PR.
 
    Status field IDs and the corresponding option IDs are project-
    specific.  Discover them per board with the GraphQL query
@@ -98,12 +108,12 @@ Example: `Contributed by: OpenCode (argo/claudesonnet46)`
 
    **Match the issue's boards.**  Before creating the PR, query the
    issue's `projectItems` to discover every board it belongs to.  Add the
-   PR to **all** of those boards — not just the one implied by the domain
-   table above.
+   PR to **all** of those boards (and only those).
 
    **Set "In review" when code is complete.**  Once the PR is pushed, set its
    project board status to **"In review"** (on boards that have that status;
-   leave "In Progress" where only Todo / In Progress / Done exist).
+   leave "In Progress" where only Todo / In Progress / Done exist).  Skip
+   this when the issue (and therefore the PR) is on no board.
 
    ```bash
    # Set milestone when creating the PR

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ issue tracker.  The initial project development roadmap is documented here:
 
 ## Unreleased
 
+### Fixed
+
+- psic `fixed_incidence_*` / `fixed_emergence_*` solutions now reproduce the requested hkl. (#307)
+- psic `fixed_psi_vertical` no longer returns empty at the natural ψ. (#306)
+
+
 ## Release v0.11.3
 
 Released 2026-06-24

--- a/src/ad_hoc_diffractometer/forward.py
+++ b/src/ad_hoc_diffractometer/forward.py
@@ -1104,10 +1104,63 @@ def _solve_bisecting(
         # Solve 1D: find the single angle that satisfies Q_phi.
         return _solve_one_free_angle(geometry, angles, free_sample[0], Q_phi, mode)
 
-    # The two remaining free stages are chi_stage and phi_stage.
-    # By convention (BL1967, You1999) the stacking order is:
-    #   [outermost ... chi_stage, phi_stage] (phi closest to sample)
-    # The last two free stages in stacking order play the chi/phi roles.
+    # Two or more free sample stages: solve the inner chi/phi pair against
+    # the Bragg condition with every earlier free stage frozen at its value
+    # in ``angles``.  Callers that must also solve an outer free stage (e.g.
+    # the psic ``fixed_psi_*`` / surface families with eta, chi, phi all
+    # free) scan that outer stage and call :func:`_solve_chi_phi_bragg`
+    # per outer-angle value (issues #306, #307).
+    return _solve_chi_phi_bragg(geometry, angles, free_sample, Q_phi, mode)
+
+
+def _solve_chi_phi_bragg(
+    geometry: AdHocDiffractometer,
+    angles: dict[str, float],
+    free_sample: list,
+    Q_phi: np.ndarray,
+    mode,
+    fast_only: bool = False,
+) -> list[dict[str, float]]:
+    """
+    Solve the inner ``(chi, phi)`` sample pair for the Bragg condition.
+
+    Given a baseline ``angles`` dict in which every stage except the last
+    two entries of ``free_sample`` is already fixed (detector at 2θ, fixed
+    sample/detector constraints applied, and any *outer* free sample stage
+    pinned at its value in ``angles``), find the ``(chi, phi)`` settings of
+    the last two free sample stages that place ``Q_phi`` on the Ewald
+    sphere.
+
+    This is the inner kernel shared by :func:`_solve_fixed_sample` (two
+    free sample stages) and :func:`_solve_reference_three_sample` (three
+    free sample stages, where the outer stage is scanned externally and
+    pinned in ``angles`` before each call).
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    angles : dict[str, float]
+        Baseline angles; the last two ``free_sample`` stages are overwritten.
+    free_sample : list of Stage
+        Free sample stages in stacking order; the last two are chi/phi.
+    Q_phi : numpy.ndarray, shape (3,)
+    mode : ConstraintSet
+    fast_only : bool, optional
+        When ``True`` and the chi/phi pair is standard Eulerian, return the
+        analytic-fast-path result (possibly empty) without running the
+        expensive multi-seed Newton fallback.  This is used by the
+        outer-stage scan in :func:`_solve_reference_three_sample`, where the
+        inner solve is invoked dozens of times and the Newton fallback's
+        cost on the (common) no-solution case dominates.  Default ``False``.
+
+    Returns
+    -------
+    list of dict[str, float]
+        Bragg-valid solutions (after cut points and limit checks).
+    """
+    # The two innermost free stages play the chi/phi roles.  By convention
+    # (BL1967, You1999) the stacking order is
+    #   [outermost ... chi_stage, phi_stage] (phi closest to sample).
     chi_stage = free_sample[-2]
     phi_stage = free_sample[-1]
 
@@ -1147,7 +1200,11 @@ def _solve_bisecting(
             if solutions:
                 return solutions
         # If analytic solver returned nothing (degenerate case), fall through
-        # to the Newton solver below.
+        # to the Newton solver below — unless the caller requested the
+        # analytic-only fast path (outer-stage scan), in which case an
+        # empty result simply means "no Bragg branch at this outer angle".
+        if fast_only:
+            return []
 
     # --- Newton fallback for non-standard axes or degenerate cases ---
 
@@ -1927,25 +1984,47 @@ def _solve_psi_mode(
     # bisect was dropped in favor of a SampleConstraint + a
     # DetectorConstraint pinning the scattering plane (nu = 0 for
     # vertical, delta = 0 for horizontal) plus the psi reference.  Once
-    # ψ is validated, delegate to ``_solve_fixed_sample`` which handles
-    # the remaining free sample stages plus the active detector at
-    # ttheta.
+    # ψ is validated it imposes no further restriction (every Bragg
+    # solution shares the natural ψ for a given hkl + UB), so the mode is
+    # degenerate in the third free sample angle.  The conventional
+    # resolution — and the one the corresponding ``bisecting_*`` mode
+    # uses — is the bisecting geometry: the lone free sample stage that
+    # is neither chi nor phi takes ttheta/2, paired with the active
+    # detector stage at ttheta.  Build that synthetic bisecting mode and
+    # delegate, so ``fixed_psi_vertical`` reproduces ``bisecting_vertical``
+    # (issue #306) instead of freezing the outer stage at its current
+    # value (which left ``forward()`` with no solutions).
     if (
         any(s.name == "chi" for s in geometry.sample_stages)
         and mode.detector_constraint is not None
         and len(mode.fixed_sample_constraints) >= 1
     ):
-        stripped = ConstraintSet(
-            [
-                c
-                for c in mode.constraints
-                if not (isinstance(c, ReferenceConstraint) and c.name == "psi")
-            ],
+        other_constraints = [
+            c
+            for c in mode.constraints
+            if not (isinstance(c, ReferenceConstraint) and c.name == "psi")
+        ]
+        # The active detector stage carries ttheta (the one NOT pinned by
+        # the mode's DetectorConstraint).
+        pinned_det = mode.detector_constraint.name
+        active_det = next(
+            s.name for s in geometry.detector_stages if s.name != pinned_det
+        )
+        # The bisecting sample stage is the free sample stage that is
+        # neither chi nor phi (eta for vertical, mu for horizontal).
+        fixed_sample_names = {c.name for c in mode.fixed_sample_constraints}
+        bisect_sample = next(
+            s.name
+            for s in geometry.sample_stages
+            if s.name not in fixed_sample_names and s.name not in {"chi", "phi"}
+        )
+        synthetic = ConstraintSet(
+            [BisectConstraint(bisect_sample, active_det)] + other_constraints,
             computed=mode.computed,
             extras=mode.extras,
             cut_points=mode.cut_points,
         )
-        return _solve_fixed_sample(geometry, Q_phi, ttheta_deg, stripped)
+        return _solve_bisecting(geometry, Q_phi, ttheta_deg, synthetic)
 
     # fourcv, fourch, kappa4cv, kappa4ch: no BisectConstraint in the mode.
     # Build a synthetic bisecting mode using the geometry's natural
@@ -3050,6 +3129,165 @@ def _is_surface_mode(geometry: AdHocDiffractometer, mode) -> bool:
     return True
 
 
+def _solve_reference_three_sample(
+    geometry: AdHocDiffractometer,
+    Q_phi: np.ndarray,
+    ttheta_deg: float,
+    mode,
+    free_sample: list,
+    reference_residual: callable,
+) -> list[dict[str, float]]:
+    """
+    Solve three free sample stages against Bragg plus one reference angle.
+
+    Used by the psic ``fixed_incidence_*`` / ``fixed_emergence_*`` families
+    (and any future mode) where three sample stages are free — an outer
+    rocking stage (``eta`` or ``mu``) plus the inner Eulerian pair
+    (``chi``, ``phi``) — and a single :class:`~mode.ReferenceConstraint`
+    (incidence, emergence, ...) selects discrete settings from the
+    one-parameter Bragg family (issues #306, #307).
+
+    Strategy: the inner ``(chi, phi)`` pair is solved against the Bragg
+    condition by :func:`_solve_chi_phi_bragg` for any fixed value of the
+    outer stage, so the three-angle problem reduces to a 1-D root find on
+    the outer stage.  Scan the outer stage over a coarse grid; at each
+    sample evaluate the reference residual on every Bragg-valid inner
+    solution; bracket sign changes (per Bragg branch) and refine by
+    bisection.  Every returned solution reproduces the requested ``hkl``
+    by construction because the inner solve always enforces Bragg.
+
+    Parameters
+    ----------
+    geometry : AdHocDiffractometer
+    Q_phi : numpy.ndarray, shape (3,)
+    ttheta_deg : float
+    mode : ConstraintSet
+    free_sample : list of Stage
+        The free sample stages in stacking order: ``[outer, chi, phi]``.
+    reference_residual : callable
+        ``reference_residual(angles) -> float``; zero when the reference
+        constraint (incidence/emergence/...) is satisfied.
+
+    Returns
+    -------
+    list of dict[str, float]
+    """
+    # Build the baseline angle dict with all fixed constraints applied.
+    angles: dict[str, float] = {
+        s.name: s.angle
+        for s in list(geometry._stages.values())  # noqa: SLF001
+    }
+    for c in mode.fixed_sample_constraints:
+        if c.name in geometry._stages:  # noqa: SLF001  # pragma: no branch
+            angles[c.name] = float(c.value)
+
+    det_constraint = mode.detector_constraint
+    pinned_det: str | None = None
+    # The psic vertical/horizontal reference modes that reach this solver
+    # always pin one detector stage (nu=0 or delta=0); the unpinned case is
+    # defensive for any future caller.
+    if det_constraint is not None and not det_constraint.is_qaz:  # pragma: no branch
+        angles[det_constraint.name] = det_constraint.value
+        pinned_det = det_constraint.name
+
+    # The active detector stage carries ttheta (the one not pinned).
+    free_det_stages = [s for s in geometry.detector_stages if s.name != pinned_det]
+    if not free_det_stages:  # pragma: no cover
+        return []
+    angles[free_det_stages[-1].name] = ttheta_deg
+
+    outer_stage = free_sample[0]
+    outer_name = outer_stage.name
+    inner_free = free_sample[1:]  # [chi, phi]
+
+    def _bragg_solutions_at(outer_deg: float) -> list[dict[str, float]]:
+        """Bragg-valid full solutions with the outer stage pinned."""
+        base = dict(angles)
+        base[outer_name] = outer_deg
+        return _solve_chi_phi_bragg(
+            geometry, base, inner_free, Q_phi, mode, fast_only=True
+        )
+
+    def _match(sol: dict[str, float], pool: list[dict[str, float]]):
+        """Return the pool entry closest to ``sol`` in (chi, phi), or None."""
+        if not pool:
+            return None
+        chi_n, phi_n = inner_free[-2].name, inner_free[-1].name
+        best = None
+        best_d = 1e9
+        for cand in pool:
+            d = abs(cand[chi_n] - sol[chi_n]) + abs(cand[phi_n] - sol[phi_n])
+            if d < best_d:
+                best_d = d
+                best = cand
+        # Only treat as the same branch when reasonably close.
+        return best if best_d < 30.0 else None
+
+    # Coarse scan of the outer stage across its limits.
+    lim_lo, lim_hi = outer_stage.limits
+    n_steps = 72
+    grid = list(np.linspace(lim_lo, lim_hi, n_steps + 1))
+
+    solutions: list[dict[str, float]] = []
+
+    def _record(sol: dict[str, float]) -> None:
+        _apply_cut_points(sol, mode, geometry)
+        for existing in solutions:
+            if all(
+                abs(existing.get(k, 0.0) - sol.get(k, 0.0)) < 1e-3 for k in sol
+            ):  # pragma: no cover - defensive against duplicate outer branches
+                return
+        if _check_limits(geometry, sol):  # pragma: no branch
+            solutions.append(sol)
+
+    prev_outer = grid[0]
+    prev_sols = _bragg_solutions_at(prev_outer)
+    prev_res = {id(s): reference_residual(s) for s in prev_sols}
+
+    for outer in grid[1:]:
+        cur_sols = _bragg_solutions_at(outer)
+        cur_res = {id(s): reference_residual(s) for s in cur_sols}
+
+        for cs in cur_sols:
+            r_cur = cur_res[id(cs)]
+            # Exact hit on the grid.
+            if abs(r_cur) < 1e-7:
+                _record(dict(cs))
+                continue
+            match = _match(cs, prev_sols)
+            if match is None:
+                continue
+            r_prev = prev_res[id(match)]
+            if r_prev * r_cur >= 0:
+                continue
+            # Sign change between prev_outer and outer on this branch:
+            # refine the outer angle by bisection.
+            a, b = prev_outer, outer
+            ra = r_prev
+            refined: dict[str, float] | None = None
+            for _ in range(60):  # pragma: no branch - converges before exhausting
+                m = 0.5 * (a + b)
+                pool = _bragg_solutions_at(m)
+                mid = _match(cs, pool)
+                if mid is None:  # pragma: no cover
+                    break
+                rm = reference_residual(mid)
+                if abs(rm) < 1e-9:
+                    refined = dict(mid)
+                    break
+                if ra * rm < 0:
+                    b = m
+                else:
+                    a, ra = m, rm
+                refined = dict(mid)
+            if refined is not None:  # pragma: no branch
+                _record(refined)
+
+        prev_outer, prev_sols, prev_res = outer, cur_sols, cur_res
+
+    return solutions
+
+
 def _solve_surface(
     geometry: AdHocDiffractometer,
     Q_phi: np.ndarray,
@@ -3137,10 +3375,36 @@ def _solve_surface(
                 return [angles]
         return []
 
+    # psic ``fixed_incidence_*`` / ``fixed_emergence_*`` families leave
+    # three sample stages free — an outer rocking stage (eta or mu) plus
+    # the inner Eulerian pair (chi, phi).  The legacy 1-D Newton below
+    # rocks only the first free stage and leaves the other two at their
+    # current values, so it enforced the surface residual on motor
+    # settings that did NOT reproduce the requested hkl (issue #307).
+    # Route that case to the outer-stage scan, which solves the inner
+    # chi/phi pair against the Bragg condition for each outer value and
+    # roots the scan on the surface residual, so every returned solution
+    # is Bragg-valid by construction.  Geometries without a chi stage
+    # (zaxis, s2d2, sixc) keep the legacy 1-D Newton, which works thanks
+    # to their constrained sample stack (issues #279, #304).
+    inner_is_chi_phi = (
+        len(free_sample) >= 3
+        and free_sample[-2].name == "chi"
+        and free_sample[-1].name == "phi"
+    )
+    if inner_is_chi_phi:
+
+        def _ref_residual(trial: dict[str, float]) -> float:
+            return _surface_residual(trial, geometry, target_name, target_value)
+
+        return _solve_reference_three_sample(
+            geometry, Q_phi, ttheta_deg, mode, free_sample, _ref_residual
+        )
+
     if len(free_sample) > 1:  # pragma: no branch
-        # More than one free sample stage — use the first one (rocking stage)
-        # and leave others at current values.  This handles cases where the
-        # reference constraint only restricts one angle.
+        # More than one free sample stage but not the psic chi/phi family
+        # — use the first one (rocking stage) and leave others at current
+        # values.  The reference constraint restricts only one angle here.
         pass
 
     free_stage = free_sample[0]

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -849,7 +849,7 @@ def _psic_reference_geometry(**kwargs):
         ),
         pytest.param(
             "emergence",
-            0.0,
+            5.0,
             {"surface_normal": (0, 0, 1)},
             does_not_raise(),
             id="emergence-residual",
@@ -897,8 +897,19 @@ def test_reference_constraint_evaluate(name, value, kwargs, context):
                 "specular": "specular_vertical",
                 "omega": "fixed_omega_vertical",
             }[name]
+            # Drive forward() with the same (accessible) target the residual
+            # is checked against, so the returned solution genuinely both
+            # reproduces (1, 0, 1) and satisfies the reference angle.
+            if name in {"incidence", "emergence"}:
+                g._modes[g.mode_name] = g.mode.with_constraint_values(  # noqa: SLF001
+                    **{name: value}
+                )
+                g.mode_name = g.mode_name
             sols = g.forward(1, 0, 1)
             angles = sols[0]
+            # The solution must reproduce the requested reflection (issue #307).
+            rt = g.inverse(angles)
+            assert rt == pytest.approx((1.0, 0.0, 1.0), abs=1e-3)
         residual = rc.evaluate(angles, g)
         assert residual == pytest.approx(0.0, abs=1e-6)
 

--- a/tests/test_regression_issue_304.py
+++ b/tests/test_regression_issue_304.py
@@ -160,6 +160,17 @@ def test_reference_mode_solves_without_spurious_violation(
         g = _setup_cubic(geometry, **{ref_attr: ref_val})
         g.mode_name = mode_name
         assert g.mode.is_implemented(g)
+        # The mode default emergence target (0°) is physically inaccessible
+        # for cubic (1, 0, 1) with surface_normal (0, 0, 1): the achievable
+        # emergence range is ~0.7°–56°, so emergence=0 yields no Bragg-valid
+        # solution.  Use an accessible target so the test exercises the
+        # verification loop on real solutions rather than (formerly) on
+        # the buggy wrong-hkl output (issues #304, #307).
+        if mode_name == "fixed_emergence_vertical":
+            g._modes[mode_name] = g.mode.with_constraint_values(  # noqa: SLF001
+                emergence=5.0
+            )
+            g.mode_name = mode_name
         sols = g.forward(1, 0, 1)
         assert len(sols) > 0
         # Re-running the verification loop explicitly must not raise.

--- a/tests/test_regression_issue_306.py
+++ b/tests/test_regression_issue_306.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+"""
+Regression tests for issue #306.
+
+Issue #306: for geometry ``psic``, mode ``fixed_psi_vertical``,
+``forward(h, k, l)`` returned an empty solution list even when the ``psi``
+constraint target equaled the reflection's natural ψ (so the ψ validation
+filter passed and no ``UserWarning`` was emitted).  The same reflection
+solved normally in ``bisecting_vertical``.
+
+Root cause: once ψ is validated it imposes no further restriction (every
+Bragg solution shares the natural ψ for a given hkl + UB), so the psic
+``fixed_psi_*`` mode is degenerate in its third free sample angle.  The
+solver delegated to ``_solve_fixed_sample``, which froze the outer sample
+stage (``eta``) at its current motor value and grid-searched only the
+inner ``(chi, phi)`` pair — no ``(chi, phi)`` satisfied Bragg with ``eta``
+frozen, so the result was empty.
+
+Fix: ``_solve_psi_mode`` now routes the psic ``fixed_psi_*`` family to a
+synthetic bisecting ConstraintSet (the lone non-chi/non-phi free sample
+stage takes ttheta/2, paired with the active detector), so
+``fixed_psi_vertical`` reproduces ``bisecting_vertical``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer.reference import natural_psi
+
+
+def _silicon_psic():
+    """psic geometry with a Si UB from two reflections (issue text setup)."""
+    g = ahd.make_geometry("psic")
+    g.sample.lattice = ahd.Lattice(a=5.431)
+    g.wavelength = 1.0
+    r1 = g.add_reflection(
+        "r1",
+        (0, 0, 1),
+        {"mu": 0, "eta": 22, "chi": 93, "phi": 0, "nu": 0, "delta": 40},
+        wavelength=1.0,
+    )
+    r2 = g.add_reflection(
+        "r2",
+        (1, 0, 0),
+        {"mu": 0, "eta": 22, "chi": 180, "phi": 0, "nu": 0, "delta": 40},
+        wavelength=1.0,
+    )
+    ahd.ub_from_two_reflections_bl1967(g.sample, r1, r2)
+    return g
+
+
+def _set_psi(g, hkl):
+    """Select fixed_psi_vertical with the constraint at the natural ψ."""
+    g.mode_name = "fixed_psi_vertical"
+    g.azimuth = (0, -1, 0)
+    nat = natural_psi(g, *hkl)
+    g._modes[g.mode_name] = g.mode.with_constraint_values(psi=nat)
+    g.mode_name = g.mode_name
+    return nat
+
+
+@pytest.mark.parametrize(
+    "hkl, context",
+    [
+        pytest.param((0, 0, 1), does_not_raise(), id="001"),
+        pytest.param((1, 0, 0), does_not_raise(), id="100"),
+    ],
+)
+def test_fixed_psi_vertical_matches_bisecting(hkl, context):
+    """fixed_psi_vertical returns the same solution set as bisecting_vertical."""
+    with context:
+        g = _silicon_psic()
+        _set_psi(g, hkl)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any ψ filter warning would raise
+            psi_sols = g.forward(*hkl)
+
+        g.mode_name = "bisecting_vertical"
+        bis_sols = g.forward(*hkl)
+
+        assert len(psi_sols) == len(bis_sols)
+        assert len(psi_sols) > 0
+        # Each psi-mode solution matches a bisecting solution motor-for-motor.
+        for ps in psi_sols:
+            assert any(all(abs(ps[k] - bs[k]) < 1e-4 for k in ps) for bs in bis_sols)
+
+
+def test_fixed_psi_vertical_solutions_round_trip():
+    """Every fixed_psi_vertical solution reproduces the requested hkl."""
+    g = _silicon_psic()
+    _set_psi(g, (0, 0, 1))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sols = g.forward(0, 0, 1)
+    assert sols
+    for sol in sols:
+        rt = g.inverse(sol)
+        assert rt == pytest.approx((0.0, 0.0, 1.0), abs=1e-3)

--- a/tests/test_regression_issue_307.py
+++ b/tests/test_regression_issue_307.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+"""
+Regression tests for issue #307.
+
+Issue #307: for geometry ``psic``, mode ``fixed_incidence_vertical``,
+``forward(h, k, l)`` returned solutions whose ``chi`` and ``phi`` were
+pinned at ``0`` and whose ``inverse()`` did **not** reproduce the
+requested reflection.  The returned motor angles satisfied the incidence
+constraint but were not a valid forward solution for the given hkl.
+
+Root cause: ``fixed_incidence_vertical`` leaves three sample stages free
+(``eta, chi, phi``), but ``_solve_surface`` did a 1-D Newton over only the
+first free sample stage (``eta``), leaving ``chi`` and ``phi`` at their
+current values and enforcing only the incidence residual — never the
+Bragg/Q condition.
+
+Fix: ``_solve_surface`` routes the multi-free-sample case to
+``_solve_reference_three_sample``, which scans the outer sample stage,
+solves the inner ``(chi, phi)`` pair against the Bragg condition for each
+value, and roots the scan on the surface residual.  Every returned
+solution reproduces the requested hkl by construction.
+"""
+
+from __future__ import annotations
+
+import warnings
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+import ad_hoc_diffractometer as ahd
+from ad_hoc_diffractometer.reference import incidence_angle
+
+
+def _silicon_psic():
+    """psic geometry with a Si UB from two reflections (issue text setup)."""
+    g = ahd.make_geometry("psic")
+    g.sample.lattice = ahd.Lattice(a=5.431)
+    g.wavelength = 1.0
+    r1 = g.add_reflection(
+        "r1",
+        (0, 0, 1),
+        {"mu": 0, "eta": 22, "chi": 93, "phi": 0, "nu": 0, "delta": 40},
+        wavelength=1.0,
+    )
+    r2 = g.add_reflection(
+        "r2",
+        (1, 0, 0),
+        {"mu": 0, "eta": 22, "chi": 180, "phi": 0, "nu": 0, "delta": 40},
+        wavelength=1.0,
+    )
+    ahd.ub_from_two_reflections_bl1967(g.sample, r1, r2)
+    return g
+
+
+def _set_incidence(g, value):
+    g.mode_name = "fixed_incidence_vertical"
+    g.surface_normal = (0, 0, 1)
+    g._modes[g.mode_name] = g.mode.with_constraint_values(incidence=value)
+    g.mode_name = g.mode_name
+
+
+@pytest.mark.parametrize(
+    "hkl, incidence, context",
+    [
+        pytest.param((0, 1, 1), 2.0, does_not_raise(), id="011-inc2"),
+        pytest.param((1, 0, 1), 1.0, does_not_raise(), id="101-inc1"),
+    ],
+)
+def test_fixed_incidence_solutions_round_trip(hkl, incidence, context):
+    """Each fixed_incidence_vertical solution reproduces hkl and honors incidence."""
+    with context:
+        g = _silicon_psic()
+        _set_incidence(g, incidence)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sols = g.forward(*hkl)
+
+        assert sols, "expected at least one accessible solution"
+        for sol in sols:
+            rt = g.inverse(sol)
+            assert rt == pytest.approx(tuple(float(v) for v in hkl), abs=1e-3)
+            assert incidence_angle(g, angles=sol) == pytest.approx(incidence, abs=1e-4)
+
+
+def test_fixed_incidence_inaccessible_returns_empty():
+    """An inaccessible incidence target returns [] (not wrong-hkl settings)."""
+    g = _silicon_psic()
+    _set_incidence(g, 89.0)  # too steep to be reachable for (0, 1, 1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sols = g.forward(0, 1, 1)
+    assert sols == []


### PR DESCRIPTION
- closes #306
- closes #307

psic `fixed_psi_*` and `fixed_incidence_*` / `fixed_emergence_*` modes
leave three sample stages free (eta, chi, phi) plus one detector, but
neither solver solved the third sample angle jointly with the Bragg
condition:

- **#306** `fixed_psi_vertical` reached `_solve_fixed_sample`, which froze
  `eta` and grid-searched only chi/phi → no Bragg solution → empty result.
- **#307** `fixed_incidence_vertical` reached `_solve_surface`, which
  rocked only `eta` and enforced only the surface residual (never Bragg) →
  wrong-hkl settings with chi=phi=0.

Resolution: extract the inner chi/phi Bragg solve into
`_solve_chi_phi_bragg` (with a `fast_only` analytic path) and add
`_solve_reference_three_sample`, which scans the outer sample stage, solves
chi/phi against Bragg per value, and roots the scan on the reference
residual. #306 routes to a synthetic bisecting mode (so
`fixed_psi_vertical` reproduces `bisecting_vertical`); #307's psic case
routes to the new scan solver. Every returned solution reproduces the
requested hkl by construction.

Two pre-existing tests that passed on the old wrong-hkl output (an
inaccessible emergence=0 target) are updated to use accessible targets and
assert round-trip.

QC: full suite 100% coverage, slow benchmark, pre-commit, US-English grep,
docs build (0 warnings) + role-leak grep — all green locally.

Contributed by: OpenCode (argo/claudeopus48)